### PR TITLE
perf(server,router): parallelize cache warmup and optimize route reso…

### DIFF
--- a/crates/rari/src/server/cache/warmup.rs
+++ b/crates/rari/src/server/cache/warmup.rs
@@ -2,10 +2,14 @@ use crate::rsc::rendering::layout::{LayoutRenderContext, LayoutRenderer};
 use crate::server::ServerState;
 use crate::server::cache::response_cache;
 use crate::server::routing::types::ParamValue;
+use futures::stream::{self, StreamExt};
 use rustc_hash::FxHashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 use tracing::{error, info};
+
+const WARMUP_CONCURRENCY: usize = 10;
 
 pub async fn warm_cache(state: &ServerState) {
     let app_router = match &state.app_router {
@@ -26,25 +30,33 @@ pub async fn warm_cache(state: &ServerState) {
     info!("[rari] Cache warmup: Pre-rendering {} routes...", paths.len());
     let start = Instant::now();
 
-    let mut success_count = 0;
-    let mut error_count = 0;
+    let success_count = Arc::new(AtomicUsize::new(0));
+    let error_count = Arc::new(AtomicUsize::new(0));
 
-    for path in &paths {
-        match warm_route(state, app_router, path).await {
-            Ok(()) => success_count += 1,
-            Err(e) => {
-                error!("[rari] Cache warmup: Failed to warm '{}': {}", path, e);
-                error_count += 1;
+    stream::iter(paths.iter())
+        .for_each_concurrent(WARMUP_CONCURRENCY, |path| {
+            let success_count = Arc::clone(&success_count);
+            let error_count = Arc::clone(&error_count);
+            async move {
+                match warm_route(state, app_router, path).await {
+                    Ok(()) => {
+                        success_count.fetch_add(1, Ordering::Relaxed);
+                    }
+                    Err(e) => {
+                        error!("[rari] Cache warmup: Failed to warm '{}': {}", path, e);
+                        error_count.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
             }
-        }
-    }
+        })
+        .await;
 
     let elapsed = start.elapsed();
     info!(
         "[rari] Cache warmup: Completed in {:.1}ms ({} succeeded, {} failed)",
         elapsed.as_secs_f64() * 1000.0,
-        success_count,
-        error_count,
+        success_count.load(Ordering::Relaxed),
+        error_count.load(Ordering::Relaxed),
     );
 }
 

--- a/crates/rari/src/server/core/mod.rs
+++ b/crates/rari/src/server/core/mod.rs
@@ -186,7 +186,10 @@ impl Server {
 
         if config.is_production() {
             CacheLoader::load_page_cache_configs(&state).await?;
-            crate::server::cache::warmup::warm_cache(&state).await;
+            let warmup_state = state.clone();
+            tokio::spawn(async move {
+                crate::server::cache::warmup::warm_cache(&warmup_state).await;
+            });
         }
 
         let mut config = config;

--- a/packages/rari/src/router/vite-plugin.ts
+++ b/packages/rari/src/router/vite-plugin.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { BACKSLASH_REGEX, QUOTE_REGEX, TSX_EXT_REGEX } from '../shared/regex-constants'
+import { generateAppRouteManifest } from './routes'
 
 const METADATA_EXPORT_REGEX = /export\s+const\s+metadata\s*(?::\s*\w+\s*)?=\s*(\{[\s\S]*?\n\})/
 const TITLE_REGEX = /title\s*:\s*['"]([^'"]+)['"]/
@@ -236,8 +237,6 @@ export function rariRouter(options: RariRouterPluginOptions = {}): Plugin {
       if (!forceRegenerate && routeStructureHash === currentHash && cachedManifestContent)
         return cachedManifestContent
 
-      const { generateAppRouteManifest } = await import('./routes')
-
       const manifest = await generateAppRouteManifest(appDir, {
         extensions: opts.extensions,
       })
@@ -440,12 +439,14 @@ export function rariRouter(options: RariRouterPluginOptions = {}): Plugin {
           if (!route.isDynamic)
             continue
 
-          const sanitizedFilePath = route.filePath
-            .replace(/\[\.\.\.([^\]]+)\]/g, '____$1_')
-            .replace(/\[([^\]]+)\]/g, '_$1_')
-            .replace(/\.tsx?$/, '.js')
+          const componentId = route.componentId
+          if (!componentId)
+            continue
 
-          const compiledPath = path.resolve(root, 'dist', 'server', 'app', sanitizedFilePath)
+          const relativePath = componentId.startsWith('app/')
+            ? componentId.slice(4)
+            : componentId
+          const compiledPath = path.resolve(serverDir, 'app', `${relativePath}.js`)
 
           try {
             const module = await import(/* @vite-ignore */ compiledPath)

--- a/packages/rari/src/vite/index.ts
+++ b/packages/rari/src/vite/index.ts
@@ -23,7 +23,7 @@ import { hasDefaultExport, hasTopLevelUseClientDirective, hasTopLevelUseServerDi
 import { resolveIndexFile, resolveWithExtensions } from './file-resolver'
 import { HMRCoordinator } from './hmr-coordinator'
 import { scanForImageUsage } from './image-scanner'
-import { createServerBuildPlugin, RARI_CSS_MODULES_PATTERN } from './server-build'
+import { createServerBuildPlugin, RARI_CSS_MODULES_PATTERN, scanDirectory, ServerComponentBuilder } from './server-build'
 
 const IMPORT_TYPE_SPECIFIER_REGEX = /import\s+type\s+(\{[^}]+\})\s+from\s+["']\.\.?\/([^"']+)["'];?/g
 const IMPORT_TYPE_NAMESPACE_REGEX = /import\s+type\s+(\*\s+as\s+\w+)\s+from\s+["']\.\.?\/([^"']+)["'];?/g
@@ -1157,10 +1157,6 @@ const ${componentName} = registerClientReference(
 
       const discoverAndRegisterComponents = async () => {
         try {
-          const { ServerComponentBuilder, scanDirectory } = await import(
-            './server-build',
-          )
-
           const builder = new ServerComponentBuilder(projectRoot, {
             outDir: 'dist',
             rscDir: 'server',
@@ -1414,7 +1410,6 @@ const ${componentName} = registerClientReference(
           if (!isServerComponent(filePath))
             return
 
-          const { ServerComponentBuilder } = await import('./server-build')
           const builder = new ServerComponentBuilder(projectRoot, {
             outDir: 'dist',
             rscDir: 'server',


### PR DESCRIPTION
- Implement concurrent cache warmup with configurable concurrency limit (10 routes at a time) using futures streaming in Rust
- Move cache warmup to background task using tokio::spawn to avoid blocking server initialization
- Replace atomic counters with Arc<AtomicUsize> for thread-safe warmup progress tracking
- Optimize dynamic route compilation by using componentId instead of sanitized file paths
- Simplify compiled route path resolution to use relative paths from componentId
- Move ServerComponentBuilder and scanDirectory imports to top-level in vite plugin to avoid repeated dynamic imports
- Remove redundant dynamic import of ServerComponentBuilder in route transformation handler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Server startup now completes faster as cache warmup runs in the background
  * Cache warmup itself is accelerated through concurrent processing instead of sequential operations
  * Improved efficiency of component discovery and route loading through optimized imports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->