### PR TITLE
build(tsdown): enable minification for build output

### DIFF
--- a/packages/create-rari-app/tsdown.config.ts
+++ b/packages/create-rari-app/tsdown.config.ts
@@ -4,4 +4,5 @@ export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
   clean: true,
+  minify: true,
 })

--- a/packages/rari/tsdown.config.ts
+++ b/packages/rari/tsdown.config.ts
@@ -15,4 +15,5 @@ export default defineConfig({
   dts: true,
   fixedExtension: true,
   format: 'esm',
+  minify: true,
 })


### PR DESCRIPTION
## Changes

Enables minification in tsdown build configurations for both `rari` and `create-rari-app` packages.