### PR TITLE
refactor(docs,examples): migrate to path aliases

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -25,7 +25,7 @@
     "@shikijs/langs": "^3.20.0",
     "@shikijs/themes": "^3.20.0",
     "markdown-it": "^14.1.0",
-    "rari": "latest",
+    "rari": "workspace:*",
     "react": "^19.2.3",
     "react-dom": "^19.2.3"
   },

--- a/docs/src/app/[slug]/page.tsx
+++ b/docs/src/app/[slug]/page.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 import type { PageProps } from 'rari/client'
-import MarkdownRenderer from '../../components/MarkdownRenderer'
+import MarkdownRenderer from '@/components/MarkdownRenderer'
 
 export default function DocPage({ params }: PageProps) {
   const slug = params?.slug

--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 import type { LayoutProps } from 'rari/client'
-import Sidebar from '../components/Sidebar'
+import Sidebar from '@/components/Sidebar'
 
 interface NpmPackageInfo {
   'dist-tags': {

--- a/docs/src/components/MarkdownRenderer.tsx
+++ b/docs/src/components/MarkdownRenderer.tsx
@@ -13,7 +13,7 @@ import tsx from '@shikijs/langs/tsx'
 import typescript from '@shikijs/langs/typescript'
 import githubDark from '@shikijs/themes/github-dark'
 import MarkdownIt from 'markdown-it'
-import NotFoundPage from '../app/not-found'
+import NotFoundPage from '@/app/not-found'
 
 interface MarkdownRendererProps {
   filePath: string

--- a/docs/tsconfig.app.json
+++ b/docs/tsconfig.app.json
@@ -12,6 +12,10 @@
     "useDefineForClassFields": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "paths": {
+      "*": ["./*"],
+      "@/*": ["./src/*"]
+    },
     "allowImportingTsExtensions": true,
     "strict": true,
     "noFallthroughCasesInSwitch": true,

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 import { rari, rariRouter } from 'rari/vite'
@@ -23,6 +24,11 @@ export default defineConfig({
           ],
         },
       },
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
     },
   },
 })

