### PR TITLE
fix(rsc): mark Image component as client reference on server

### DIFF
--- a/packages/rari/src/image/index.ts
+++ b/packages/rari/src/image/index.ts
@@ -1,3 +1,5 @@
+import { Image as ImageComponent } from './Image'
+
 export type { ImageFormat } from './constants'
 export {
   DEFAULT_DEVICE_SIZES,
@@ -7,5 +9,14 @@ export {
   DEFAULT_MINIMUM_CACHE_TTL,
   DEFAULT_QUALITY_LEVELS,
 } from './constants'
-export { Image } from './Image'
 export type { ImageProps, StaticImageData } from './Image'
+
+const isServer = typeof window === 'undefined'
+const Image: any = ImageComponent
+
+if (isServer) {
+  Image.$$typeof = Symbol.for('react.client.reference')
+  Image.$$id = 'rari/image#Image'
+}
+
+export { Image }

--- a/packages/rari/src/vite/server-build.ts
+++ b/packages/rari/src/vite/server-build.ts
@@ -1468,12 +1468,11 @@ function registerClientReference(clientReference, id, exportName) {
   });
 
   try {
-    if (typeof globalThis['~rari']?.bridge !== 'undefined' &&
-        typeof globalThis['~rari'].bridge.registerClientReference === 'function') {
-      globalThis['~rari'].bridge.registerClientReference(key, id, exportName);
+    if (typeof globalThis.registerClientComponent === 'function') {
+      globalThis.registerClientComponent(key, id, clientProxy);
     }
   } catch (error) {
-    console.error('[rari] Build: Failed to register client reference with Rust bridge:', error);
+    console.error('[rari] Build: Failed to register client reference:', error);
   }
 
   return clientProxy;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized Image component export handling for server environments
  * Streamlined client reference registration mechanism in the build process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->