### PR TITLE
feat(router): add duplicate route detection and support API routes in…

### DIFF
--- a/packages/rari/src/router/routes.ts
+++ b/packages/rari/src/router/routes.ts
@@ -146,6 +146,9 @@ class AppRouteGenerator {
       this.finalizeGroupEntries(routes, entries)
     }
 
+    this.assertNoDuplicateRoutes(routes)
+    this.assertNoDuplicateRoutes(apiRoutes)
+
     if (this.verbose) {
       console.warn(`[rari] Router: Found ${routes.length} routes`)
       console.warn(`[rari] Router: Found ${layouts.length} layouts`)
@@ -196,6 +199,21 @@ class AppRouteGenerator {
 
       if (uniqueSorted.length > 1) {
         entry.additionalPaths = uniqueSorted.slice(1)
+      }
+    }
+  }
+
+  private assertNoDuplicateRoutes(routes: Array<{ path: string, filePath: string }>): void {
+    const seen = new Map<string, string>()
+    for (const route of routes) {
+      const existing = seen.get(route.path)
+      if (existing) {
+        throw new Error(
+          `[rari] Route conflict: path '${route.path}' is defined by both '${existing}' and '${route.filePath}'.`,
+        )
+      }
+      else {
+        seen.set(route.path, route.filePath)
       }
     }
   }
@@ -352,7 +370,7 @@ class AppRouteGenerator {
     }
 
     const routeFile = this.findFile(files, SPECIAL_FILES.ROUTE)
-    if (routeFile && !isInGroup(relativePath)) {
+    if (routeFile) {
       const apiRoute = await this.processApiRouteFile(relativePath, routeFile)
       apiRoutes.push(apiRoute)
     }

--- a/test/unit/router/routes.test.ts
+++ b/test/unit/router/routes.test.ts
@@ -350,7 +350,7 @@ describe('generateAppRouteManifest', () => {
       })
     })
 
-    it('skips API routes inside groups', async () => {
+    it('supports API routes inside groups', async () => {
       vi.mocked(fs.readdir)
         .mockResolvedValueOnce(['(api)'] as any)
         .mockResolvedValueOnce(['hello'] as any)
@@ -365,8 +365,9 @@ describe('generateAppRouteManifest', () => {
 
       const manifest = await generateAppRouteManifest('/app')
 
-      expect(manifest.apiRoutes).toHaveLength(0)
-      expect(fs.readFile).not.toHaveBeenCalled()
+      expect(manifest.apiRoutes).toHaveLength(1)
+      expect(manifest.apiRoutes[0].path).toBe('/hello')
+      expect(manifest.apiRoutes[0].methods).toContain('GET')
     })
   })
 
@@ -943,6 +944,67 @@ describe('generateAppRouteManifest', () => {
 
       expect(consoleSpy).toHaveBeenCalled()
       consoleSpy.mockRestore()
+    })
+  })
+
+  describe('duplicate route detection', () => {
+    it('throws when two groups produce the same page route', async () => {
+      vi.mocked(fs.readdir)
+        .mockResolvedValueOnce(['(a)', '(b)'] as any)
+        .mockResolvedValueOnce(['about'] as any)
+        .mockResolvedValueOnce(['page.tsx'] as any)
+        .mockResolvedValueOnce(['about'] as any)
+        .mockResolvedValueOnce(['page.tsx'] as any)
+
+      vi.mocked(fs.stat)
+        .mockResolvedValueOnce({ isDirectory: () => true, isFile: () => false } as any)
+        .mockResolvedValueOnce({ isDirectory: () => true, isFile: () => false } as any)
+        .mockResolvedValueOnce({ isDirectory: () => true, isFile: () => false } as any)
+        .mockResolvedValueOnce({ isDirectory: () => false, isFile: () => true } as any)
+        .mockResolvedValueOnce({ isDirectory: () => true, isFile: () => false } as any)
+        .mockResolvedValueOnce({ isDirectory: () => false, isFile: () => true } as any)
+
+      await expect(generateAppRouteManifest('/app')).rejects.toThrow(/Route conflict.*\/about/)
+    })
+
+    it('throws when two groups produce the same API route', async () => {
+      vi.mocked(fs.readdir)
+        .mockResolvedValueOnce(['(a)', '(b)'] as any)
+        .mockResolvedValueOnce(['users'] as any)
+        .mockResolvedValueOnce(['route.ts'] as any)
+        .mockResolvedValueOnce(['users'] as any)
+        .mockResolvedValueOnce(['route.ts'] as any)
+
+      vi.mocked(fs.stat)
+        .mockResolvedValueOnce({ isDirectory: () => true, isFile: () => false } as any)
+        .mockResolvedValueOnce({ isDirectory: () => true, isFile: () => false } as any)
+        .mockResolvedValueOnce({ isDirectory: () => true, isFile: () => false } as any)
+        .mockResolvedValueOnce({ isDirectory: () => false, isFile: () => true } as any)
+        .mockResolvedValueOnce({ isDirectory: () => true, isFile: () => false } as any)
+        .mockResolvedValueOnce({ isDirectory: () => false, isFile: () => true } as any)
+
+      vi.mocked(fs.readFile).mockResolvedValue('export function GET() {}' as any)
+
+      await expect(generateAppRouteManifest('/app')).rejects.toThrow(/Route conflict.*\/users/)
+    })
+
+    it('does not throw when routes are unique', async () => {
+      vi.mocked(fs.readdir)
+        .mockResolvedValueOnce(['(a)', '(b)'] as any)
+        .mockResolvedValueOnce(['about'] as any)
+        .mockResolvedValueOnce(['page.tsx'] as any)
+        .mockResolvedValueOnce(['pricing'] as any)
+        .mockResolvedValueOnce(['page.tsx'] as any)
+
+      vi.mocked(fs.stat)
+        .mockResolvedValueOnce({ isDirectory: () => true, isFile: () => false } as any)
+        .mockResolvedValueOnce({ isDirectory: () => true, isFile: () => false } as any)
+        .mockResolvedValueOnce({ isDirectory: () => true, isFile: () => false } as any)
+        .mockResolvedValueOnce({ isDirectory: () => false, isFile: () => true } as any)
+        .mockResolvedValueOnce({ isDirectory: () => true, isFile: () => false } as any)
+        .mockResolvedValueOnce({ isDirectory: () => false, isFile: () => true } as any)
+
+      await expect(generateAppRouteManifest('/app')).resolves.toBeDefined()
     })
   })
 })


### PR DESCRIPTION
- Add assertNoDuplicateRoutes method to validate no path conflicts between routes
- Validate duplicate routes for both page routes and API routes during manifest generation
- Remove isInGroup check to allow API routes to be processed inside route groups
- Update test to reflect new behavior: API routes inside groups are now supported
- Add comprehensive test suite for duplicate route detection scenarios
- Throw descriptive error when route path conflicts are detected with file paths listed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Routes inside grouped segments are now properly detected during discovery.
  * Duplicate route conflicts are now validated with detailed error messages identifying conflicting paths.

* **Tests**
  * Added tests verifying route detection within grouped segments.
  * Added tests for duplicate route detection and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->