### PR TITLE
perf: move image/OG cache to .cache/ and optimize build performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 node_modules/
 packages/*/bin/
 .pnpm-store/
+.cache/

--- a/crates/rari/src/server/og/cache.rs
+++ b/crates/rari/src/server/og/cache.rs
@@ -24,7 +24,7 @@ impl OgImageCache {
         if is_production {
             PathBuf::from("/tmp/rari-og-cache")
         } else {
-            project_path.join("dist").join("cache").join("og")
+            project_path.join(".cache").join("og")
         }
     }
 

--- a/packages/create-rari-app/templates/default/gitignore
+++ b/packages/create-rari-app/templates/default/gitignore
@@ -7,6 +7,9 @@ bin/
 dist/
 build/
 
+# Cache
+.cache/
+
 # Environment variables
 .env
 .env.local


### PR DESCRIPTION
## Changes

Moves image and OG image optimization caches from `dist/cache/` to `.cache/` to persist across rebuilds, significantly improving build performance.

### Key improvements

- **Persistent cache across rebuilds**: Cache now survives `dist/` cleanup during builds
- **Lazy directory creation**: Cache directories only created when actually needed (no empty `.cache/` folders)
- **Silent when unused**: Pre-optimization logs only appear when images are actually configured
- **Standard convention**: Follows common patterns

### Technical details

**Cache locations:**
- Development: `.cache/images/` and `.cache/og/`
- Production: `/tmp/rari-image-cache` and `/tmp/rari-og-cache` (unchanged)

**Behavior changes:**
- Cache directories created lazily on first write instead of eagerly on initialization
- Pre-optimization skipped silently when no `localPatterns` or `preoptimize_manifest` configured
- Added `.cache/` to root and template `.gitignore` files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized cache directory structure to use `.cache` folder instead of `dist/cache`.
  * Updated gitignore files to exclude new cache location.
  * Enhanced robustness of image optimization validation with early exit checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->