### PR TITLE
fix: Windows path compatibility for tests and Rust path resolver

### DIFF
--- a/crates/rari/src/runtime/utils/path.rs
+++ b/crates/rari/src/runtime/utils/path.rs
@@ -37,11 +37,10 @@ impl DistPathResolver {
 
     #[cfg(test)]
     pub fn file_path_to_component_id(&self, file_path: &Path) -> String {
-        let relative_path = if file_path.is_absolute() {
-            file_path.strip_prefix(&self.project_root).unwrap_or(file_path).to_path_buf()
-        } else {
-            file_path.to_path_buf()
-        };
+        let relative_path = file_path
+            .strip_prefix(&self.project_root)
+            .unwrap_or(file_path)
+            .to_path_buf();
 
         let path_str = relative_path.to_string_lossy();
 

--- a/test/unit/vite/image-scanner.test.ts
+++ b/test/unit/vite/image-scanner.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import fs from 'node:fs/promises'
 import { scanForImageUsage } from '@rari/vite/image-scanner'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
@@ -97,9 +98,9 @@ export default function MyComponent() {
 
       expect(fs.readdir).toHaveBeenCalledTimes(2)
       expect(fs.readdir).toHaveBeenCalledWith(mockSrcDir, { withFileTypes: true })
-      expect(fs.readdir).toHaveBeenCalledWith(`${mockSrcDir}/src`, { withFileTypes: true })
-      expect(fs.readdir).not.toHaveBeenCalledWith(`${mockSrcDir}/node_modules`, expect.anything())
-      expect(fs.readdir).not.toHaveBeenCalledWith(`${mockSrcDir}/dist`, expect.anything())
+      expect(fs.readdir).toHaveBeenCalledWith(path.join(mockSrcDir, 'src'), { withFileTypes: true })
+      expect(fs.readdir).not.toHaveBeenCalledWith(path.join(mockSrcDir, 'node_modules'), expect.anything())
+      expect(fs.readdir).not.toHaveBeenCalledWith(path.join(mockSrcDir, 'dist'), expect.anything())
     })
 
     it('should handle multiple image components in same file', async () => {

--- a/test/unit/vite/server-build.test.ts
+++ b/test/unit/vite/server-build.test.ts
@@ -336,7 +336,7 @@ export default function A() { return <B /> }`)
       builder.buildImportGraph(srcDir)
 
       const graph = builder.getImportGraph()
-      const bPath = path.join(srcDir, 'B.tsx')
+      const bPath = path.resolve(srcDir, 'B.tsx')
       const aPath = path.join(srcDir, 'A.tsx')
 
       expect(graph.has(bPath)).toBe(true)


### PR DESCRIPTION
## Pull Request Description

### Summary
Fix Windows compatibility issues in path resolution for both Rust and TypeScript test code. Three targeted changes ensure tests pass on Windows without affecting Linux/macOS behavior.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

### Related Issues
No related issues — discovered while running the test suite on Windows.

### Motivation and Context
The project's test suite and Rust path resolver had hardcoded assumptions about POSIX path conventions (trailing `/`, `path.is_absolute()`) that break on Windows, where:
- Root-relative paths like `/project` lack a drive letter and are not considered absolute
- `path.join()` and `path.resolve()` produce different results
- Directory separators differ

Without these fixes, 2 unit tests fail and `file_path_to_component_id` produces incorrect component IDs on Windows.

## Changes Made

### Code Changes

**`crates/rari/src/runtime/utils/path.rs`** — `file_path_to_component_id` unconditionally calls `strip_prefix` instead of guarding with `file_path.is_absolute()`. On Windows, root-relative paths like `/project` are not absolute (no drive letter), so `is_absolute()` returns `false` and the prefix is never stripped, producing path like `/project/src/pages/about` instead of `pages/about`.

**`test/unit/vite/image-scanner.test.ts`** — Replaced string concatenation `` `${mockSrcDir}/src` `` with `path.join(mockSrcDir, 'src')` to produce correct paths on Windows.

**`test/unit/vite/server-build.test.ts`** — In `buildImportGraph` test, `bPath` now uses `path.resolve(srcDir, 'B.tsx')` (matching internal `path.resolve` usage for graph keys) while `aPath` stays as `path.join(srcDir, 'A.tsx')` (matching internal `path.join` usage for Set values).

### API Changes
None — no public APIs changed.

### Configuration Changes
None.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Cross-platform testing completed

### Test Results

```
# Rust (495 tests)
cargo test
test result: ok. 495 passed; 0 failed

# JS/TS (593 tests)
pnpm test:unit:run
Test Files: 22 passed
     Tests: 593 passed
```

### Manual Testing Steps
1. Run `cargo test` on Windows — all 495 tests pass
2. Run `pnpm test:unit:run` on Windows — all 593 tests pass
3. Verify same commands pass on Linux/macOS (no behavioral change for POSIX)

## Performance Impact

### Performance Considerations

- [x] No performance impact expected
`strip_prefix` on a non-matching path returns `Err` immediately (zero-cost), so the unconditional call is equivalent to the old `if` branch.

### Benchmarks
N/A

## Breaking Changes

### Breaking Changes Details
None.

### Migration Guide
N/A

## Documentation

### Documentation Updates

- [x] No documentation changes needed
Changes are internal implementation details and test assertions. No user-facing behavior changed.

## Checklist

### General
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

### Rust-specific (if applicable)
- [x] Code compiles without warnings (`cargo build`)
- [x] All tests pass (`cargo test`)
- [x] Code is properly formatted (`cargo fmt`)
- [x] Clippy checks pass (`cargo clippy`)

### TypeScript-specific (if applicable)
- [x] TypeScript compilation succeeds
- [x] ESLint checks pass

### Build & Release
- [x] Build process works correctly

### Security
- [x] No sensitive information exposed in code or commits

## Additional Context

### Related Work
N/A

### Future Work
- Add Windows CI runner to catch regressions
- Check for similar `is_absolute()` patterns elsewhere in path-related code

### Notes for Reviewers
- The `path.rs` change is the most impactful — please verify the logic is correct for both absolute and relative paths on all platforms
- The test changes are mechanical Windows compatibility fixes with no behavioral impact on Linux/macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined path normalization logic to consistently process both relative and absolute file paths in a unified manner.

* **Tests**
  * Updated test assertions to use standard path resolution utilities for constructing and comparing file paths, ensuring more accurate and reliable test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->