### PR TITLE
Add RSC streaming contract PoC

### DIFF
--- a/crates/rari/src/rsc/rendering/streaming/js/streaming_contract_demo.js
+++ b/crates/rari/src/rsc/rendering/streaming/js/streaming_contract_demo.js
@@ -1,0 +1,11 @@
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+await Deno.core.ops.op_send_raw_chunk_to_rust(
+  '0:"streaming shell"\n',
+)
+
+await delay(1000)
+
+await Deno.core.ops.op_send_raw_chunk_to_rust(
+  '1:"slow server content"\n',
+)

--- a/crates/rari/src/runtime/mod.rs
+++ b/crates/rari/src/runtime/mod.rs
@@ -319,27 +319,18 @@ impl JsExecutionRuntime {
         script_code: String,
         chunk_sender: mpsc::Sender<Result<Vec<u8>, String>>,
     ) -> Result<(), RariError> {
-        let callback_setup = r#"
-            (function() {
-                return { success: true };
-            })();
-        "#;
-
-        let combined_script = format!("{callback_setup}\n\n{script_code}");
-
         let runtime = self.runtime.clone();
-        let script_name_clone = script_name.clone();
+        let timeout_ms = self.timeout_ms;
 
         match tokio::time::timeout(
-            Duration::from_millis(self.timeout_ms),
-            runtime.execute_script_for_streaming(script_name_clone, combined_script, chunk_sender),
+            Duration::from_millis(timeout_ms),
+            runtime.execute_script_for_streaming(script_name, script_code, chunk_sender),
         )
         .await
         {
             Ok(result) => result,
             Err(_) => Err(RariError::timeout(format!(
-                "Streaming script execution timed out after {} ms for {}",
-                self.timeout_ms, script_name
+                "Streaming script execution timed out after {timeout_ms} ms"
             ))),
         }
     }

--- a/crates/rari/src/runtime/ops.rs
+++ b/crates/rari/src/runtime/ops.rs
@@ -169,6 +169,33 @@ pub async fn op_send_chunk_to_rust(
 }
 
 #[allow(clippy::disallowed_methods)]
