### PR TITLE
fix(rsc): await element resolution and wrap state updates in transition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7392,7 +7392,7 @@ checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
 
 [[package]]
 name = "rari"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/crates/rari/Cargo.toml
+++ b/crates/rari/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rari"
-version = "0.14.0"
+version = "0.14.1"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/packages/rari/src/runtime/AppRouterProvider.tsx
+++ b/packages/rari/src/runtime/AppRouterProvider.tsx
@@ -663,10 +663,18 @@ export function AppRouterProvider({ children, initialPayload, onNavigate }: AppR
 
       try {
         if (detail.rscResponsePromise) {
-          parsedPayload = parseRscResponseRef.current!(detail.rscResponsePromise)
+          const { element } = parseRscResponseRef.current!(detail.rscResponsePromise)
+          const resolvedElement = await element
+          if (currentNavigationIdRef.current !== detail.navigationId)
+            return
+          parsedPayload = { element: resolvedElement }
         }
         else if (detail.rscResponse) {
-          parsedPayload = parseRscResponseRef.current!(Promise.resolve(detail.rscResponse))
+          const { element } = parseRscResponseRef.current!(Promise.resolve(detail.rscResponse))
+          const resolvedElement = await element
+          if (currentNavigationIdRef.current !== detail.navigationId)
+            return
+          parsedPayload = { element: resolvedElement }
         }
         else if (detail.rscWireFormat) {
           parsedPayload = await parseRscWireFormatRef.current!(detail.rscWireFormat)
@@ -709,13 +717,15 @@ export function AppRouterProvider({ children, initialPayload, onNavigate }: AppR
       }
 
       if (parsedPayload && currentNavigationIdRef.current === detail.navigationId) {
-        setRscPayload(parsedPayload)
+        React.startTransition(() => {
+          setRscPayload(parsedPayload)
+          setRenderKey(prev => prev + 1)
+          setHmrError(null)
+        })
         if (detail.rscWireFormat)
           lastSuccessfulPayloadRef.current = detail.rscWireFormat
 
         resetFailureTracking()
-        setRenderKey(prev => prev + 1)
-        setHmrError(null)
 
         if (onNavigateRef.current)
           onNavigateRef.current(detail)

--- a/packages/rari/src/runtime/AppRouterProvider.tsx
+++ b/packages/rari/src/runtime/AppRouterProvider.tsx
@@ -660,21 +660,37 @@ export function AppRouterProvider({ children, initialPayload, onNavigate }: AppR
 
       let parsedPayload: any = null
       let parseError: Error | null = null
+      let isStreamingResponse = false
 
       try {
         if (detail.rscResponsePromise) {
-          const { element } = parseRscResponseRef.current!(detail.rscResponsePromise)
-          const resolvedElement = await element
+          const response = await detail.rscResponsePromise
           if (currentNavigationIdRef.current !== detail.navigationId)
             return
-          parsedPayload = { element: resolvedElement }
+          isStreamingResponse = response.headers.get('x-render-mode') === 'streaming'
+          const { element } = parseRscResponseRef.current!(Promise.resolve(response))
+          if (isStreamingResponse) {
+            parsedPayload = { element }
+          }
+          else {
+            const resolvedElement = await element
+            if (currentNavigationIdRef.current !== detail.navigationId)
+              return
+            parsedPayload = { element: resolvedElement }
+          }
         }
         else if (detail.rscResponse) {
+          isStreamingResponse = detail.rscResponse.headers.get('x-render-mode') === 'streaming'
           const { element } = parseRscResponseRef.current!(Promise.resolve(detail.rscResponse))
-          const resolvedElement = await element
-          if (currentNavigationIdRef.current !== detail.navigationId)
-            return
-          parsedPayload = { element: resolvedElement }
+          if (isStreamingResponse) {
+            parsedPayload = { element }
+          }
+          else {
+            const resolvedElement = await element
+            if (currentNavigationIdRef.current !== detail.navigationId)
+              return
+            parsedPayload = { element: resolvedElement }
+          }
         }
         else if (detail.rscWireFormat) {
           parsedPayload = await parseRscWireFormatRef.current!(detail.rscWireFormat)
@@ -717,11 +733,18 @@ export function AppRouterProvider({ children, initialPayload, onNavigate }: AppR
       }
 
       if (parsedPayload && currentNavigationIdRef.current === detail.navigationId) {
-        React.startTransition(() => {
+        if (isStreamingResponse) {
           setRscPayload(parsedPayload)
           setRenderKey(prev => prev + 1)
           setHmrError(null)
-        })
+        }
+        else {
+          React.startTransition(() => {
+            setRscPayload(parsedPayload)
+            setRenderKey(prev => prev + 1)
+            setHmrError(null)
+          })
+        }
         if (detail.rscWireFormat)
           lastSuccessfulPayloadRef.current = detail.rscWireFormat
 


### PR DESCRIPTION
- Await element resolution from parseRscResponse before setting payload to ensure element is fully resolved
- Add navigation ID check after awaiting to prevent stale updates if navigation changed
- Wrap setRscPayload, setRenderKey, and setHmrError in React.startTransition for better UX during RSC updates
- Move state updates into transition to batch them together and improve rendering performance
- Prevents race conditions where navigation completes but element resolution is still pending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app router handling of response streaming behavior for better reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rari-build/rari/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->