### PR TITLE
chore(create-rari-app): update bin entry point to ESM format

### DIFF
--- a/packages/create-rari-app/package.json
+++ b/packages/create-rari-app/package.json
@@ -31,7 +31,7 @@
     "project-template"
   ],
   "bin": {
-    "create-rari-app": "dist/index.js"
+    "create-rari-app": "dist/index.mjs"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Description

Fixes the `create-rari-app` bootstrap command failing with ENOENT error when running `pnpm create rari-app`.

## Problem

The package was configured to use `dist/index.js` as the bin entry point, but the build process (tsdown with ESM format) was actually generating `dist/index.mjs`. This caused pnpm to fail when trying to create the bin symlink during installation.

## Solution

Updated the bin entry in `package.json` to point to the correct output file: `dist/index.mjs`.

## Testing

- Built the package locally with `pnpm build`
- Verified `dist/index.mjs` is generated with execute permissions
- Tested the CLI runs successfully when invoked directly
- Linked globally and confirmed the bin command works

Closes #57
