### PR TITLE
fix: properly handle client components and server actions across all import styles

### DIFF
--- a/packages/rari/src/vite/server-build.ts
+++ b/packages/rari/src/vite/server-build.ts
@@ -952,7 +952,7 @@ const ${importName} = (props) => {
         write: false,
         plugins: [
           {
-            name: 'external-server-actions',
+            name: 'resolve-client-server-boundaries',
             setup: (build) => {
               build.onResolve({ filter: /.*/ }, async (args) => {
                 if (args.namespace !== 'file' && args.namespace !== '')


### PR DESCRIPTION
## Problem

When a server component imported a client component using a relative path (e.g., `import Counter from './Counter'`), the client component code was being bundled into the server component instead of being transformed into a client reference. This caused:

- Client component code (with hooks, event handlers) to be included in server bundles
- Runtime errors when the Deno runtime tried to execute client-only code
- Broken interactivity for client components imported via relative paths

The issue only affected relative imports - alias-based imports (e.g., `@/components/Counter`) worked correctly.

## Root Cause

The original plugin architecture had:
- `external-server-actions` plugin: Only handled server actions
- `resolve-aliases` plugin: Only handled alias-based imports for client components

This meant relative imports of client components bypassed both plugins and were bundled by esbuild's default resolution.

## Solution

Refactored the plugin architecture for better separation of concerns:

1. **Renamed and expanded `external-server-actions` → `resolve-client-server-boundaries`**: This plugin now handles ALL imports (relative and alias-based) and checks for both client components and server actions
2. **Client component detection**: For each resolved import, check if it contains `'use client'` directive
3. **Server action detection**: Check if it contains `'use server'` directive  
4. **Transform to references**: Return appropriate namespaces (`client-component-reference` or `server-action-reference`) instead of bundling
5. **Generate reference code**: `onLoad` handlers create proper reference calls with correct component/action IDs
6. **Skip internal imports**: Added checks to exclude `node_modules` and rari package internals

## Changes

- Modified `packages/rari/src/vite/server-build.ts`:
  - Renamed `external-server-actions` → `resolve-client-server-boundaries` for clarity
  - Plugin now checks for client components BEFORE server actions
  - Added `client-component-reference` namespace handling
  - Added `node_modules` and rari package exclusion checks
  - Pass absolute resolved paths through namespaces for proper component ID generation
  - Simplified `resolve-aliases` plugin since boundaries are now handled earlier