### PR TITLE
chore(deps): upgrade tokio, tower-http, rustc-hash, and sysinfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,6 +3273,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5151,16 +5161,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is-docker"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6292,6 +6292,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
 ]
 
 [[package]]
@@ -6328,6 +6330,17 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -6384,9 +6397,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
-version = "5.3.4"
+version = "5.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
 dependencies = [
  "is-wsl",
  "libc",
@@ -9315,15 +9328,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.4"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+checksum = "a4deba334e1190ba7cb498327affa11e5ece10d26a30ab2f27fcf09504b8d8b6"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
+ "objc2-open-directory",
  "windows",
 ]
 
@@ -9633,9 +9647,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -9856,9 +9870,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "async-compression",
  "bitflags 2.11.1",
@@ -9870,7 +9884,6 @@ dependencies = [
  "http-body-util",
  "http-range-header",
  "httpdate",
- "iri-string",
  "mime",
  "mime_guess",
  "percent-encoding",
@@ -9880,7 +9893,7 @@ dependencies = [
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
- "tracing",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7287,7 +7287,7 @@ checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
 
 [[package]]
 name = "rari"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ significant_drop_in_scrutinee = "warn"
 unused_peekable = "warn"
 
 [workspace.dependencies]
-tokio = { version = "1.52.1", features = [
+tokio = { version = "1.52.3", features = [
   "full",
   "process"
 ] }

--- a/crates/rari/Cargo.toml
+++ b/crates/rari/Cargo.toml
@@ -87,7 +87,7 @@ async-stream = "0.3.6"
 async-trait = "0.1.89"
 futures = "0.3.32"
 futures-util = "0.3.32"
-tokio = { version = "1.47.1", features = [
+tokio = { version = "1.52.3", features = [
   "rt-multi-thread",
   "macros",
   "sync",
@@ -121,7 +121,7 @@ axum = { version = "0.8.9", features = [
   "macros"
 ] }
 tower = { version = "0.5.3", default-features = false, features = [ "util" ] }
-tower-http = { version = "0.6.8", features = [
+tower-http = { version = "0.6.10", features = [
   "fs",
   "compression-full"
 ] }
@@ -140,7 +140,7 @@ dashmap = "6.1.0"
 parking_lot = "0.12.5"
 smallvec = "1.15.1"
 regex = { workspace = true }
-rustc-hash = "2.1.1"
+rustc-hash = "2.1.2"
 lru = "0.18.0"
 uuid = { version = "1.23.1", features = [ "v4" ] }
 thiserror = "2.0.18"
@@ -171,7 +171,7 @@ hyper-util = { version = "0.1.20", features = [
 libc = "0.2.182"
 nix = { version = "=0.30.1", features = [ "term" ] }
 sys_traits = "=0.1.27"
-sysinfo = "0.38.4"
+sysinfo = "0.39.1"
 
 # === Development Tools ===
 rustyline = "=17.0.0"

--- a/crates/rari/Cargo.toml
+++ b/crates/rari/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rari"
-version = "0.13.5"
+version = "0.13.6"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/crates/rari/src/rsc/rendering/layout/core.rs
+++ b/crates/rari/src/rsc/rendering/layout/core.rs
@@ -13,12 +13,18 @@ use tracing::error;
 
 use super::{constants::*, error_messages, types::*, utils};
 
-struct LayoutHtmlCache {
+pub struct LayoutHtmlCache {
     cache: DashMap<u64, String>,
 }
 
+impl Default for LayoutHtmlCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LayoutHtmlCache {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { cache: DashMap::new() }
     }
 
@@ -28,6 +34,10 @@ impl LayoutHtmlCache {
 
     fn insert(&self, key: u64, html: String) {
         self.cache.insert(key, html);
+    }
+
+    pub fn clear(&self) {
+        self.cache.clear();
     }
 }
 
@@ -39,6 +49,17 @@ pub struct LayoutRenderer {
 impl LayoutRenderer {
     pub fn new(renderer: Arc<tokio::sync::Mutex<RscRenderer>>) -> Self {
         Self { renderer, html_cache: Arc::new(LayoutHtmlCache::new()) }
+    }
+
+    pub fn with_shared_cache(
+        renderer: Arc<tokio::sync::Mutex<RscRenderer>>,
+        html_cache: Arc<LayoutHtmlCache>,
+    ) -> Self {
+        Self { renderer, html_cache }
+    }
+
+    pub fn create_shared_cache() -> Arc<LayoutHtmlCache> {
+        Arc::new(LayoutHtmlCache::new())
     }
 
     async fn enable_streaming_and_inject_lazy_resolver(
@@ -300,13 +321,9 @@ impl LayoutRenderer {
         >,
         return_rsc_on_fallback: bool,
     ) -> Result<RenderResult, RariError> {
-        let can_use_html_cache = request_context.is_none();
         let cache_key = utils::generate_cache_key(route_match, context);
 
-        if can_use_html_cache
-            && !return_rsc_on_fallback
-            && let Some(cached_html) = self.html_cache.get(cache_key)
-        {
+        if !return_rsc_on_fallback && let Some(cached_html) = self.html_cache.get(cache_key) {
             return Ok(RenderResult::Static(cached_html));
         }
 
@@ -323,6 +340,31 @@ impl LayoutRenderer {
             None
         };
 
+        let needs_streaming = loading_component_id.is_some();
+
+        if !needs_streaming {
+            let rsc_wire_format = self.render_route(route_match, context, request_context).await?;
+
+            if return_rsc_on_fallback {
+                return Ok(RenderResult::Static(rsc_wire_format));
+            }
+
+            let runtime = {
+                let renderer = self.renderer.lock().await;
+                Arc::clone(&renderer.runtime)
+            };
+            let html_renderer = crate::rsc::rendering::html::RscHtmlRenderer::new(runtime);
+            let config =
+                Config::get().ok_or_else(|| RariError::internal("Config not available"))?;
+            let html = html_renderer.render_to_html(&rsc_wire_format, config).await?;
+
+            if route_match.not_found.is_none() {
+                self.html_cache.insert(cache_key, html.clone());
+            }
+
+            return Ok(RenderResult::Static(html));
+        }
+
         let composition_script = self.build_composition_script(
             route_match,
             context,
@@ -336,6 +378,8 @@ impl LayoutRenderer {
             loading_component_id.as_deref(),
             false,
         )?;
+
+        let can_use_html_cache = true;
 
         if let Some(ctx) = request_context {
             let renderer_guard = self.renderer.lock().await;

--- a/crates/rari/src/rsc/rendering/layout/mod.rs
+++ b/crates/rari/src/rsc/rendering/layout/mod.rs
@@ -9,7 +9,7 @@ mod utils;
 pub mod tests;
 
 pub use constants::*;
-pub use core::LayoutRenderer;
+pub use core::{LayoutHtmlCache, LayoutRenderer};
 pub use route_composer::{LayoutInfo, RouteComposer};
 pub use types::*;
 pub use utils::create_layout_context;

--- a/crates/rari/src/server/actions/mod.rs
+++ b/crates/rari/src/server/actions/mod.rs
@@ -338,6 +338,7 @@ pub async fn handle_server_action(
 
                 state.response_cache.invalidate_by_tag(&redirect_path).await;
                 state.html_cache.remove(&redirect_path);
+                state.layout_html_cache.clear();
             }
 
             let response =
@@ -449,6 +450,7 @@ pub async fn handle_form_action(
 
                 state.response_cache.invalidate_by_tag(&redirect_path).await;
                 state.html_cache.remove(&redirect_path);
+                state.layout_html_cache.clear();
 
                 let mut redirect_response = Response::builder()
                     .status(StatusCode::SEE_OTHER)
@@ -529,6 +531,7 @@ pub async fn handle_form_action(
             if let Some(redirect_path) = redirect_path_opt {
                 state.response_cache.invalidate_by_tag(&redirect_path).await;
                 state.html_cache.remove(&redirect_path);
+                state.layout_html_cache.clear();
             }
 
             let mut redirect_response = Response::builder()

--- a/crates/rari/src/server/cache/response_cache.rs
+++ b/crates/rari/src/server/cache/response_cache.rs
@@ -20,12 +20,27 @@ pub struct CachedResponse {
     pub body: Bytes,
     pub headers: HeaderMap,
     pub metadata: CacheMetadata,
+    pub compressed_zstd: Option<Bytes>,
+    pub compressed_br: Option<Bytes>,
+    pub compressed_gzip: Option<Bytes>,
 }
 
 impl CachedResponse {
     pub fn is_valid(&self) -> bool {
         let elapsed = self.metadata.cached_at.elapsed().as_secs();
         elapsed < self.metadata.ttl
+    }
+
+    pub fn get_compressed(
+        &self,
+        encoding: &crate::server::compression::CompressionEncoding,
+    ) -> Option<&Bytes> {
+        match encoding {
+            crate::server::compression::CompressionEncoding::Zstd => self.compressed_zstd.as_ref(),
+            crate::server::compression::CompressionEncoding::Brotli => self.compressed_br.as_ref(),
+            crate::server::compression::CompressionEncoding::Gzip => self.compressed_gzip.as_ref(),
+            crate::server::compression::CompressionEncoding::Identity => None,
+        }
     }
 }
 
@@ -245,6 +260,12 @@ impl ResponseCache {
         self.update_entry_count();
     }
 
+    pub async fn update_in_place(&self, key: &str, response: CachedResponse) {
+        if self.cache.contains_key(key) {
+            self.cache.insert(key.to_string(), response);
+        }
+    }
+
     pub async fn invalidate(&self, key: &str) {
         if let Some((_, response)) = self.cache.remove(key) {
             for tag in &response.metadata.tags {
@@ -383,6 +404,9 @@ mod tests {
                 etag: Some("test-etag".to_string()),
                 tags: vec!["test-tag".to_string()],
             },
+            compressed_zstd: None,
+            compressed_br: None,
+            compressed_gzip: None,
         }
     }
 

--- a/crates/rari/src/server/compression/mod.rs
+++ b/crates/rari/src/server/compression/mod.rs
@@ -1,3 +1,34 @@
 pub mod stream;
 
 pub use stream::{CompressionEncoding, compress_stream};
+
+use bytes::Bytes;
+use futures::StreamExt;
+
+pub async fn compress_body(
+    body: Bytes,
+    encoding: CompressionEncoding,
+) -> (Bytes, CompressionEncoding) {
+    if matches!(encoding, CompressionEncoding::Identity) || body.is_empty() {
+        return (body, CompressionEncoding::Identity);
+    }
+
+    let body_clone = body.clone();
+    let input_stream =
+        futures::stream::once(async move { Ok::<Bytes, std::io::Error>(body_clone) });
+    let mut compressed_stream = compress_stream(input_stream, encoding);
+
+    let mut compressed = Vec::new();
+    while let Some(chunk) = compressed_stream.next().await {
+        match chunk {
+            Ok(data) => compressed.extend_from_slice(&data),
+            Err(_) => return (body, CompressionEncoding::Identity),
+        }
+    }
+
+    if compressed.len() < body.len() {
+        (Bytes::from(compressed), encoding)
+    } else {
+        (body, CompressionEncoding::Identity)
+    }
+}

--- a/crates/rari/src/server/core/mod.rs
+++ b/crates/rari/src/server/core/mod.rs
@@ -187,6 +187,7 @@ impl Server {
             api_route_handler,
             module_reload_manager,
             html_cache: Arc::new(dashmap::DashMap::new()),
+            layout_html_cache: crate::rsc::rendering::layout::LayoutRenderer::create_shared_cache(),
             response_cache,
             og_generator,
             project_root,

--- a/crates/rari/src/server/handlers/app_handler.rs
+++ b/crates/rari/src/server/handlers/app_handler.rs
@@ -269,7 +269,8 @@ pub async fn render_with_fallback(
     context: crate::rsc::rendering::layout::LayoutRenderContext,
     accept_encoding: Option<&str>,
 ) -> Result<Response, StatusCode> {
-    let layout_renderer = LayoutRenderer::new(state.renderer.clone());
+    let layout_renderer =
+        LayoutRenderer::with_shared_cache(state.renderer.clone(), state.layout_html_cache.clone());
 
     match render_streaming_with_layout(
         state.clone(),
@@ -294,7 +295,8 @@ pub async fn render_rsc_navigation_streaming(
     context: crate::rsc::rendering::layout::LayoutRenderContext,
     accept_encoding: Option<&str>,
 ) -> Result<Response, StatusCode> {
-    let layout_renderer = LayoutRenderer::new(state.renderer.clone());
+    let layout_renderer =
+        LayoutRenderer::with_shared_cache(state.renderer.clone(), state.layout_html_cache.clone());
     let is_not_found = route_match.not_found.is_some();
 
     let request_context =
@@ -416,7 +418,8 @@ pub async fn render_synchronous(
     context: crate::rsc::rendering::layout::LayoutRenderContext,
     accept_encoding: Option<&str>,
 ) -> Result<Response, StatusCode> {
-    let layout_renderer = LayoutRenderer::new(state.renderer.clone());
+    let layout_renderer =
+        LayoutRenderer::with_shared_cache(state.renderer.clone(), state.layout_html_cache.clone());
     let request_context =
         std::sync::Arc::new(crate::server::middleware::request_context::RequestContext::new(
             route_match.route.path.clone(),
@@ -628,6 +631,8 @@ pub async fn render_streaming_with_layout(
     let rsc_stream = match render_result {
         crate::rsc::rendering::layout::RenderResult::Streaming(stream) => stream,
         crate::rsc::rendering::layout::RenderResult::Static(html) => {
+            use crate::server::compression::{CompressionEncoding, compress_body};
+
             let html_with_assets = match inject_assets_into_html(&html, &state.config).await {
                 Ok(html) => html,
                 Err(e) => {
@@ -641,13 +646,21 @@ pub async fn render_streaming_with_layout(
 
             let status_code = if is_not_found { StatusCode::NOT_FOUND } else { StatusCode::OK };
 
-            return Ok(Response::builder()
+            let encoding = CompressionEncoding::from_accept_encoding(accept_encoding);
+            let (body_bytes, actual_encoding) =
+                compress_body(bytes::Bytes::from(final_html), encoding).await;
+
+            let mut response_builder = Response::builder()
                 .status(status_code)
                 .header("content-type", "text/html; charset=utf-8")
                 .header("x-render-mode", "static")
-                .header("vary", "Accept")
-                .body(Body::from(final_html))
-                .expect("Valid HTML response"));
+                .header("vary", "Accept, Accept-Encoding");
+
+            if let Some(encoding_header) = actual_encoding.as_header_value() {
+                response_builder = response_builder.header("content-encoding", encoding_header);
+            }
+
+            return Ok(response_builder.body(Body::from(body_bytes)).expect("Valid HTML response"));
         }
     };
 
@@ -864,7 +877,8 @@ pub async fn handle_app_route(
         route_match.pathname.clone(),
     );
 
-    let layout_renderer = LayoutRenderer::new(state.renderer.clone());
+    let layout_renderer =
+        LayoutRenderer::with_shared_cache(state.renderer.clone(), state.layout_html_cache.clone());
 
     if route_match.not_found.is_none() && route_match.route.is_dynamic {
         match layout_renderer.check_page_not_found(&route_match, &context).await {
@@ -978,6 +992,9 @@ pub async fn handle_app_route(
                                 etag: None,
                                 tags: cache_policy.tags,
                             },
+                            compressed_zstd: None,
+                            compressed_br: None,
+                            compressed_gzip: None,
                         };
 
                         state.response_cache.set(cache_key, cached_response).await;
@@ -1027,11 +1044,45 @@ pub async fn handle_app_route(
 
                 let merged_vary = merge_vary_with_accept(cached.headers.get("vary"));
 
+                use crate::server::compression::{CompressionEncoding, compress_body};
+                let encoding = CompressionEncoding::from_accept_encoding(accept_encoding);
+
+                let (body_bytes, actual_encoding) =
+                    if let Some(pre_compressed) = cached.get_compressed(&encoding) {
+                        (pre_compressed.clone(), encoding)
+                    } else if matches!(encoding, CompressionEncoding::Identity) {
+                        (cached.body.clone(), CompressionEncoding::Identity)
+                    } else {
+                        let (compressed, actual_enc) =
+                            compress_body(cached.body.clone(), encoding).await;
+                        if !matches!(actual_enc, CompressionEncoding::Identity) {
+                            let mut updated = cached.clone();
+                            match actual_enc {
+                                CompressionEncoding::Zstd => {
+                                    updated.compressed_zstd = Some(compressed.clone())
+                                }
+                                CompressionEncoding::Brotli => {
+                                    updated.compressed_br = Some(compressed.clone())
+                                }
+                                CompressionEncoding::Gzip => {
+                                    updated.compressed_gzip = Some(compressed.clone())
+                                }
+                                CompressionEncoding::Identity => {}
+                            }
+                            state.response_cache.update_in_place(&cache_key, updated).await;
+                        }
+                        (compressed, actual_enc)
+                    };
+
                 let mut response_builder = Response::builder()
                     .status(status_code)
                     .header("content-type", "text/html; charset=utf-8")
                     .header("vary", merged_vary)
                     .header("x-cache", "HIT");
+
+                if let Some(encoding_header) = actual_encoding.as_header_value() {
+                    response_builder = response_builder.header("content-encoding", encoding_header);
+                }
 
                 if let Some(etag) = &cached.metadata.etag {
                     response_builder = response_builder.header("etag", etag);
@@ -1044,7 +1095,7 @@ pub async fn handle_app_route(
                 }
 
                 return Ok(response_builder
-                    .body(Body::from(cached.body))
+                    .body(Body::from(body_bytes))
                     .expect("Valid cached response"));
             }
 
@@ -1101,6 +1152,9 @@ pub async fn handle_app_route(
                                 etag: Some(etag.clone()),
                                 tags: cache_policy.tags,
                             },
+                            compressed_zstd: None,
+                            compressed_br: None,
+                            compressed_gzip: None,
                         };
 
                         state.response_cache.set(cache_key.clone(), cached_response).await;
@@ -1285,6 +1339,9 @@ pub async fn handle_app_route(
                         etag: Some(etag),
                         tags: cache_policy.tags,
                     },
+                    compressed_zstd: None,
+                    compressed_br: None,
+                    compressed_gzip: None,
                 };
 
                 state.response_cache.set(cache_key, cached_response).await;

--- a/crates/rari/src/server/handlers/hmr_handlers.rs
+++ b/crates/rari/src/server/handlers/hmr_handlers.rs
@@ -226,6 +226,8 @@ async fn handle_register(state: ServerState, file_path: String) -> Result<Json<V
             }
         }
 
+        state.layout_html_cache.clear();
+
         serde_json::json!({
             "success": true,
             "file_path": file_path,

--- a/crates/rari/src/server/handlers/revalidate_handlers.rs
+++ b/crates/rari/src/server/handlers/revalidate_handlers.rs
@@ -57,6 +57,8 @@ pub async fn revalidate_by_path(
                 }
             }
 
+            state.layout_html_cache.clear();
+
             #[allow(clippy::disallowed_methods)]
             Ok(Json(RevalidateResponse {
                 revalidated: true,

--- a/crates/rari/src/server/types/mod.rs
+++ b/crates/rari/src/server/types/mod.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 pub mod request;
 
+use crate::rsc::rendering::layout::LayoutHtmlCache;
 use crate::server::cache::response_cache;
 use crate::server::config;
 use crate::server::og::OgImageGenerator;
@@ -26,6 +27,7 @@ pub struct ServerState {
     pub api_route_handler: Option<Arc<routing::ApiRouteHandler>>,
     pub module_reload_manager: Arc<crate::runtime::module_reload::ModuleReloadManager>,
     pub html_cache: Arc<dashmap::DashMap<String, String>>,
+    pub layout_html_cache: Arc<LayoutHtmlCache>,
     pub response_cache: Arc<response_cache::ResponseCache>,
     pub og_generator: Option<Arc<OgImageGenerator>>,
     pub project_root: PathBuf,

--- a/tools/release/Cargo.toml
+++ b/tools/release/Cargo.toml
@@ -21,4 +21,4 @@ clap = { workspace = true }
 colored = { workspace = true }
 regex = { workspace = true }
 urlencoding = "2.1.3"
-open = "5.3.4"
+open = "5.3.5"


### PR DESCRIPTION
- Upgrade tokio from 1.47.1 to 1.52.3 in workspace dependencies
- Upgrade tokio from 1.52.1 to 1.52.3 in root Cargo.toml
- Upgrade tower-http from 0.6.8 to 0.6.10
- Upgrade rustc-hash from 2.1.1 to 2.1.2
- Upgrade sysinfo from 0.38.4 to 0.39.1
- Refactor LayoutHtmlCache to support shared cache instances across renderers
- Add Default trait implementation for LayoutHtmlCache
- Add public methods: new(), clear(), with_shared_cache(), and create_shared_cache()
- Simplify cache key logic by removing request_context check in render_route
- Optimize rendering path to cache non-streaming routes
- Add layout_html_cache clearing on server action redirects
- Add compressed response caching for zstd, brotli, and gzip formats

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added layout rendering caching to improve application performance.
  * Implemented automatic response body compression based on Accept-Encoding headers.

* **Chores**
  * Updated dependencies: tokio, tower-http, rustc-hash, sysinfo, and open.
  * Bumped version to 0.13.6.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rari-build/rari/pull/175)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->