### PR TITLE
chore(deps): upgrade deno runtime dependencies to latest versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
 dependencies = [
- "object",
+ "object 0.37.3",
 ]
 
 [[package]]
@@ -455,50 +455,23 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http 1.4.1",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core 0.5.6",
+ "axum-core",
  "axum-macros",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -511,30 +484,10 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.4.1",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -545,8 +498,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -1504,7 +1457,7 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
- "mio 1.2.0",
+ "mio",
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
@@ -1780,6 +1733,7 @@ dependencies = [
  "swc_eq_ignore_macros",
  "swc_macros_common",
  "swc_sourcemap",
+ "swc_ts_fast_strip",
  "swc_visit",
  "text_lines",
  "thiserror 2.0.18",
@@ -1789,9 +1743,9 @@ dependencies = [
 
 [[package]]
 name = "deno_bundle_runtime"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60011fbad2c636cb84a754dfd21cce76d940c9ec3478087b933510f1471959c0"
+checksum = "9d5c2a20e47c951c193e840b2f5d77fc666a9823886e1b805c46850c611d5f53"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -1802,9 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "deno_cache"
-version = "0.182.0"
+version = "0.183.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3502acc6b551d012701bae2e8ae4d61442f7561ff3c09de1b0f0d79053bb905f"
+checksum = "fcca3a07e4de01ca346dc8da96ff7319eac00d933a01ea6481e6694770f2e618"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -1813,10 +1767,10 @@ dependencies = [
  "deno_core",
  "deno_error",
  "futures",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "log",
  "rusqlite",
@@ -1829,9 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "deno_cache_dir"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c2273d77408a992128626cee98900a7976df67ef06356daac49e5d0f988bae"
+checksum = "78132f92490cc94aded5197eb20134e576f1d05237404a7d5f479630bce5c396"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1842,7 +1796,7 @@ dependencies = [
  "deno_maybe_sync",
  "deno_media_type",
  "deno_path_util",
- "http 1.4.1",
+ "http",
  "log",
  "once_cell",
  "parking_lot",
@@ -1856,9 +1810,9 @@ dependencies = [
 
 [[package]]
 name = "deno_canvas"
-version = "0.111.0"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847f4d43dd133cefb24829be833d048c062649d16fdae4e2b9c23a42c5307a4f"
+checksum = "11198014f935965c31143fbcf210eedd64e3df59d47d4908fa3ea52e8eb1bf22"
 dependencies = [
  "bytemuck",
  "deno_core",
@@ -1871,9 +1825,9 @@ dependencies = [
 
 [[package]]
 name = "deno_config"
-version = "0.99.0"
+version = "0.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf085683c4035cb37acd31cffa6d39f9e5965a5c1f00b8582be29d045a8dcd"
+checksum = "4a06411a763d48ef63930dbf08782dcf97e8ef9c690df148a0877d42a48bfb25"
 dependencies = [
  "boxed_error",
  "capacity_builder",
@@ -1886,7 +1840,7 @@ dependencies = [
  "glob",
  "ignore",
  "import_map",
- "indexmap 2.14.0",
+ "indexmap",
  "jsonc-parser",
  "log",
  "serde",
@@ -1898,9 +1852,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.402.0"
+version = "0.403.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14a38b8c716b41d1ac8ae9cb43e31dfd01e6d2e7d1d0c8d5be82ade4c04b092f"
+checksum = "ad3c1fcdf9cccb942bfd3f24cb0118c899837434d5b887a374bab7ce45ace6da"
 dependencies = [
  "anyhow",
  "az",
@@ -1917,7 +1871,7 @@ dependencies = [
  "deno_path_util",
  "deno_unsync",
  "futures",
- "indexmap 2.14.0",
+ "indexmap",
  "inventory",
  "libc",
  "num-bigint",
@@ -1941,9 +1895,9 @@ dependencies = [
 
 [[package]]
 name = "deno_cron"
-version = "0.129.0"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce5d1405e8a63d5d7761daf38ef210e938a0a358b60faa54fa93d16e7662b02a"
+checksum = "fbadeda43970fe9207d711d3d108819acc7c5fbb7e2077ef411e4f596b84a3f1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1960,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "deno_crypto"
-version = "0.263.0"
+version = "0.264.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8dbe5be4f38f78af47a6f419f5f133f431b584b71406fb0618a6f7de32231a"
+checksum = "b78f95ebb4fbd3918900ecdd2fe26956b3b7289b6b51ae4817775bb6d357e6d5"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1978,6 +1932,7 @@ dependencies = [
  "ecdsa",
  "ed448-goldilocks",
  "elliptic-curve 0.13.8",
+ "hmac",
  "num-traits",
  "ocb3",
  "once_cell",
@@ -2001,18 +1956,18 @@ dependencies = [
 
 [[package]]
 name = "deno_crypto_provider"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92574c2244e5a4fcece0d68c9760c82af36112354d1171138b30fb3472021a1"
+checksum = "2712b251d4ece4af288dc94aa79a2dca151b6babea8eaa04a5db2e193f322a97"
 dependencies = [
  "aws-lc-sys",
 ]
 
 [[package]]
 name = "deno_dotenv"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2e42eff1c6348ae7285ed69c1747a4c5240542e1d848bd5d5f51633e24451d"
+checksum = "7dda2d94ac35496d8b821c81d1852849901483a4317df2a4855ca2eec07a778a"
 dependencies = [
  "deno_path_util",
  "sys_traits",
@@ -2046,18 +2001,18 @@ dependencies = [
 
 [[package]]
 name = "deno_features"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7c9837df1064a1cba4cc4b849c0109add3a88ea12eca3908821468599a1cee"
+checksum = "bb525829630748a1eea55194538ad3bad12a22bbc05ee1b3338a8e864bfb2d81"
 dependencies = [
  "deno_core",
 ]
 
 [[package]]
 name = "deno_fetch"
-version = "0.273.0"
+version = "0.274.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eaa3c0d5fe248373392a6c9baf02e5e3673d5126c60319b5f4508efcd64e4c3"
+checksum = "a51d2ecd885f522a8983457a3a3360616a78b81279dde679f8aeeffde4db449a"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2070,11 +2025,11 @@ dependencies = [
  "deno_permissions",
  "deno_tls",
  "error_reporter",
- "h2 0.4.13",
+ "h2",
  "hickory-resolver",
- "http 1.4.1",
+ "http",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "ipnet",
@@ -2086,16 +2041,16 @@ dependencies = [
  "tokio-rustls",
  "tokio-socks",
  "tokio-vsock",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
 ]
 
 [[package]]
 name = "deno_ffi"
-version = "0.236.0"
+version = "0.237.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c00d2fdb915860b1db69abb65ce38c3c1cda6776c31f91671c8378f8470fe0c"
+checksum = "6ddb2e7996134edc35b90cf9a8103e99a3c9fa030f5ebf1189df18a25772d898"
 dependencies = [
  "cranelift",
  "cranelift-native",
@@ -2113,14 +2068,14 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "deno_fs"
-version = "0.159.0"
+version = "0.160.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b043ea147ea72b7890f637aa9b569635b9f10c36ac96f0887c5c2686c5bff2"
+checksum = "61f9d45705d1025e6dd66eed462f7d82cab02d7526f2dc1f71e5d29b382da081"
 dependencies = [
  "async-trait",
  "boxed_error",
@@ -2138,14 +2093,14 @@ dependencies = [
  "rayon",
  "serde",
  "thiserror 2.0.18",
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "deno_http"
-version = "0.247.0"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e7becf37fd085f40b483181ab2c84de5a65627a51f82bfd2596a2a45125a969"
+checksum = "b332617b9af7c23f4bad00f9ad0643402f0701258f2aabf10873c0528819b43e"
 dependencies = [
  "async-compression",
  "async-trait",
@@ -2159,11 +2114,10 @@ dependencies = [
  "deno_telemetry",
  "deno_websocket",
  "flate2",
- "http 0.2.12",
- "http 1.4.1",
+ "http",
+ "http-body-util",
  "httparse",
- "hyper 0.14.32",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "itertools 0.14.0",
  "log",
@@ -2182,9 +2136,9 @@ dependencies = [
 
 [[package]]
 name = "deno_image"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8022dbc9c9596e11c3aff4d2656a56bce8a2b164637c5de6d2114e0995dacefb"
+checksum = "951fc4d252135ba91147672afdf7f025d1fdcdd0fed24273d548c7795334ca9c"
 dependencies = [
  "bytemuck",
  "deno_core",
@@ -2197,16 +2151,16 @@ dependencies = [
 
 [[package]]
 name = "deno_inspector_server"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd3bbf26a2eb24d02548500a3d489bc8a349f2be1dfe87d7abfb6e4a43f34e0"
+checksum = "055fbb6fd4ba828a6a2916f7da74d7c6b5ba8983d2a33c985e00b15cefb5c669"
 dependencies = [
  "deno_core",
  "deno_error",
  "fastwebsockets",
- "http 1.4.1",
+ "http",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "log",
  "thiserror 2.0.18",
@@ -2216,9 +2170,9 @@ dependencies = [
 
 [[package]]
 name = "deno_io"
-version = "0.159.0"
+version = "0.160.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de5e337b81009e9ef2ecae7db646548ef1263af6ca28dc72be839437d6fa0e2"
+checksum = "1e6cde35f89d5a30d5ac58a81c8a80c8af48f15cace8aec94c6971a46b6a8ebf"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -2235,15 +2189,14 @@ dependencies = [
  "rand 0.8.5",
  "tokio",
  "uuid",
- "winapi",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "deno_kv"
-version = "0.157.0"
+version = "0.158.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e1a183b82a4a1b50923d52075bc942d00d9501aa169a4616aba36058d6424c"
+checksum = "3cde96188a765773b3115c4c49326660720d62f87cf9b6eeea3218539876eebc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2262,7 +2215,7 @@ dependencies = [
  "denokv_remote",
  "denokv_sqlite",
  "faster-hex",
- "http 1.4.1",
+ "http",
  "http-body-util",
  "log",
  "num-bigint",
@@ -2276,9 +2229,9 @@ dependencies = [
 
 [[package]]
 name = "deno_lockfile"
-version = "0.51.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777225c4ebff5b4d445bc22810852d6ed8fda75c4203e5b7eda1f63135c79bec"
+checksum = "90eaf9974970a127206892fc6a01e26fc2bfce5a8b1efcde3780d389b612aff1"
 dependencies = [
  "async-trait",
  "deno_semver",
@@ -2289,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "deno_maybe_sync"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc186cbd3e9907e165f09e6b81a13c2b8abce5628bef13cbe7c9bafe91c7c3c1"
+checksum = "35888cf73df1b1abc87e46ed74bcbcbb274b555b2f4e9ab677b3f5e45a1eabe3"
 dependencies = [
  "dashmap 5.5.3",
 ]
@@ -2309,9 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "deno_napi"
-version = "0.180.0"
+version = "0.181.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e62f4e711dd66ae329e3536fb68e2eef31704778e6082f2c63d462ed61b0f92d"
+checksum = "29f8d7d5ca9ae4c009a7491f3dc8b30c47cc4359a52205f76008fe0d74318805"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -2321,6 +2274,7 @@ dependencies = [
  "libloading 0.7.4",
  "log",
  "napi_sym",
+ "object 0.36.7",
  "thiserror 2.0.18",
  "windows-sys 0.59.0",
 ]
@@ -2340,9 +2294,9 @@ dependencies = [
 
 [[package]]
 name = "deno_net"
-version = "0.241.0"
+version = "0.242.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22aeb6dd7070b4a395f851715cde809d608a0911554cd63a1b6a852a1d219465"
+checksum = "007b1ca989ac7b3f6fd37939761acaef310c7b9f7fb73bf53d2a03093db0220f"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -2369,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "deno_node"
-version = "0.187.0"
+version = "0.188.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ed8949f965ce17bb0f63023fffab9704c8f7acb92b8fa2928f355293e26d46"
+checksum = "e4be0f4ba5fe1dc4cd39d680f316c54d56b710897d4e8174c815aefecba231df"
 dependencies = [
  "base64 0.22.1",
  "boxed_error",
@@ -2392,14 +2346,15 @@ dependencies = [
  "deno_path_util",
  "deno_permissions",
  "deno_process",
+ "deno_resolver",
  "deno_subprocess_windows",
  "deno_tls",
  "deno_whoami",
- "errno 0.3.14",
+ "errno",
  "filetime",
  "hdrhistogram",
  "idna",
- "ipnetwork",
+ "ipnet",
  "libc",
  "libnghttp2",
  "libz-sys",
@@ -2419,16 +2374,15 @@ dependencies = [
  "tokio-eld",
  "url",
  "webpki-root-certs 0.26.11",
- "winapi",
  "windows-sys 0.59.0",
  "zstd",
 ]
 
 [[package]]
 name = "deno_node_crypto"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9751d1f04bda6eb509d188cc23bb9afb7b865900d82c4cb4e7d9f3654e9583a8"
+checksum = "4477cdfcef49bb452597f3efd671f51ee11b0981759c6366a9e17e5180dfd58b"
 dependencies = [
  "aead-gcm-stream",
  "aes",
@@ -2489,9 +2443,9 @@ dependencies = [
 
 [[package]]
 name = "deno_node_sqlite"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f239bbebaebd46897947bf0ba113cccf4befcf4d8811ba1dc9926cd98bae84f2"
+checksum = "a4f38860337ce27eb5cf03a66276e415f1b0fa60c7b5f9607af92e76fde4dbf2"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -2502,9 +2456,9 @@ dependencies = [
 
 [[package]]
 name = "deno_npm"
-version = "0.61.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30aeb638d32f9796b04a5241c23ecd33f272970c3e650e0792b4098a109c3ae3"
+checksum = "def88c9c55e316eb2dfaafe6d4c571d3d6f0c65dcc46c0328b2f68da39761958"
 dependencies = [
  "async-trait",
  "capacity_builder",
@@ -2514,7 +2468,7 @@ dependencies = [
  "deno_package_json",
  "deno_semver",
  "futures",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "monch",
  "serde",
@@ -2524,9 +2478,9 @@ dependencies = [
 
 [[package]]
 name = "deno_npmrc"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af443c511f81c066500e81b5bdd022d2223b5c7da9610b7549073bc35df137c2"
+checksum = "f40f37ca180a707f2b25cea2de9cb7eb59078ebea203af2a3db07f9750401dbb"
 dependencies = [
  "log",
  "monch",
@@ -2537,11 +2491,11 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.278.0"
+version = "0.279.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da015faedc5633db3141b025e62b3fbbd17ce99eb52c638469ac6e0cbba7b805"
+checksum = "59263ebf5578416f8195220aca525c89b29c6616d8171bdfc4df3d3bf4d8da58"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "proc-macro2",
  "quote",
  "stringcase",
@@ -2554,9 +2508,9 @@ dependencies = [
 
 [[package]]
 name = "deno_os"
-version = "0.66.0"
+version = "0.67.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126fad9901b281a94c2d538b739a701b546bfa9734d565db0532af7b68a8471a"
+checksum = "8fe37754116978d74afbe96771f79d43546b4bea64ceb77c5c4aafc227d75d76"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -2565,17 +2519,16 @@ dependencies = [
  "deno_signals",
  "libc",
  "netif",
- "ntapi",
  "thiserror 2.0.18",
  "tokio",
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "deno_package_json"
-version = "0.51.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0e1d77ea786b35e684744f6369945663e83f88d9fa231a8f9110f653e4352fa"
+checksum = "9eeb00428bf6190cdc1bf4ce74956b4c07b82f9241e5765dea6c95c9549ad5c9"
 dependencies = [
  "boxed_error",
  "capacity_builder",
@@ -2583,7 +2536,7 @@ dependencies = [
  "deno_maybe_sync",
  "deno_path_util",
  "deno_semver",
- "indexmap 2.14.0",
+ "indexmap",
  "serde",
  "serde_json",
  "sys_traits",
@@ -2606,9 +2559,9 @@ dependencies = [
 
 [[package]]
 name = "deno_permissions"
-version = "0.108.0"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4d65533759cc674d61f70cd42f7ef203f1b25bce676631707f78cff229f7bc"
+checksum = "9936e4cec7067ec356c29452dfa954ba5ef75b3d74b84b797ef08be8ac2280bc"
 dependencies = [
  "capacity_builder",
  "chrono",
@@ -2617,7 +2570,7 @@ dependencies = [
  "deno_terminal",
  "deno_unsync",
  "fqdn",
- "ipnetwork",
+ "ipnet",
  "libc",
  "log",
  "nix 0.30.1",
@@ -2630,15 +2583,14 @@ dependencies = [
  "unicode-normalization",
  "url",
  "which 8.0.2",
- "winapi",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "deno_process"
-version = "0.64.0"
+version = "0.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6426f15bfe8b0317b40ea43534225a179361ae901d4011355ee741468918df"
+checksum = "836d3d3f4d7854d90a2b169e222cbf03563bdf0da71c268cea944db91125dc91"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -2655,20 +2607,18 @@ dependencies = [
  "nix 0.30.1",
  "rand 0.8.5",
  "serde",
- "simd-json",
  "sys_traits",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "winapi",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "deno_resolver"
-version = "0.80.0"
+version = "0.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ec651463a3c77f14f2a6f29783dddba38dcc6bea2f747f0e4e1b291b14b51d"
+checksum = "30f16233b629d974c27c87d62e3728c98f08fc59e7c483d7bcf7c55867431243"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -2693,7 +2643,7 @@ dependencies = [
  "futures",
  "imara-diff",
  "import_map",
- "indexmap 2.14.0",
+ "indexmap",
  "jsonc-parser",
  "log",
  "node_resolver",
@@ -2710,9 +2660,9 @@ dependencies = [
 
 [[package]]
 name = "deno_runtime"
-version = "0.257.0"
+version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a80cd18970153ed42caf43415cfc8b5e72b82cb6bbcef96c42bc4dff603b50"
+checksum = "09e1dac6ccbbc72816d8a6cd23824b03dc60d78e0d7fae212aef7e9778bff21a"
 dependencies = [
  "boxed_error",
  "color-print",
@@ -2752,9 +2702,9 @@ dependencies = [
  "deno_websocket",
  "deno_webstorage",
  "encoding_rs",
- "http 1.4.1",
+ "http",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "libc",
  "log",
  "nix 0.30.1",
@@ -2771,7 +2721,6 @@ dependencies = [
  "twox-hash",
  "unicode-normalization",
  "uuid",
- "winapi",
  "windows-sys 0.59.0",
 ]
 
@@ -2794,22 +2743,22 @@ dependencies = [
 
 [[package]]
 name = "deno_signals"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecf82bc889889ce2ababa2aec5ec1b580f7e1938328cb593bd26233a15a82d70"
+checksum = "44e9bc8aad0a6cd10b5a5f966721ca129b808af8169e34b1c49f223822e47d32"
 dependencies = [
  "libc",
  "signal-hook",
  "thiserror 2.0.18",
  "tokio",
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "deno_subprocess_windows"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491b73aca352372fbe7759a8c6b03eaba0321a017f1f3850866638c1871d7f6"
+checksum = "c48beaae226679b6e7d75db0da7d4228ba4bf06fd8f7680f662f3645b3e9dd27"
 dependencies = [
  "fastrand",
  "futures-channel",
@@ -2819,9 +2768,9 @@ dependencies = [
 
 [[package]]
 name = "deno_telemetry"
-version = "0.71.0"
+version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d900c8013d88fc762bd3e510d3725dc8c105c503c95ca19b3b438e36d3080b3"
+checksum = "d4035258dd3dfcb0e702627fd8e95f2eecf66c1c356c27b5cd3a2120aa24f4c8"
 dependencies = [
  "async-trait",
  "deno_core",
@@ -2832,7 +2781,7 @@ dependencies = [
  "deno_tls",
  "flate2",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "log",
@@ -2865,9 +2814,9 @@ dependencies = [
 
 [[package]]
 name = "deno_tls"
-version = "0.236.0"
+version = "0.237.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05617adf9e871689b0674ae81a88984bb3658ba7be401e4be010e802626c5deb"
+checksum = "846a5fdfed2951711023bb832ffc808fd843a3da0cc71f1ade2a22a9a830a619"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -2912,9 +2861,9 @@ dependencies = [
 
 [[package]]
 name = "deno_web"
-version = "0.280.0"
+version = "0.281.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d76370526ed5750425bcae0dfa61dbc2218101c2e994090f58042e946167afe"
+checksum = "83a2b7142747344b15cd8aa53b872b1419145d2d14d38c46493d9858f0bb3d5b"
 dependencies = [
  "async-trait",
  "brotli 6.0.0",
@@ -2935,14 +2884,14 @@ dependencies = [
 
 [[package]]
 name = "deno_webgpu"
-version = "0.216.0"
+version = "0.217.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919bb2e6f10e9b98e3f41fea176becaab6fb4d709244a10919c41cbc72646f39"
+checksum = "2e6ab9920ec186dc18cfef8f9acdf7545fcbc8993bfedab40f34a1f4bf20b584"
 dependencies = [
  "deno_core",
  "deno_error",
  "deno_image",
- "indexmap 2.14.0",
+ "indexmap",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -2952,18 +2901,18 @@ dependencies = [
 
 [[package]]
 name = "deno_webidl"
-version = "0.249.0"
+version = "0.250.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5290cf50c2fbd99a0ba5a5f907892f03109dcdc37e666ebd4d75289c7b742538"
+checksum = "98b864e971f041db94c87e22723a5037c90a0fdfd3eca2e590d4ece386967234"
 dependencies = [
  "deno_core",
 ]
 
 [[package]]
 name = "deno_websocket"
-version = "0.254.0"
+version = "0.255.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bd146b4899a0cb4ff66c5f92a6536f1f23d4089fe6562a5e9409f1f2256d6d"
+checksum = "fd8591b8090d43661127ef92cde4a48cd7f31e167e60e970f671de31f4898dcd"
 dependencies = [
  "bytes",
  "deno_core",
@@ -2973,10 +2922,10 @@ dependencies = [
  "deno_permissions",
  "deno_tls",
  "fastwebsockets",
- "h2 0.4.13",
- "http 1.4.1",
+ "h2",
+ "http",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "once_cell",
  "thiserror 2.0.18",
@@ -2985,9 +2934,9 @@ dependencies = [
 
 [[package]]
 name = "deno_webstorage"
-version = "0.244.0"
+version = "0.245.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862b258c5754341d7e7e95a4b4ea423b964e3f95af7d4f40ffa10e51a153db3e"
+checksum = "90799826f1b7f0112bc51b9108b03f6586be1d2e96b904f80a1186e2ad3cf26d"
 dependencies = [
  "deno_core",
  "deno_error",
@@ -3034,7 +2983,7 @@ dependencies = [
  "deno_error",
  "denokv_proto",
  "futures",
- "http 1.4.1",
+ "http",
  "log",
  "prost",
  "rand 0.8.5",
@@ -3074,9 +3023,9 @@ dependencies = [
 
 [[package]]
 name = "denort_helper"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b2a8551398ebe62bfc2a2fe10913ce13939856f386a7e445362f88cdd01c520"
+checksum = "34b7b33ad4a9da060b797d44d92d75dc86e0f722be295ba46d4925c9ddc75268"
 dependencies = [
  "deno_error",
  "deno_path_util",
@@ -3557,33 +3506,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -3605,16 +3533,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "exec"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "886b70328cba8871bfc025858e1de4be16b1d5088f2ba50b57816f4210672615"
-dependencies = [
- "errno 0.2.8",
- "libc",
 ]
 
 [[package]]
@@ -3676,7 +3594,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-util",
  "pin-project",
  "rand 0.8.5",
@@ -3778,15 +3696,6 @@ name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-
-[[package]]
-name = "float-cmp"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "fnv"
@@ -4110,7 +4019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.14.0",
+ "indexmap",
  "stable_deref_trait",
 ]
 
@@ -4335,25 +4244,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.14.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -4363,8 +4253,8 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.1",
- "indexmap 2.14.0",
+ "http",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -4382,16 +4272,6 @@ dependencies = [
  "num-traits",
  "serde",
  "zerocopy",
-]
-
-[[package]]
-name = "halfbrown"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8588661a8607108a5ca69cab034063441a0413a0b041c13618a7dd348021ef6f"
-dependencies = [
- "hashbrown 0.14.5",
- "serde",
 ]
 
 [[package]]
@@ -4424,12 +4304,6 @@ checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -4633,17 +4507,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
@@ -4654,23 +4517,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.1",
+ "http",
 ]
 
 [[package]]
@@ -4681,9 +4533,10 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -4717,30 +4570,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
@@ -4749,9 +4578,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.1",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -4767,25 +4596,12 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.1",
- "hyper 1.9.0",
+ "http",
+ "hyper",
  "hyper-util",
  "rustls",
  "tokio",
  "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
-dependencies = [
- "hyper 1.9.0",
- "hyper-util",
- "pin-project-lite",
- "tokio",
  "tower-service",
 ]
 
@@ -4799,9 +4615,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.1",
- "http-body 1.0.1",
- "hyper 1.9.0",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -5076,23 +4892,13 @@ checksum = "61dcb2ebdf4a4df8e6353c566f4b51ee2f602341538e41e77c8f861ac1bb16d5"
 dependencies = [
  "boxed_error",
  "deno_error",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "percent-encoding",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "url",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -5118,11 +4924,11 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.9.6"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.1",
  "inotify-sys",
  "libc",
 ]
@@ -5197,15 +5003,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "ipnetwork"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "is-docker"
@@ -5768,12 +5565,6 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -5895,18 +5686,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
@@ -5985,7 +5764,7 @@ dependencies = [
  "half",
  "hashbrown 0.16.1",
  "hexf-parse",
- "indexmap 2.14.0",
+ "indexmap",
  "libm",
  "log",
  "num-traits",
@@ -6032,9 +5811,9 @@ dependencies = [
 
 [[package]]
 name = "napi_sym"
-version = "0.179.0"
+version = "0.180.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "992fe34891b3095f8294867c9d498f3cc5950cf1a6e64013f26232bb237e06d0"
+checksum = "bbef72a0840c1572d5178d1cdb0f3e5e089c7c72f5cbb459fe9e124df6af114d"
 dependencies = [
  "quote",
  "serde",
@@ -6126,9 +5905,9 @@ dependencies = [
 
 [[package]]
 name = "node_resolver"
-version = "0.87.0"
+version = "0.88.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968cd8dc2485957d16c272cd17690e2a694f9b0b3cd58507371b293b994bbe52"
+checksum = "29c1b2fceeed9efbb330d23984dfea635acc2fd691af7731124a854a26b40d83"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6156,11 +5935,10 @@ dependencies = [
 
 [[package]]
 name = "node_shim"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d13f10160d4daf72fe19ab57400ce915d11f887191b5287ee0dc3d9a5569d6"
+checksum = "67cd80599dc5cb2732432adb23c8e468579e5bcfa55d8c73fc001140c9d764cb"
 dependencies = [
- "exec",
  "serde_json",
  "url",
 ]
@@ -6202,30 +5980,29 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "notify"
-version = "6.1.1"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
  "bitflags 2.11.1",
- "crossbeam-channel",
- "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
  "log",
- "mio 0.8.11",
+ "mio",
+ "notify-types",
  "walkdir",
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.4.3"
+name = "notify-types"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "winapi",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -6408,6 +6185,15 @@ dependencies = [
 
 [[package]]
 name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
@@ -6503,7 +6289,7 @@ checksum = "10a8a7f5f6ba7c1b286c2fbca0454eaba116f63bbe69ed250b642d36fbb04d80"
 dependencies = [
  "async-trait",
  "bytes",
- "http 1.4.1",
+ "http",
  "opentelemetry",
 ]
 
@@ -6515,7 +6301,7 @@ checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
 dependencies = [
  "async-trait",
  "futures-core",
- "http 1.4.1",
+ "http",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
@@ -6523,8 +6309,6 @@ dependencies = [
  "prost",
  "serde_json",
  "thiserror 1.0.69",
- "tokio",
- "tonic",
  "tracing",
 ]
 
@@ -7389,7 +7173,7 @@ dependencies = [
  "async-compression",
  "async-stream",
  "async-trait",
- "axum 0.8.9",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "clap",
@@ -7432,7 +7216,7 @@ dependencies = [
  "futures",
  "futures-util",
  "hex",
- "http 1.4.1",
+ "http",
  "hyper-util",
  "image",
  "libc",
@@ -7460,7 +7244,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -7730,26 +7514,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ref-cast"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "regalloc2"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7812,10 +7576,10 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -7830,7 +7594,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -7924,7 +7688,7 @@ dependencies = [
  "bytecheck",
  "bytes",
  "hashbrown 0.17.0",
- "indexmap 2.14.0",
+ "indexmap",
  "munge",
  "ptr_meta",
  "rancor",
@@ -8066,7 +7830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags 2.11.1",
- "errno 0.3.14",
+ "errno",
  "libc",
  "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
@@ -8079,7 +7843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.11.1",
- "errno 0.3.14",
+ "errno",
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
@@ -8467,7 +8231,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -8500,9 +8264,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.311.0"
+version = "0.312.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8114fbbce546c2e8b933ecb4b026792a89af14bc83db97936ed1a62dec51b699"
+checksum = "51d8ed4ae5203d63dfcc13c8eed95343d18c732940823ad4fb2fbd57a8141688"
 dependencies = [
  "deno_error",
  "num-bigint",
@@ -8617,7 +8381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio 1.2.0",
+ "mio",
  "signal-hook",
 ]
 
@@ -8627,7 +8391,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.3.14",
+ "errno",
  "libc",
 ]
 
@@ -8669,21 +8433,6 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
-name = "simd-json"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2bcf6c6e164e81bc7a5d49fc6988b3d515d9e8c07457d7b74ffb9324b9cd40"
-dependencies = [
- "getrandom 0.2.17",
- "halfbrown",
- "ref-cast",
- "serde",
- "serde_json",
- "simdutf8",
- "value-trait",
-]
 
 [[package]]
 name = "simd_helpers"
@@ -8904,7 +8653,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 dependencies = [
- "float-cmp 0.9.0",
+ "float-cmp",
 ]
 
 [[package]]
@@ -9036,7 +8785,7 @@ checksum = "72e90b52ee734ded867104612218101722ad87ff4cf74fe30383bd244a533f97"
 dependencies = [
  "anyhow",
  "bytes-str",
- "indexmap 2.14.0",
+ "indexmap",
  "serde",
  "serde_json",
  "swc_config_macro",
@@ -9174,7 +8923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f6f165578ca4fee47bd57585c1b9597c94bf4ea6591df47f2b5fa5b1883fe"
 dependencies = [
  "better_scoped_tls",
- "indexmap 2.14.0",
+ "indexmap",
  "once_cell",
  "par-core",
  "phf 0.11.3",
@@ -9240,7 +8989,7 @@ checksum = "03de12e38e47ac1c96ac576f793ad37a9d7b16fbf4f2203881f89152f2498682"
 dependencies = [
  "base64 0.22.1",
  "bytes-str",
- "indexmap 2.14.0",
+ "indexmap",
  "once_cell",
  "rustc-hash 2.1.2",
  "serde",
@@ -9280,7 +9029,7 @@ version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fb99e179988cabd473779a4452ab942bcb777176983ca3cbaf22a8f056a65b0"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "num_cpus",
  "once_cell",
  "par-core",
@@ -9347,6 +9096,26 @@ dependencies = [
  "serde_json",
  "unicode-id-start",
  "url",
+]
+
+[[package]]
+name = "swc_ts_fast_strip"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7939f2933c4e0fbfedc30fcedd8530c557dee7ea7c73bc4bed854c751c476e"
+dependencies = [
+ "anyhow",
+ "bytes-str",
+ "serde",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_parser",
+ "swc_ecma_transforms_base",
+ "swc_ecma_transforms_react",
+ "swc_ecma_transforms_typescript",
+ "swc_ecma_visit",
 ]
 
 [[package]]
@@ -9760,7 +9529,7 @@ checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.2.0",
+ "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -9814,9 +9583,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-socks"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+checksum = "a7e2948f60dbe26b35f2c7fb74ac2854c1fddded0fe9d7548fcc674a246f7615"
 dependencies = [
  "either",
  "futures-util",
@@ -9883,45 +9652,16 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
- "async-stream",
  "async-trait",
- "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.13",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.9.0",
- "hyper-timeout",
- "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost",
- "socket2 0.5.10",
- "tokio",
  "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -9954,8 +9694,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -9965,7 +9705,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "url",
@@ -10099,7 +9839,7 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.1",
+ "http",
  "httparse",
  "log",
  "rand 0.9.4",
@@ -10360,7 +10100,7 @@ checksum = "97599c400fc79925922b58303e98fcb8fa88f573379a08ddb652e72cbd2e70f6"
 dependencies = [
  "bitflags 2.11.1",
  "encoding_rs",
- "indexmap 2.14.0",
+ "indexmap",
  "num-bigint",
  "serde",
  "thiserror 1.0.69",
@@ -10383,18 +10123,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "value-trait"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9170e001f458781e92711d2ad666110f153e4e50bfd5cbd02db6547625714187"
-dependencies = [
- "float-cmp 0.10.0",
- "halfbrown",
- "itoa",
- "ryu",
-]
 
 [[package]]
 name = "vcpkg"
@@ -10554,7 +10282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.14.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -10590,7 +10318,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
  "semver",
 ]
 
@@ -10621,7 +10349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "974fa1e325e6cc5327de8887f189a441fcff4f8eedcd31ec87f0ef0cc5283fbc"
 dependencies = [
  "bytes",
- "http 1.4.1",
+ "http",
  "thiserror 2.0.18",
  "url",
 ]
@@ -10764,7 +10492,7 @@ dependencies = [
  "cfg_aliases",
  "document-features",
  "hashbrown 0.16.1",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "macro_rules_attribute",
  "naga",
@@ -11069,15 +10797,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -11125,21 +10844,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -11192,12 +10896,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -11216,12 +10914,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -11237,12 +10929,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -11276,12 +10962,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -11297,12 +10977,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -11324,12 +10998,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -11345,12 +11013,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -11404,7 +11066,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.14.0",
+ "indexmap",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -11435,7 +11097,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -11454,7 +11116,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "semver",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7254,7 +7254,6 @@ dependencies = [
  "urlencoding",
  "uuid",
  "webp",
- "winapi",
  "windows-sys 0.59.0",
  "wuff",
  "zeno",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ unused_peekable = "warn"
 
 [workspace.dependencies]
 deno_ast = { version = "=0.53.2", features = [ "transpiling" ] }
-deno_core = "0.402.0"
+deno_core = "0.403.0"
 deno_error = "=0.7.1"
 rustc-hash = "2.1.2"
 url = "2.5.8"

--- a/crates/rari/Cargo.toml
+++ b/crates/rari/Cargo.toml
@@ -39,48 +39,48 @@ path = "src/bin/rari.rs"
 # === Core Runtime Dependencies ===
 deno_core = { workspace = true }
 deno_error = { workspace = true }
-deno_features = "0.46.0"
-deno_bundle_runtime = "0.36.0"
-deno_runtime = "0.257.0"
-deno_permissions = "0.108.0"
-deno_process = "0.64.0"
+deno_features = "0.47.0"
+deno_bundle_runtime = "0.37.0"
+deno_runtime = "0.258.0"
+deno_permissions = "0.109.0"
+deno_process = "0.65.0"
 
 # === Essential Web APIs ===
-deno_cache = "0.182.0"
-deno_crypto = "0.263.0"
-deno_fetch = "0.273.0"
-deno_web = "0.280.0"
-deno_webidl = "0.249.0"
-deno_webstorage = "0.244.0"
+deno_cache = "0.183.0"
+deno_crypto = "0.264.0"
+deno_fetch = "0.274.0"
+deno_web = "0.281.0"
+deno_webidl = "0.250.0"
+deno_webstorage = "0.245.0"
 
 # === Network & HTTP ===
-deno_http = "0.247.0"
-deno_net = "0.241.0"
-deno_tls = "0.236.0"
-deno_websocket = "0.254.0"
+deno_http = "0.248.0"
+deno_net = "0.242.0"
+deno_tls = "0.237.0"
+deno_websocket = "0.255.0"
 
 # === File System & I/O ===
-deno_fs = "0.159.0"
-deno_io = "0.159.0"
+deno_fs = "0.160.0"
+deno_io = "0.160.0"
 
 # === Advanced Features ===
-deno_telemetry = "0.71.0"
+deno_telemetry = "0.72.0"
 deno_terminal = "=0.2.3"
-deno_webgpu = "0.216.0"
-deno_kv = "0.157.0"
-deno_cron = "0.129.0"
+deno_webgpu = "0.217.0"
+deno_kv = "0.158.0"
+deno_cron = "0.130.0"
 
 # === Node.js Integration ===
-deno_node = "0.187.0"
-deno_node_crypto = "0.19.0"
-deno_node_sqlite = "0.19.0"
-deno_resolver = "0.80.0"
-node_resolver = "0.87.0"
+deno_node = "0.188.0"
+deno_node_crypto = "0.20.0"
+deno_node_sqlite = "0.20.0"
+deno_resolver = "0.81.0"
+node_resolver = "0.88.0"
 num-bigint-dig = "=0.8.2"
 
 # === FFI & NAPI ===
-deno_ffi = "0.236.0"
-deno_napi = "0.180.0"
+deno_ffi = "0.237.0"
+deno_napi = "0.181.0"
 
 # === Async & Concurrency ===
 async-stream = "0.3.6"
@@ -173,7 +173,7 @@ sys_traits = "=0.1.28"
 # === Development Tools ===
 rustyline = "=17.0.0"
 deno_ast = { workspace = true }
-deno_package_json = { version = "0.51.0", default-features = false }
+deno_package_json = { version = "0.52.0", default-features = false }
 deno_semver = "=0.10.0"
 
 # === Platform-specific Dependencies ===

--- a/crates/rari/Cargo.toml
+++ b/crates/rari/Cargo.toml
@@ -177,17 +177,11 @@ deno_package_json = { version = "0.52.0", default-features = false }
 deno_semver = "=0.10.0"
 
 # === Platform-specific Dependencies ===
-winapi = { version = "0.3.9", features = [
-  "std",
-  "wincon",
-  "handleapi",
-  "consoleapi",
-  "minwindef",
-] }
 windows-sys = { version = "=0.59.0", features = [
-  "Win32_Networking",
-  "Win32_Networking_WinSock",
-  "Win32_System_SystemInformation",
+  "Win32_Foundation",
+  "Win32_Storage_FileSystem",
+  "Win32_System_Console",
+  "Win32_UI_Input_KeyboardAndMouse",
 ] }
 
 # === CLI & Logging ===

--- a/crates/rari/src/runtime/ext/io/tty_windows.rs
+++ b/crates/rari/src/runtime/ext/io/tty_windows.rs
@@ -16,10 +16,8 @@ use rustyline::config::Configurer;
 use rustyline::error::ReadlineError;
 use std::io::Error;
 use std::sync::Arc;
-use winapi::shared::minwindef::DWORD;
-use winapi::shared::minwindef::FALSE;
-use winapi::um::consoleapi;
-use winapi::um::wincon;
+use windows_sys::Win32::Foundation::FALSE;
+use windows_sys::Win32::System::Console as wincon;
 
 deno_core::extension!(deno_tty, ops = [op_set_raw, op_console_size, op_read_line_prompt],);
 
@@ -66,7 +64,7 @@ impl From<Error> for TtyError {
 }
 
 // ref: <https://learn.microsoft.com/en-us/windows/console/setconsolemode>
-const COOKED_MODE: DWORD =
+const COOKED_MODE: u32 =
     // enable line-by-line input (returns input only after CR is read)
     wincon::ENABLE_LINE_INPUT
   // enables real-time character echo to console display (requires ENABLE_LINE_INPUT)
@@ -74,11 +72,11 @@ const COOKED_MODE: DWORD =
   // system handles CTRL-C (with ENABLE_LINE_INPUT, also handles BS, CR, and LF) and other control keys (when using `ReadFile` or `ReadConsole`)
   | wincon::ENABLE_PROCESSED_INPUT;
 
-fn mode_raw_input_on(original_mode: DWORD) -> DWORD {
+fn mode_raw_input_on(original_mode: u32) -> u32 {
     original_mode & !COOKED_MODE | wincon::ENABLE_VIRTUAL_TERMINAL_INPUT
 }
 
-fn mode_raw_input_off(original_mode: DWORD) -> DWORD {
+fn mode_raw_input_off(original_mode: u32) -> u32 {
     original_mode & !wincon::ENABLE_VIRTUAL_TERMINAL_INPUT | COOKED_MODE
 }
 
@@ -98,9 +96,9 @@ fn op_set_raw(state: &mut OpState, rid: u32, is_raw: bool, cbreak: bool) -> Resu
         return Err(TtyError::Other(JsErrorBox::not_supported()));
     }
 
-    let mut original_mode: DWORD = 0;
-    // SAFETY: winapi call
-    if unsafe { consoleapi::GetConsoleMode(handle, &mut original_mode) } == FALSE {
+    let mut original_mode: u32 = 0;
+    // SAFETY: Win32 call
+    if unsafe { wincon::GetConsoleMode(handle, &mut original_mode) } == FALSE {
         return Err(TtyError::Io(Error::last_os_error()));
     }
 
@@ -118,45 +116,52 @@ fn op_set_raw(state: &mut OpState, rid: u32, is_raw: bool, cbreak: bool) -> Resu
         if original_mode & COOKED_MODE != 0 && !stdin_state.cancelled {
             // SAFETY: Write enter key event to force the console wait to return.
             let record = unsafe {
+                use windows_sys::Win32::UI::Input::KeyboardAndMouse::MAPVK_VK_TO_VSC;
+                use windows_sys::Win32::UI::Input::KeyboardAndMouse::MapVirtualKeyW;
+                use windows_sys::Win32::UI::Input::KeyboardAndMouse::VK_RETURN;
+
                 let mut record: wincon::INPUT_RECORD = std::mem::zeroed();
-                record.EventType = wincon::KEY_EVENT;
-                record.Event.KeyEvent_mut().wVirtualKeyCode = winapi::um::winuser::VK_RETURN as u16;
-                record.Event.KeyEvent_mut().bKeyDown = 1;
-                record.Event.KeyEvent_mut().wRepeatCount = 1;
-                *record.Event.KeyEvent_mut().uChar.UnicodeChar_mut() = '\r' as u16;
-                record.Event.KeyEvent_mut().dwControlKeyState = 0;
-                record.Event.KeyEvent_mut().wVirtualScanCode = winapi::um::winuser::MapVirtualKeyW(
-                    winapi::um::winuser::VK_RETURN as u32,
-                    winapi::um::winuser::MAPVK_VK_TO_VSC,
-                ) as u16;
+                record.EventType = wincon::KEY_EVENT as u16;
+                record.Event.KeyEvent.wVirtualKeyCode = VK_RETURN;
+                record.Event.KeyEvent.bKeyDown = 1;
+                record.Event.KeyEvent.wRepeatCount = 1;
+                record.Event.KeyEvent.uChar.UnicodeChar = '\r' as u16;
+                record.Event.KeyEvent.dwControlKeyState = 0;
+                record.Event.KeyEvent.wVirtualScanCode =
+                    MapVirtualKeyW(VK_RETURN as u32, MAPVK_VK_TO_VSC) as u16;
                 record
             };
             stdin_state.cancelled = true;
 
-            // SAFETY: winapi call to open conout$ and save screen state.
+            // SAFETY: Win32 call to open conout$ and save screen state.
             let active_screen_buffer = unsafe {
+                use windows_sys::Win32::Foundation::GENERIC_READ;
+                use windows_sys::Win32::Foundation::GENERIC_WRITE;
+                use windows_sys::Win32::Storage::FileSystem::CreateFileW;
+                use windows_sys::Win32::Storage::FileSystem::FILE_SHARE_READ;
+                use windows_sys::Win32::Storage::FileSystem::FILE_SHARE_WRITE;
+                use windows_sys::Win32::Storage::FileSystem::OPEN_EXISTING;
+
                 /* Save screen state before sending the VK_RETURN event */
-                let handle = winapi::um::fileapi::CreateFileW(
+                let handle = CreateFileW(
                     "conout$".encode_utf16().chain(Some(0)).collect::<Vec<_>>().as_ptr(),
-                    winapi::um::winnt::GENERIC_READ | winapi::um::winnt::GENERIC_WRITE,
-                    winapi::um::winnt::FILE_SHARE_READ | winapi::um::winnt::FILE_SHARE_WRITE,
-                    std::ptr::null_mut(),
-                    winapi::um::fileapi::OPEN_EXISTING,
+                    GENERIC_READ | GENERIC_WRITE,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE,
+                    std::ptr::null(),
+                    OPEN_EXISTING,
                     0,
                     std::ptr::null_mut(),
                 );
 
                 let mut active_screen_buffer = std::mem::zeroed();
-                winapi::um::wincon::GetConsoleScreenBufferInfo(handle, &mut active_screen_buffer);
-                winapi::um::handleapi::CloseHandle(handle);
+                wincon::GetConsoleScreenBufferInfo(handle, &mut active_screen_buffer);
+                windows_sys::Win32::Foundation::CloseHandle(handle);
                 active_screen_buffer
             };
             stdin_state.screen_buffer_info = Some(active_screen_buffer);
 
-            // SAFETY: winapi call to write the VK_RETURN event.
-            if unsafe { winapi::um::wincon::WriteConsoleInputW(handle, &record, 1, &mut 0) }
-                == FALSE
-            {
+            // SAFETY: Win32 call to write the VK_RETURN event.
+            if unsafe { wincon::WriteConsoleInputW(handle, &record, 1, &mut 0) } == FALSE {
                 return Err(TtyError::Io(Error::last_os_error()));
             }
 
@@ -167,8 +172,8 @@ fn op_set_raw(state: &mut OpState, rid: u32, is_raw: bool, cbreak: bool) -> Resu
         }
     }
 
-    // SAFETY: winapi call
-    if unsafe { consoleapi::SetConsoleMode(handle, new_mode) } == FALSE {
+    // SAFETY: Win32 call
+    if unsafe { wincon::SetConsoleMode(handle, new_mode) } == FALSE {
         return Err(TtyError::Io(Error::last_os_error()));
     }
 
@@ -211,25 +216,23 @@ pub struct ConsoleSize {
 fn console_size_from_fd(
     handle: std::os::windows::io::RawHandle,
 ) -> Result<ConsoleSize, std::io::Error> {
-    // SAFETY: winapi calls
+    // SAFETY: Win32 calls
     unsafe {
-        let mut bufinfo: winapi::um::wincon::CONSOLE_SCREEN_BUFFER_INFO = std::mem::zeroed();
+        let mut bufinfo: wincon::CONSOLE_SCREEN_BUFFER_INFO = std::mem::zeroed();
 
-        if winapi::um::wincon::GetConsoleScreenBufferInfo(handle, &mut bufinfo) == 0 {
+        if wincon::GetConsoleScreenBufferInfo(handle, &mut bufinfo) == 0 {
             return Err(Error::last_os_error());
         }
 
         // calculate the size of the visible window
         // * use over/under-flow protections b/c MSDN docs only imply that srWindow components are all non-negative
         // * ref: <https://docs.microsoft.com/en-us/windows/console/console-screen-buffer-info-str> @@ <https://archive.is/sfjnm>
-        let cols = std::cmp::max(
-            i32::from(bufinfo.srWindow.Right) - i32::from(bufinfo.srWindow.Left) + 1,
-            0,
-        ) as u32;
-        let rows = std::cmp::max(
-            i32::from(bufinfo.srWindow.Bottom) - i32::from(bufinfo.srWindow.Top) + 1,
-            0,
-        ) as u32;
+        let cols =
+            std::cmp::max(bufinfo.srWindow.Right as i32 - bufinfo.srWindow.Left as i32 + 1, 0)
+                as u32;
+        let rows =
+            std::cmp::max(bufinfo.srWindow.Bottom as i32 - bufinfo.srWindow.Top as i32 + 1, 0)
+                as u32;
 
         Ok(ConsoleSize { cols, rows })
     }

--- a/crates/rari/src/runtime/ext/node/cjs_translator.rs
+++ b/crates/rari/src/runtime/ext/node/cjs_translator.rs
@@ -144,11 +144,13 @@ impl CjsCodeAnalyzer {
                 Some(CjsAnalysisExports {
                     exports: analysis.exports,
                     reexports: analysis.reexports,
+                    member_reexports: vec![],
                 }),
             )),
             CjsAnalysis::Cjs(analysis) => Ok(ExtNodeCjsAnalysis::Cjs(CjsAnalysisExports {
                 exports: analysis.exports,
                 reexports: analysis.reexports,
+                member_reexports: vec![],
             })),
         }
     }
@@ -178,12 +180,14 @@ impl node_resolver::analyze::CjsCodeAnalyzer for CjsCodeAnalyzer {
                         return Ok(ExtNodeCjsAnalysis::Cjs(CjsAnalysisExports {
                             exports: vec![],
                             reexports: vec![],
+                            member_reexports: vec![],
                         }));
                     }
                 } else {
                     return Ok(ExtNodeCjsAnalysis::Cjs(CjsAnalysisExports {
                         exports: vec![],
                         reexports: vec![],
+                        member_reexports: vec![],
                     }));
                 }
             }
@@ -198,12 +202,23 @@ impl node_resolver::analyze::CjsCodeAnalyzer for CjsCodeAnalyzer {
                 Some(CjsAnalysisExports {
                     exports: analysis.exports,
                     reexports: analysis.reexports,
+                    member_reexports: vec![],
                 }),
             )),
             CjsAnalysis::Cjs(analysis) => Ok(ExtNodeCjsAnalysis::Cjs(CjsAnalysisExports {
                 exports: analysis.exports,
                 reexports: analysis.reexports,
+                member_reexports: vec![],
             })),
         }
+    }
+
+    async fn analyze_cjs_member_props<'a>(
+        &self,
+        _specifier: &ModuleSpecifier,
+        _source: Option<Cow<'a, str>>,
+        _member: &str,
+    ) -> Result<Option<Vec<String>>, JsErrorBox> {
+        Ok(None)
     }
 }

--- a/crates/rari/src/runtime/ext/node/resolvers.rs
+++ b/crates/rari/src/runtime/ext/node/resolvers.rs
@@ -488,6 +488,13 @@ impl NodeRequireLoader for RequireLoader {
             _ => Ok(true),
         }
     }
+
+    fn is_maybe_cjs_from_require(
+        &self,
+        specifier: &reqwest::Url,
+    ) -> Result<bool, PackageJsonLoadError> {
+        self.is_maybe_cjs(specifier)
+    }
 }
 impl Clone for RequireLoader {
     fn clone(&self) -> Self {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Deno core and related ecosystem dependencies for improved runtime stability and compatibility.

* **Refactor**
  * Improved CommonJS module handling and member-export analysis in the Node compatibility layer.
  * Migrated Windows console/TTY implementation to newer system APIs for more robust console sizing, input cancellation, and buffer handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->