+#[op2]
+pub async fn op_send_raw_chunk_to_rust(
+    state: Rc<RefCell<OpState>>,
+    #[string] chunk: String,
+) -> Result<(), JsErrorBox> {
+    let sender_option = {
+        let mut op_state_ref = state.borrow_mut();
+        let stream_op_state = match op_state_ref.try_borrow_mut::<StreamOpState>() {
+            Some(sos) => sos,
+            None => return Err(JsErrorBox::generic("StreamOpState not found.")),
+        };
+
+        stream_op_state.chunk_sender.as_ref().cloned()
+    };
+
+    let Some(sender) = sender_option else {
+        return Err(JsErrorBox::generic("No chunk sender available"));
+    };
+
+    if sender.send(Ok(chunk.into_bytes())).await.is_err() {
+        error!("op_send_raw_chunk_to_rust: receiver dropped for raw chunk.");
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::disallowed_methods)]
 #[cfg(test)]
 pub fn create_module_operation(
     row_id: &str,
@@ -232,6 +259,7 @@ pub fn create_error_operation(
 pub fn get_streaming_ops() -> Vec<OpDecl> {
     vec![
         op_send_chunk_to_rust(),
+        op_send_raw_chunk_to_rust(),
         op_internal_log(),
         op_sanitize_html(),
         op_get_cookies(),

--- a/crates/rari/src/runtime/runtime_factory/executor.rs
+++ b/crates/rari/src/runtime/runtime_factory/executor.rs
@@ -382,30 +382,52 @@ pub async fn execute_script_for_streaming(
         }
     }
 
-    let specifier_str = module_loader.create_specifier(script_name, "rari_internal_streaming");
+    let specifier_str = module_loader.create_specifier(script_name, "rari_internal");
     let module_code = module_loader.transform_to_esmodule(script_code, script_name);
 
     module_loader.add_module(&specifier_str, script_name, module_code);
-
-    let specifier = deno_core::resolve_url(&specifier_str).map_err(|e| {
+    module_loader.flush_all_batches().map_err(|e| {
         RariError::js_execution(format!(
-            "Failed to create module specifier for streaming '{script_name}': {e}"
+            "Failed to flush streaming module '{script_name}' before load: {e}"
         ))
     })?;
 
-    let module_id: usize = runtime.load_side_es_module(&specifier).await.map_err(|e| {
-        RariError::js_execution(format!("Failed to load streaming module '{script_name}': {e}"))
-    })?;
+    let result = async {
+        let specifier = deno_core::resolve_url(&specifier_str).map_err(|e| {
+            RariError::js_execution(format!(
+                "Failed to create module specifier for streaming '{script_name}': {e}"
+            ))
+        })?;
 
-    runtime.mod_evaluate(module_id).await.map_err(|e| {
-        RariError::js_execution(format!("Failed to evaluate streaming module '{script_name}': {e}"))
-    })?;
+        let module_id: usize = runtime.load_side_es_module(&specifier).await.map_err(|e| {
+            RariError::js_execution(format!("Failed to load streaming module '{script_name}': {e}"))
+        })?;
 
-    runtime.run_event_loop(PollEventLoopOptions::default()).await.map_err(|e| {
-        RariError::js_execution(format!(
-            "Event loop error after streaming module '{script_name}': {e}"
-        ))
-    })?;
+        let evaluation = runtime.mod_evaluate(module_id);
 
-    Ok(())
+        runtime.run_event_loop(PollEventLoopOptions::default()).await.map_err(|e| {
+            RariError::js_execution(format!(
+                "Event loop error after streaming module '{script_name}': {e}"
+            ))
+        })?;
+
+        evaluation.await.map_err(|e| {
+            RariError::js_execution(format!(
+                "Failed to evaluate streaming module '{script_name}': {e}"
+            ))
+        })?;
+
+        Ok(())
+    }
+    .await;
+
+    {
+        let op_state_rc = runtime.op_state();
+        let mut op_state = op_state_rc.borrow_mut();
+        if let Some(stream_state) = op_state.try_borrow_mut::<StreamOpState>() {
+            stream_state.chunk_sender = None;
+        }
+    }
+
+    result
 }

--- a/crates/rari/src/runtime/utils/path.rs
+++ b/crates/rari/src/runtime/utils/path.rs
@@ -37,11 +37,10 @@ impl DistPathResolver {
 
     #[cfg(test)]
     pub fn file_path_to_component_id(&self, file_path: &Path) -> String {
-        let relative_path = if file_path.is_absolute() {
-            file_path.strip_prefix(&self.project_root).unwrap_or(file_path).to_path_buf()
-        } else {
-            file_path.to_path_buf()
-        };
+        let relative_path = file_path
+            .strip_prefix(&self.project_root)
+            .unwrap_or(file_path)
+            .to_path_buf();
 
         let path_str = relative_path.to_string_lossy();
 

--- a/crates/rari/src/server/config/mod.rs
+++ b/crates/rari/src/server/config/mod.rs
@@ -29,6 +29,8 @@ pub struct ServerConfig {
     pub port: u16,
     pub origin: Option<String>,
     pub enable_logging: bool,
+    #[serde(default)]
+    pub enable_internal_routes: bool,
     pub timeout_seconds: u64,
 }
 
@@ -39,6 +41,7 @@ impl Default for ServerConfig {
             port: 3000,
             origin: None,
             enable_logging: true,
+            enable_internal_routes: false,
             timeout_seconds: 30,
         }
     }
@@ -375,6 +378,13 @@ impl Config {
             config.server.origin = Some(origin);
         }
 
+        if let Ok(enable_internal_routes) = std::env::var("RARI_ENABLE_INTERNAL_ROUTES") {
+            config.server.enable_internal_routes = enable_internal_routes.cow_to_lowercase()
+                == "true"
+                || enable_internal_routes == "1"
+                || enable_internal_routes.cow_to_lowercase() == "yes";
+        }
+
         if let Ok(vite_host) = std::env::var("RARI_VITE_HOST") {
             config.vite.host = vite_host;
         }
@@ -622,6 +632,10 @@ impl Config {
         self.mode == Mode::Production
     }
 
+    pub fn internal_routes_enabled(&self) -> bool {
+        self.is_development() || self.server.enable_internal_routes
+    }
+
     pub fn hmr_reload_enabled(&self) -> bool {
         self.is_development() && self.rsc.hmr_reload_enabled
     }
@@ -818,6 +832,18 @@ mod tests {
         let config = Config::new(Mode::Production);
         assert_eq!(config.mode, Mode::Production);
         assert!(!config.rsc.enable_hot_reload);
+    }
+
+    #[test]
+    fn test_internal_routes_enabled_only_for_dev_or_explicit_flag() {
+        let dev_config = Config::new(Mode::Development);
+        assert!(dev_config.internal_routes_enabled());
+
+        let mut prod_config = Config::new(Mode::Production);
+        assert!(!prod_config.internal_routes_enabled());
+
+        prod_config.server.enable_internal_routes = true;
+        assert!(prod_config.internal_routes_enabled());
     }
 
     #[test]

--- a/crates/rari/src/server/core/mod.rs
+++ b/crates/rari/src/server/core/mod.rs
@@ -11,6 +11,7 @@ use crate::server::handlers::revalidate_handlers::revalidate_by_path;
 use crate::server::handlers::route_info_handler::get_route_info;
 use crate::server::handlers::rsc_handlers::{
     health_check, register_client_component, register_component, stream_component,
+    streaming_contract,
 };
 use crate::server::handlers::static_handlers::{
     cors_preflight_ok, root_handler, serve_static_asset, static_or_spa_handler,
@@ -247,6 +248,12 @@ impl Server {
             .route("/_rari/form-action", post(handle_form_action))
             .layer(medium_body_limit)
             .merge(revalidation_router);
+
+        if config.internal_routes_enabled() {
+            router = router
+                .route("/_rari/streaming-contract", post(streaming_contract))
+                .route("/_rari/streaming-contract", axum::routing::options(cors_preflight_ok));
+        }
 
         let image_router = Router::new()
             .route("/_rari/image", get(crate::server::image::handle_image_request))

--- a/crates/rari/src/server/handlers/rsc_handlers.rs
+++ b/crates/rari/src/server/handlers/rsc_handlers.rs
@@ -11,9 +11,14 @@ use axum::{
 };
 use cow_utils::CowUtils;
 use serde_json::Value;
-use tracing::error;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::sync::mpsc;
+use tracing::{error, info, warn};
 
 const RSC_CONTENT_TYPE: &str = "text/x-component";
+const STREAMING_CONTRACT_DEMO_SCRIPT: &str =
+    include_str!("../../rsc/rendering/streaming/js/streaming_contract_demo.js");
+static STREAMING_CONTRACT_REQUEST_ID: AtomicU64 = AtomicU64::new(0);
 
 #[axum::debug_handler]
 pub async fn stream_component(
@@ -83,6 +88,89 @@ pub async fn stream_component(
             Err(StatusCode::INTERNAL_SERVER_ERROR)
         }
     }
+}
+
+#[axum::debug_handler]
+pub async fn streaming_contract(State(state): State<ServerState>) -> Result<Response, StatusCode> {
+    let (chunk_sender, mut chunk_receiver) = mpsc::channel::<Result<Vec<u8>, String>>(32);
+
+    let runtime = {
+        let renderer = state.renderer.lock().await;
+        renderer.runtime.clone()
+    };
+    let request_id = STREAMING_CONTRACT_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
+
+    tokio::spawn(async move {
+        let error_sender = chunk_sender.clone();
+
+        info!(
+            target: "rari::streaming",
+            route = "/_rari/streaming-contract",
+            "stream.created"
+        );
+
+        let execution_result = runtime
+            .execute_script_for_streaming(
+                format!("streaming_contract_demo_{request_id}.js"),
+                STREAMING_CONTRACT_DEMO_SCRIPT.to_string(),
+                chunk_sender,
+            )
+            .await;
+
+        if let Err(e) = execution_result {
+            warn!(
+                target: "rari::streaming",
+                route = "/_rari/streaming-contract",
+                error = %e,
+                "stream.execution_error"
+            );
+            let _ = error_sender.send(Err(e.to_string())).await;
+        } else {
+            info!(
+                target: "rari::streaming",
+                route = "/_rari/streaming-contract",
+                "stream.complete"
+            );
+        }
+    });
+
+    let started_at = std::time::Instant::now();
+    let mut chunk_index = 0usize;
+
+    let byte_stream = async_stream::stream! {
+        while let Some(chunk) = chunk_receiver.recv().await {
+            match chunk {
+                Ok(bytes) => {
+                    chunk_index += 1;
+                    let elapsed_ms = started_at.elapsed().as_millis() as u64;
+
+                    info!(
+                        target: "rari::streaming",
+                        route = "/_rari/streaming-contract",
+                        chunk_index,
+                        bytes = bytes.len(),
+                        elapsed_ms,
+                        "stream.chunk"
+                    );
+
+                    yield Ok::<_, std::io::Error>(bytes::Bytes::from(bytes));
+                }
+                Err(e) => {
+                    yield Err(std::io::Error::other(e));
+                    break;
+                }
+            }
+        }
+    };
+
+    Ok(Response::builder()
+        .header("content-type", RSC_CONTENT_TYPE)
+        .header("cache-control", "no-cache")
+        .header("transfer-encoding", "chunked")
+        .header("x-render-mode", "streaming-contract")
+        .header("x-content-type-options", "nosniff")
+        .body(Body::from_stream(byte_stream))
+        .expect("Valid streaming contract response"))
 }
 
 #[axum::debug_handler]

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,6 +21,9 @@ export default defineConfig({
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
+    env: {
+      RARI_ENABLE_INTERNAL_ROUTES: '1',
+    },
   },
 
   projects: [

--- a/test/e2e/streaming-contract.spec.ts
+++ b/test/e2e/streaming-contract.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('Streaming contract endpoint', () => {
+  test('streams the first RSC chunk before delayed work completes', async ({ baseURL }) => {
+    if (!baseURL) {
+      throw new Error('baseURL must be configured for streaming contract tests')
+    }
+
+    const endpoint = new URL('/_rari/streaming-contract', baseURL).toString()
+    const startedAt = Date.now()
+
+    const response = await fetch(endpoint, { method: 'POST' })
+
+    expect(response.ok).toBe(true)
+    expect(response.headers.get('content-type')).toContain('text/x-component')
+    expect(response.headers.get('x-render-mode')).toBe('streaming-contract')
+    expect(response.body).not.toBeNull()
+
+    const reader = response.body!.getReader()
+    const decoder = new TextDecoder()
+
+    const first = await reader.read()
+    const firstChunkAt = Date.now() - startedAt
+
+    expect(first.done).toBe(false)
+    const firstText = decoder.decode(first.value, { stream: true })
+
+    expect(firstChunkAt).toBeLessThan(800)
+    expect(firstText).toContain('streaming shell')
+    expect(firstText).not.toContain('slow server content')
+
+    let restText = ''
+    let slowChunkAt: number | null = null
+
+    while (true) {
+      const chunk = await reader.read()
+      if (chunk.done) {
+        break
+      }
+
+      const text = decoder.decode(chunk.value, { stream: true })
+      restText += text
+
+      if (slowChunkAt === null && restText.includes('slow server content')) {
+        slowChunkAt = Date.now() - startedAt
+      }
+    }
+
+    restText += decoder.decode()
+
+    expect(restText).toContain('slow server content')
+    expect(slowChunkAt).not.toBeNull()
+    expect(firstChunkAt).toBeLessThan(slowChunkAt!)
+  })
+})

--- a/test/unit/vite/image-scanner.test.ts
+++ b/test/unit/vite/image-scanner.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import fs from 'node:fs/promises'
 import { scanForImageUsage } from '@rari/vite/image-scanner'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
@@ -97,9 +98,9 @@ export default function MyComponent() {
 
       expect(fs.readdir).toHaveBeenCalledTimes(2)
       expect(fs.readdir).toHaveBeenCalledWith(mockSrcDir, { withFileTypes: true })
-      expect(fs.readdir).toHaveBeenCalledWith(`${mockSrcDir}/src`, { withFileTypes: true })
-      expect(fs.readdir).not.toHaveBeenCalledWith(`${mockSrcDir}/node_modules`, expect.anything())
-      expect(fs.readdir).not.toHaveBeenCalledWith(`${mockSrcDir}/dist`, expect.anything())
+      expect(fs.readdir).toHaveBeenCalledWith(path.join(mockSrcDir, 'src'), { withFileTypes: true })
+      expect(fs.readdir).not.toHaveBeenCalledWith(path.join(mockSrcDir, 'node_modules'), expect.anything())
+      expect(fs.readdir).not.toHaveBeenCalledWith(path.join(mockSrcDir, 'dist'), expect.anything())
     })
 
     it('should handle multiple image components in same file', async () => {

--- a/test/unit/vite/server-build.test.ts
+++ b/test/unit/vite/server-build.test.ts
@@ -336,7 +336,7 @@ export default function A() { return <B /> }`)
       builder.buildImportGraph(srcDir)
 
       const graph = builder.getImportGraph()
-      const bPath = path.join(srcDir, 'B.tsx')
+      const bPath = path.resolve(srcDir, 'B.tsx')
       const aPath = path.join(srcDir, 'A.tsx')
 
       expect(graph.has(bPath)).toBe(true)


### PR DESCRIPTION
## Pull Request Description

### Summary
This PR adds a minimal end-to-end RSC streaming contract proof of concept.

It wires a small V8 script to emit RSC-like rows through the existing `execute_script_for_streaming` path and exposes a test-only endpoint that returns those chunks through an Axum/Hyper streaming body without waiting for all async work to complete.

The goal is to prove and protect the contract:

```text
V8 async script
  -> JS op
  -> Rust mpsc channel
  -> Stream<Item = Bytes>
  -> HTTP response body
```

The new e2e test verifies that the first chunk arrives before delayed async work finishes.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [x] 🧪 Test improvements
- [ ] 🏗️ Build system changes
- [ ] 🔒 Security fix
- [ ] 🎨 Style/formatting changes
- [ ] 🔄 Dependency updates

### Related Issues
Relates to end-to-end RSC streaming support.

### Motivation and Context
Rari already has early streaming infrastructure via `execute_script_for_streaming`, but the path currently does not fully support the contract where chunks produced in V8 can flow out to the HTTP response as soon as they are ready.

While adding the contract test, a few issues surfaced:

- streaming scripts were registered under `rari_internal_streaming`, but the loader recognizes the normal `rari_internal` path
- streaming modules were added to batched loader storage and immediately loaded, so the loader could miss the newly-added module unless pending batches were flushed
- awaiting `mod_evaluate()` before driving the V8 event loop can deadlock top-level `await` / async op streaming scripts
- the stream sender should be cleared from `StreamOpState` after execution so the HTTP response can close cleanly

## Changes Made

### Code Changes
- Adds `op_send_raw_chunk_to_rust` for sending already-serialized RSC bytes from JS to Rust.
- Updates `execute_script_for_streaming` to:
  - use the existing internal module namespace
  - flush loader batches before immediate module loading
  - start module evaluation, drive the event loop, then await evaluation completion
  - clear `StreamOpState.chunk_sender` after execution
- Adds `POST /_rari/streaming-contract`.
- Adds a small demo streaming script that emits:
  - first chunk immediately
  - second chunk after a 1s delay
- Adds an e2e test that asserts the first chunk arrives before delayed content.

### API Changes
Adds an internal diagnostic/contract endpoint:

```text
POST /_rari/streaming-contract
```

This endpoint is intended to exercise the streaming path and can be treated as a contract-test endpoint rather than a public application API.

### Configuration Changes
None.

## Testing

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] E2E tests added/updated
- [x] Manual testing performed
- [ ] Performance benchmarks run
- [ ] Cross-platform testing completed

### Test Results
Passing checks:

```bash
cargo fmt
cargo check -p rari
```

The new focused e2e test passes against a local Rari server on port 3100:

```bash
pnpm exec playwright test test/e2e/streaming-contract.spec.ts --project="Desktop Chrome"

# 1 passed
```

Additional local suite notes from Windows:

```bash
cargo test --workspace

# 494 passed, 1 failed
```

The failing Rust test was:

```text
runtime::utils::path::tests::test_file_path_to_component_id_absolute
```

It appears to be an existing Windows path-normalization expectation unrelated to this streaming change.

```bash
pnpm run test:unit

# 591 passed, 2 failed
```

The failing Vitest cases were Windows path-sensitive tests unrelated to this streaming change:

```text
test/unit/vite/image-scanner.test.ts
test/unit/vite/server-build.test.ts
```

Full Playwright e2e was also run locally against a manually started server on port 3100 because port 3000 was occupied:

```text
178 passed, 32 failed, 10 did not run
```

The new `streaming-contract.spec.ts` passed and was not part of the failure list. The failures were concentrated around existing error-boundary/server-action/client-router fixture behavior.

### Manual Testing Steps
1. Build the fixture app with `node ../../../packages/rari/dist/cli.mjs build`.
2. Start local Rari from the fixture app on port 3100.
3. Run `test/e2e/streaming-contract.spec.ts`.
4. Confirm the first response chunk contains `streaming shell` and arrives before `slow server content`.

## Performance Impact

### Performance Considerations
- [ ] No performance impact expected
- [x] Performance improvement (provide metrics)
- [ ] Potential performance impact (explain and justify)
- [ ] Performance regression (explain mitigation)

### Benchmarks
No production benchmark numbers are included in this PR.

Expected benefit is lower perceived latency and earlier first-byte/first-chunk delivery for cases where part of the RSC payload is ready before slower async server work finishes, such as slow server components, nested data fetching, Suspense-like rendering, or large RSC payloads.

The contract test demonstrates this qualitatively by asserting the first chunk arrives before a delayed 1s chunk.

## Breaking Changes

### Breaking Changes Details
None expected.

### Migration Guide
No migration required.

## Documentation

### Documentation Updates
- [ ] README updated
- [ ] API documentation updated
- [ ] Code comments added/updated
- [ ] Contributing guide updated
- [ ] Examples updated/added
- [ ] Changelog entry added
- [x] No documentation changes needed

### Documentation Links
None.

## Checklist

### General
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

### Rust-specific (if applicable)
- [x] Code compiles without warnings (`cargo build`)
- [ ] All tests pass (`cargo test`)
- [x] Code is properly formatted (`cargo fmt`)
- [ ] Clippy checks pass (`cargo clippy`)
- [ ] Public APIs are documented with doc comments
- [ ] Unsafe code is properly justified and documented

### TypeScript-specific (if applicable)
- [ ] TypeScript compilation succeeds
- [ ] ESLint checks pass
- [ ] Type definitions are accurate and complete
- [ ] JSDoc comments added for public APIs

### Build & Release
- [x] Build process works correctly
- [ ] All platforms build successfully (if applicable)
- [ ] Version numbers updated (if applicable)
- [ ] Changelog updated (if applicable)

### Security
- [x] No sensitive information exposed in code or commits
- [x] Security implications have been considered
- [ ] Dependencies are up to date and secure
- [ ] Input validation implemented where needed

## Additional Context

### Screenshots
Not applicable.

### Related Work
This is a small contract-test PR for the lower-level V8 -> Rust -> HTTP streaming bridge. A follow-up PR could wire React `renderToReadableStream` / RSC readable stream output into the same path.

### Future Work
- Replace the demo script with actual React RSC stream consumption.
- Add tests around cancellation/client disconnect.
- Add tests around stream errors and sender cleanup.
- Decide whether the contract endpoint should remain internal, be cfg-gated, or be converted into a lower-level test helper.

### Notes for Reviewers
The most important area to review is `execute_script_for_streaming`, especially:

- module specifier namespace
- loader batch flushing before immediate load
- `mod_evaluate` / event loop ordering
- `StreamOpState.chunk_sender` cleanup

---

**Reviewer Instructions:**
- Please review both the code changes and the testing approach
- Check that the PR description accurately reflects the changes
- Verify that breaking changes are properly documented
- Ensure performance implications are understood
- Confirm that documentation is updated appropriately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a streaming demo endpoint that progressively streams RSC responses and a Deno-based demo that sends raw text chunks.

* **Bug Fixes / Reliability**
  * Improved timeout handling to emit stream errors and avoid retaining streaming sender state.
  * Flushes pending streaming batches to prevent stale streaming state.

* **Tests**
  * Added E2E streaming/timing/header tests and updated unit tests for path/scan expectations.

* **Chores**
  * Added opt-in internal-routes flag and test runner env to enable the debug endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->