### PR TITLE
feat(server): implement on-demand revalidation and response caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,6 +1028,8 @@ dependencies = [
  "compression-core",
  "flate2",
  "memchr",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -9455,6 +9457,34 @@ dependencies = [
  "potential_utf",
  "resb",
  "serde",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/crates/rari/Cargo.toml
+++ b/crates/rari/Cargo.toml
@@ -108,7 +108,8 @@ tower = { version = "0.5.2", default-features = false, features = [ "full" ] }
 tower-http = { version = "0.6.8", features = [
   "fs",
   "cors",
-  "trace"
+  "trace",
+  "compression-full"
 ] }
 tower_governor = "0.8.0"
 governor = "0.10.4"

--- a/crates/rari/src/server/cache/response_cache.rs
+++ b/crates/rari/src/server/cache/response_cache.rs
@@ -50,7 +50,7 @@ impl CacheConfig {
             default_ttl: std::env::var("RARI_CACHE_DEFAULT_TTL")
                 .ok()
                 .and_then(|v| v.parse().ok())
-                .unwrap_or(60),
+                .unwrap_or(31536000),
             enabled: std::env::var("RARI_CACHE_ENABLED")
                 .ok()
                 .and_then(|v| v.parse().ok())
@@ -322,6 +322,10 @@ impl ResponseCache {
     pub fn get_metrics(&self) -> CacheMetrics {
         let metrics = self.metrics.lock();
         metrics.clone()
+    }
+
+    pub fn get_all_keys(&self) -> Vec<String> {
+        self.cache.iter().map(|entry| entry.key().clone()).collect()
     }
 
     fn record_hit(&self) {
@@ -601,7 +605,7 @@ mod tests {
         let config = CacheConfig::from_env(true);
         assert!(config.enabled);
         assert_eq!(config.max_entries, 1000);
-        assert_eq!(config.default_ttl, 60);
+        assert_eq!(config.default_ttl, 31536000);
 
         let config = CacheConfig::from_env(false);
         assert!(!config.enabled);

--- a/crates/rari/src/server/config/mod.rs
+++ b/crates/rari/src/server/config/mod.rs
@@ -154,7 +154,7 @@ impl Default for CacheControlConfig {
         Self {
             routes: FxHashMap::default(),
             static_files: "public, max-age=31536000, immutable".to_string(),
-            server_components: "no-cache".to_string(),
+            server_components: "public, max-age=31536000, stale-while-revalidate=86400".to_string(),
         }
     }
 }
@@ -763,7 +763,7 @@ mod tests {
         let config = Config::default();
 
         let cache_control = config.get_cache_control_for_route("/some/random/path");
-        assert_eq!(cache_control, "no-cache");
+        assert_eq!(cache_control, "public, max-age=31536000, stale-while-revalidate=86400");
     }
 
     #[test]

--- a/crates/rari/src/server/handlers/mod.rs
+++ b/crates/rari/src/server/handlers/mod.rs
@@ -2,6 +2,7 @@ pub mod api_handler;
 pub mod app_handler;
 pub mod csrf_handler;
 pub mod hmr_handlers;
+pub mod revalidate_handlers;
 pub mod route_info_handler;
 pub mod rsc_handlers;
 pub mod static_handlers;

--- a/crates/rari/src/server/handlers/revalidate_handlers.rs
+++ b/crates/rari/src/server/handlers/revalidate_handlers.rs
@@ -1,0 +1,109 @@
+use crate::server::ServerState;
+use axum::{extract::State, http::StatusCode, response::Json};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Deserialize)]
+pub struct RevalidatePathRequest {
+    pub path: String,
+    #[serde(default)]
+    pub secret: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RevalidateTagRequest {
+    pub tag: String,
+    #[serde(default)]
+    pub secret: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RevalidateResponse {
+    pub revalidated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+#[axum::debug_handler]
+pub async fn revalidate_by_path(
+    State(state): State<ServerState>,
+    Json(request): Json<RevalidatePathRequest>,
+) -> Result<Json<RevalidateResponse>, StatusCode> {
+    let expected_secret = std::env::var("RARI_REVALIDATE_SECRET").map_err(|_| {
+        tracing::error!("RARI_REVALIDATE_SECRET not configured. Set this environment variable to enable revalidation.");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    match request.secret {
+        Some(provided_secret) if provided_secret == expected_secret => {}
+        _ => {
+            return Ok(Json(RevalidateResponse {
+                revalidated: false,
+                message: Some("Invalid or missing secret".to_string()),
+            }));
+        }
+    }
+
+    state.response_cache.invalidate(&request.path).await;
+
+    let path_pattern = format!("{}?", request.path);
+    let all_keys = state.response_cache.get_all_keys();
+
+    for key in all_keys {
+        if key.starts_with(&path_pattern) {
+            state.response_cache.invalidate(&key).await;
+        }
+    }
+
+    #[allow(clippy::disallowed_methods)]
+    Ok(Json(RevalidateResponse {
+        revalidated: true,
+        message: Some(format!("Revalidated path: {}", request.path)),
+    }))
+}
+
+#[axum::debug_handler]
+pub async fn revalidate_by_tag(
+    State(state): State<ServerState>,
+    Json(request): Json<RevalidateTagRequest>,
+) -> Result<Json<RevalidateResponse>, StatusCode> {
+    let expected_secret = std::env::var("RARI_REVALIDATE_SECRET").map_err(|_| {
+        tracing::error!("RARI_REVALIDATE_SECRET not configured. Set this environment variable to enable revalidation.");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    match request.secret {
+        Some(provided_secret) if provided_secret == expected_secret => {}
+        _ => {
+            return Ok(Json(RevalidateResponse {
+                revalidated: false,
+                message: Some("Invalid or missing secret".to_string()),
+            }));
+        }
+    }
+
+    state.response_cache.invalidate_by_tag(&request.tag).await;
+
+    #[allow(clippy::disallowed_methods)]
+    Ok(Json(RevalidateResponse {
+        revalidated: true,
+        message: Some(format!("Revalidated tag: {}", request.tag)),
+    }))
+}
+
+#[axum::debug_handler]
+pub async fn cache_stats(State(state): State<ServerState>) -> Json<Value> {
+    let metrics = state.response_cache.get_metrics();
+
+    #[allow(clippy::disallowed_methods)]
+    Json(serde_json::json!({
+        "total_entries": metrics.total_entries,
+        "memory_usage_bytes": metrics.memory_usage_bytes,
+        "hits": metrics.cache_hits,
+        "misses": metrics.cache_misses,
+        "hit_rate": metrics.hit_rate,
+        "enabled": state.response_cache.config.enabled,
+        "max_entries": state.response_cache.config.max_entries,
+        "default_ttl": state.response_cache.config.default_ttl,
+    }))
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,20 +218,20 @@ importers:
         version: 0.17.3(@typescript/native-preview@7.0.0-dev.20251223.1)(synckit@0.11.11)(typescript@5.9.3)
     optionalDependencies:
       rari-darwin-arm64:
-        specifier: 0.5.19
-        version: 0.5.19
+        specifier: 0.5.20
+        version: 0.5.20
       rari-darwin-x64:
-        specifier: 0.5.19
-        version: 0.5.19
+        specifier: 0.5.20
+        version: 0.5.20
       rari-linux-arm64:
-        specifier: 0.5.19
-        version: 0.5.19
+        specifier: 0.5.20
+        version: 0.5.20
       rari-linux-x64:
-        specifier: 0.5.19
-        version: 0.5.19
+        specifier: 0.5.20
+        version: 0.5.20
       rari-win32-x64:
-        specifier: 0.5.19
-        version: 0.5.19
+        specifier: 0.5.20
+        version: 0.5.20
 
   packages/rari-darwin-arm64: {}
 
@@ -2754,8 +2754,22 @@ packages:
     os: [darwin]
     hasBin: true
 
+  rari-darwin-arm64@0.5.20:
+    resolution: {integrity: sha512-6P7z0h7lr0k6LAt3dSI9y7ScisAL1rIcdH8XjUwtXRmbo0l9lMIt86/tSG4BliqAmMV3GVEMxI48t4DyKiXxUQ==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
   rari-darwin-x64@0.5.19:
     resolution: {integrity: sha512-kvRXIyR77xWZfReTW/cTeyraJ4ERFDzXWJoR6kupA8IDe3FzPMXlsw32+Wk7fIbsg4CaCQdohc43+fF5gmG18w==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [darwin]
+    hasBin: true
+
+  rari-darwin-x64@0.5.20:
+    resolution: {integrity: sha512-6gvCq5wJq4Bz1e2n2KLvAb3J3maMHYBR0kiMoPv+vOCKkDUPzeHe2PmUtytimcuQvor56QBZI4mh7I2IkC3duA==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [darwin]
@@ -2768,6 +2782,13 @@ packages:
     os: [linux]
     hasBin: true
 
+  rari-linux-arm64@0.5.20:
+    resolution: {integrity: sha512-YIBPBobMAg5HOCjTmjTWzTAk2i0gdoURhaFhmOZTjV3aTtRZu72s2qLetWoC0ZRkRkqoSyO/enjr7n0MVA5KLA==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
   rari-linux-x64@0.5.19:
     resolution: {integrity: sha512-yEiN1BIZowTEQt1C/vw1hnMY+GRCigRMJqyg8iRruoJ5YBNEB0VLQ/LRad4bVePEeDpL48twyt5spmp/OS+dyQ==}
     engines: {node: '>=20.0.0'}
@@ -2775,8 +2796,22 @@ packages:
     os: [linux]
     hasBin: true
 
+  rari-linux-x64@0.5.20:
+    resolution: {integrity: sha512-JWLrH7EwN6UgqVHGJzZMWcf4g5K6m1thDD3wwXoqkDhXLSJaL8737ILkeXw/400tCKo8GGCtcJ/9Hb07v5+SpA==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+
   rari-win32-x64@0.5.19:
     resolution: {integrity: sha512-agV4CBcBS/pGhy6QrPf2a3i6s00IcBwfVY+RMRN56APNcBGm3sd/Pc9/9tAlkyTUltrm0JbGj4VyXWikh3zTNg==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [win32]
+    hasBin: true
+
+  rari-win32-x64@0.5.20:
+    resolution: {integrity: sha512-H/skZxBIOlzoOQgLAHTVbocBOe0VM521gGbcQ8uqKE9vRq1R9+Qv+xYmKjE2D2cT454cYwoOrn71/Bt3paSg2Q==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [win32]
@@ -6090,16 +6125,31 @@ snapshots:
   rari-darwin-arm64@0.5.19:
     optional: true
 
+  rari-darwin-arm64@0.5.20:
+    optional: true
+
   rari-darwin-x64@0.5.19:
+    optional: true
+
+  rari-darwin-x64@0.5.20:
     optional: true
 
   rari-linux-arm64@0.5.19:
     optional: true
 
+  rari-linux-arm64@0.5.20:
+    optional: true
+
   rari-linux-x64@0.5.19:
     optional: true
 
+  rari-linux-x64@0.5.20:
+    optional: true
+
   rari-win32-x64@0.5.19:
+    optional: true
+
+  rari-win32-x64@0.5.20:
     optional: true
 
   rari@0.5.25(react-dom@19.2.3(react@19.2.3))(react@19.2.3):


### PR DESCRIPTION
- Add revalidation handlers for cache invalidation by path and tag
- Implement cache statistics endpoint for monitoring cache performance
- Enable HTTP compression layer using tower-http CompressionLayer
- Update default cache TTL from 60 seconds to 1 year (31536000 seconds)
- Change server component cache control from "no-cache" to long-lived with stale-while-revalidate
- Add cache key generation and retrieval for RSC navigation responses
- Implement cache hit/miss tracking with x-cache response headers
- Add get_all_keys() method to ResponseCache for cache introspection
- Register new revalidation and cache stats endpoints in server router
- Update tower-http dependency to include compression-full feature
- Improve cache efficiency for server-rendered components with proper cache policies