--- a/examples/app-router-example/src/app/about/page.tsx
+++ b/examples/app-router-example/src/app/about/page.tsx
@@ -1,7 +1,6 @@
 export default function AboutPage() {
   return (
     <div className="space-y-8">
-      {/* Header Section */}
       <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8 md:p-12">
         <h1 className="text-4xl font-bold text-gray-900 mb-4">
           About This Example
@@ -13,7 +12,6 @@ export default function AboutPage() {
         </p>
       </div>
 
-      {/* Key Features */}
       <div>
         <h2 className="text-2xl font-bold text-gray-900 mb-4">Key Features</h2>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -97,7 +95,6 @@ export default function AboutPage() {
         </div>
       </div>
 
-      {/* Architecture */}
       <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8">
         <h2 className="text-2xl font-bold text-gray-900 mb-6">
           Architecture Overview
@@ -195,7 +192,6 @@ export default function AboutPage() {
         </div>
       </div>
 
-      {/* Tech Stack */}
       <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8">
         <h2 className="text-2xl font-bold text-gray-900 mb-4">
           Technology Stack

--- a/examples/app-router-example/src/app/actions/page.tsx
+++ b/examples/app-router-example/src/app/actions/page.tsx
@@ -1,13 +1,12 @@
-import { getTodos } from '../../actions/todo-actions'
-import ProgressiveFormExample from '../../components/ProgressiveFormExample'
-import TodoAppWithActions from '../../components/TodoAppWithActions'
+import { getTodos } from '@/actions/todo-actions'
+import ProgressiveFormExample from '@/components/ProgressiveFormExample'
+import TodoAppWithActions from '@/components/TodoAppWithActions'
 
 export default async function ActionsPage() {
   const initialTodos = await getTodos()
 
   return (
     <div className="space-y-8">
-      {/* Header Section */}
       <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8 md:p-12">
         <div className="flex items-center gap-3 mb-4">
           <h1 className="text-4xl font-bold text-gray-900">
@@ -21,7 +20,6 @@ export default async function ActionsPage() {
         </p>
       </div>
 
-      {/* Interactive Todo App */}
       <div>
         <h2 className="text-2xl font-bold text-gray-900 mb-4">
           Interactive Todo Application
@@ -29,7 +27,6 @@ export default async function ActionsPage() {
         <TodoAppWithActions initialTodos={initialTodos} />
       </div>
 
-      {/* Progressive Enhancement */}
       <div>
         <h2 className="text-2xl font-bold text-gray-900 mb-4">
           Progressive Enhancement Form
@@ -37,7 +34,6 @@ export default async function ActionsPage() {
         <ProgressiveFormExample />
       </div>
 
-      {/* Server Action Patterns */}
       <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8">
         <h2 className="text-2xl font-bold text-gray-900 mb-6">
           Server Action Patterns Demonstrated
@@ -111,7 +107,6 @@ export default async function ActionsPage() {
         </div>
       </div>
 
-      {/* Technical Implementation */}
       <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8">
         <h2 className="text-2xl font-bold text-gray-900 mb-6">
           Technical Implementation

--- a/examples/app-router-example/src/app/interactive/page.tsx
+++ b/examples/app-router-example/src/app/interactive/page.tsx
@@ -1,5 +1,5 @@
-import Counter from '../../components/Counter'
-import TodoList from '../../components/TodoList'
+import Counter from '@/components/Counter'
+import TodoList from '@/components/TodoList'
 
 export default function InteractivePage() {
   return (

--- a/examples/app-router-example/src/app/page.tsx
+++ b/examples/app-router-example/src/app/page.tsx
@@ -3,7 +3,6 @@ import type { PageProps } from 'rari/client'
 export default function HomePage({ params, searchParams }: PageProps) {
   return (
     <div className="space-y-8">
-      {/* Hero Section */}
       <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8 md:p-12">
         <div className="flex items-center gap-3 mb-4">
           <h1 className="text-4xl md:text-5xl font-bold text-gray-900">
@@ -31,7 +30,6 @@ export default function HomePage({ params, searchParams }: PageProps) {
         </div>
       </div>
 
-      {/* Features Grid */}
       <div>
         <h2 className="text-2xl font-bold text-gray-900 mb-4">Core Features</h2>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
@@ -105,7 +103,6 @@ export default function HomePage({ params, searchParams }: PageProps) {
         </div>
       </div>
 
-      {/* Examples Section */}
       <div>
         <h2 className="text-2xl font-bold text-gray-900 mb-4">
           Try the Examples
@@ -168,7 +165,6 @@ export default function HomePage({ params, searchParams }: PageProps) {
         </div>
       </div>
 
-      {/* Debug Info */}
       <details className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
         <summary className="font-semibold text-gray-900 cursor-pointer select-none">
           Debug Information

--- a/examples/app-router-example/src/app/server-demo/page.tsx
+++ b/examples/app-router-example/src/app/server-demo/page.tsx
@@ -1,4 +1,4 @@
-import FetchExample from '../../components/FetchExample'
+import FetchExample from '@/components/FetchExample'
 
 export default function ServerDemoPage() {
   const serverTime = new Date().toISOString()

--- a/examples/app-router-example/src/components/ProgressiveFormExample.tsx
+++ b/examples/app-router-example/src/components/ProgressiveFormExample.tsx
@@ -2,7 +2,7 @@
 
 import { createFormAction } from 'rari/runtime/actions'
 import { useEffect, useId, useRef, useState } from 'react'
-import { createTodoAndRedirect } from '../actions/todo-actions'
+import { createTodoAndRedirect } from '@/actions/todo-actions'
 
 export default function ProgressiveFormExample() {
   const formId = useId()

--- a/examples/app-router-example/src/components/TodoAppWithActions.tsx
+++ b/examples/app-router-example/src/components/TodoAppWithActions.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import type { Todo } from '../actions/todo-actions'
+import type { Todo } from '@/actions/todo-actions'
 import { useState } from 'react'
-import { getTodos } from '../actions/todo-actions'
+import { getTodos } from '@/actions/todo-actions'
 import TodoFormWithActions from './TodoFormWithActions'
 import TodoListWithActions from './TodoListWithActions'
 

--- a/examples/app-router-example/src/components/TodoFormWithActions.tsx
+++ b/examples/app-router-example/src/components/TodoFormWithActions.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useId, useState, useTransition } from 'react'
-import { addTodo } from '../actions/todo-actions'
+import { addTodo } from '@/actions/todo-actions'
 
 interface TodoFormProps {
   onSuccess?: () => void

--- a/examples/app-router-example/src/components/TodoListWithActions.tsx
+++ b/examples/app-router-example/src/components/TodoListWithActions.tsx
@@ -1,12 +1,12 @@
 'use client'
 
-import type { Todo } from '../actions/todo-actions'
+import type { Todo } from '@/actions/todo-actions'
 import { useEffect, useState, useTransition } from 'react'
 import {
   clearCompleted,
   deleteTodo,
   toggleTodo,
-} from '../actions/todo-actions'
+} from '@/actions/todo-actions'
 
 interface TodoListProps {
   initialTodos: Todo[]

--- a/examples/app-router-example/tsconfig.json
+++ b/examples/app-router-example/tsconfig.json
@@ -6,6 +6,10 @@
     "useDefineForClassFields": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "paths": {
+      "*": ["./*"],
+      "@/*": ["./src/*"]
+    },
     "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "strict": true,

--- a/examples/app-router-example/vite.config.ts
+++ b/examples/app-router-example/vite.config.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 import { rari, rariRouter } from 'rari/vite'
@@ -5,4 +6,9 @@ import { defineConfig } from 'rolldown-vite'
 
 export default defineConfig({
   plugins: [rari(), rariRouter(), react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: ^14.1.0
         version: 14.1.0
       rari:
-        specifier: latest
-        version: 0.5.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: workspace:*
+        version: link:../packages/rari
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -2612,14 +2612,6 @@ packages:
     cpu: [x64]
     os: [win32]
     hasBin: true
-
-  rari@0.5.15:
-    resolution: {integrity: sha512-pav8LPiHXzx9/4GGt1/pt0sH3pdR7i0n7wbzh716zKDz1IW87BWAI1fzSyNbb0EsmkmOPaHhRHibFykRG0f47g==}
-    engines: {node: '>=20.0.0'}
-    hasBin: true
-    peerDependencies:
-      react: ^19.0.0
-      react-dom: ^19.0.0
 
   react-dom@19.2.1:
     resolution: {integrity: sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==}
@@ -5515,20 +5507,6 @@ snapshots:
 
   rari-win32-x64@0.5.10:
     optional: true
-
-  rari@0.5.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
-    dependencies:
-      acorn: 8.15.0
-      esbuild: 0.27.1
-      picocolors: 1.1.1
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    optionalDependencies:
-      rari-darwin-arm64: 0.5.10
-      rari-darwin-x64: 0.5.10
-      rari-linux-arm64: 0.5.10
-      rari-linux-x64: 0.5.10
-      rari-win32-x64: 0.5.10
 
   react-dom@19.2.1(react@19.2.1):
     dependencies:


### PR DESCRIPTION
- Add TypeScript path aliases (@/*) configuration to docs/tsconfig.app.json
- Configure Vite alias resolution for @ imports in docs/vite.config.ts
- Migrate all relative imports to @ path aliases in docs components and pages
- Migrate all relative imports to @ path aliases in app-router-example
- Update rari Vite plugin to support path alias resolution in server builds