### PR TITLE
feat(server-build): add component export detection for server components

### DIFF
--- a/packages/rari/src/shared/regex-constants.ts
+++ b/packages/rari/src/shared/regex-constants.ts
@@ -47,8 +47,8 @@ export const CAMEL_TO_KEBAB_REGEX = /([A-Z])/g
 
 export const EXPORT_DEFAULT_REGEX = /export\s+default\s+/
 export const EXPORT_NAMED_DECLARATION_REGEX = /export\s+(?:function|const|class)\s+(\w+)/
-export const EXPORTED_FUNCTION_REGEX = /export\s+(?:default\s+)?(?:async\s+)?function[\s*(]/
-export const EXPORTED_ARROW_OR_CLASS_REGEX = /export\s+default\s+(?:class\b|(?:async\s+)?\(|(?:async\s+)?[a-zA-Z_$][\w$]*\s*=>)/
+export const EXPORTED_FUNCTION_REGEX = /export\s+(?:default\s+)?(?:async\s+)?(?:function|class)[\s{(]/
+export const EXPORTED_ARROW_OR_CLASS_REGEX = /export\s+default\s+(?:(?:async\s+)?\(|(?:async\s+)?[a-zA-Z_$][\w$]*\s*=>)/
 export const EXPORTED_CONST_FUNCTION_REGEX = /export\s+(?:const|let|var)\s+\w[^=]*=\s*(?:async\s+)?(?:\(|[a-zA-Z_$][\w$]*\s*=>)/
 
 export const TITLE_EXPORT_REGEX = /^export\s+const\s+title\s*=\s*['"](.+?)['"]/m

--- a/packages/rari/src/shared/regex-constants.ts
+++ b/packages/rari/src/shared/regex-constants.ts
@@ -49,7 +49,7 @@ export const EXPORT_DEFAULT_REGEX = /export\s+default\s+/
 export const EXPORT_NAMED_DECLARATION_REGEX = /export\s+(?:function|const|class)\s+(\w+)/
 export const EXPORTED_FUNCTION_REGEX = /export\s+(?:default\s+)?(?:async\s+)?(?:function|class)[\s{(]/
 export const EXPORTED_DEFAULT_ARROW_REGEX = /export\s+default\s+(?:(?:async\s+)?\(|(?:async\s+)?[a-zA-Z_$][\w$]*\s*=>)/
-export const EXPORTED_CONST_FUNCTION_REGEX = /export\s+(?:const|let|var)\s+[a-zA-Z_$][\w$]*(?:\s*:[^;]*[^;=\s])?\s*=\s*(?:async\s+)?(?:function[\s*(]|\(\s*[)a-zA-Z_$.{[]|[a-zA-Z_$][\w$]*\s*=>)/
+export const EXPORTED_CONST_FUNCTION_REGEX = /export\s+(?:const|let|var)\s+[a-zA-Z_$][\w$]*(?:\s*:[^;]*[^;=\s])?\s*=\s*(?:async\s+)?(?:function[\s*(]|\([^)]*\)\s*=>|[a-zA-Z_$][\w$]*\s*=>)/
 
 export const TITLE_EXPORT_REGEX = /^export\s+const\s+title\s*=\s*['"](.+?)['"]/m
 export const DESCRIPTION_EXPORT_REGEX = /^export\s+const\s+description\s*=\s*['"](.+?)['"]/m

--- a/packages/rari/src/shared/regex-constants.ts
+++ b/packages/rari/src/shared/regex-constants.ts
@@ -48,8 +48,8 @@ export const CAMEL_TO_KEBAB_REGEX = /([A-Z])/g
 export const EXPORT_DEFAULT_REGEX = /export\s+default\s+/
 export const EXPORT_NAMED_DECLARATION_REGEX = /export\s+(?:function|const|class)\s+(\w+)/
 export const EXPORTED_FUNCTION_REGEX = /export\s+(?:default\s+)?(?:async\s+)?(?:function|class)[\s{(]/
-export const EXPORTED_ARROW_OR_CLASS_REGEX = /export\s+default\s+(?:(?:async\s+)?\(|(?:async\s+)?[a-zA-Z_$][\w$]*\s*=>)/
-export const EXPORTED_CONST_FUNCTION_REGEX = /export\s+(?:const|let|var)\s+\w[^=]*=\s*(?:async\s+)?(?:\(|[a-zA-Z_$][\w$]*\s*=>)/
+export const EXPORTED_DEFAULT_ARROW_REGEX = /export\s+default\s+(?:(?:async\s+)?\(|(?:async\s+)?[a-zA-Z_$][\w$]*\s*=>)/
+export const EXPORTED_CONST_FUNCTION_REGEX = /export\s+(?:const|let|var)\s+[a-zA-Z_$][\w$]*(?:\s*:[^;]*[^;=\s])?\s*=\s*(?:async\s+)?(?:\(|[a-zA-Z_$][\w$]*\s*=>)/
 
 export const TITLE_EXPORT_REGEX = /^export\s+const\s+title\s*=\s*['"](.+?)['"]/m
 export const DESCRIPTION_EXPORT_REGEX = /^export\s+const\s+description\s*=\s*['"](.+?)['"]/m

--- a/packages/rari/src/shared/regex-constants.ts
+++ b/packages/rari/src/shared/regex-constants.ts
@@ -47,6 +47,9 @@ export const CAMEL_TO_KEBAB_REGEX = /([A-Z])/g
 
 export const EXPORT_DEFAULT_REGEX = /export\s+default\s+/
 export const EXPORT_NAMED_DECLARATION_REGEX = /export\s+(?:function|const|class)\s+(\w+)/
+export const EXPORTED_FUNCTION_REGEX = /export\s+(?:default\s+)?(?:async\s+)?function[\s*(]/
+export const EXPORTED_ARROW_OR_CLASS_REGEX = /export\s+default\s+(?:class\b|(?:async\s+)?\(|(?:async\s+)?[a-zA-Z_$][\w$]*\s*=>)/
+export const EXPORTED_CONST_FUNCTION_REGEX = /export\s+(?:const|let|var)\s+\w[^=]*=\s*(?:async\s+)?(?:\(|[a-zA-Z_$][\w$]*\s*=>)/
 
 export const TITLE_EXPORT_REGEX = /^export\s+const\s+title\s*=\s*['"](.+?)['"]/m
 export const DESCRIPTION_EXPORT_REGEX = /^export\s+const\s+description\s*=\s*['"](.+?)['"]/m

--- a/packages/rari/src/shared/regex-constants.ts
+++ b/packages/rari/src/shared/regex-constants.ts
@@ -49,7 +49,7 @@ export const EXPORT_DEFAULT_REGEX = /export\s+default\s+/
 export const EXPORT_NAMED_DECLARATION_REGEX = /export\s+(?:function|const|class)\s+(\w+)/
 export const EXPORTED_FUNCTION_REGEX = /export\s+(?:default\s+)?(?:async\s+)?(?:function|class)[\s{(]/
 export const EXPORTED_DEFAULT_ARROW_REGEX = /export\s+default\s+(?:(?:async\s+)?\(|(?:async\s+)?[a-zA-Z_$][\w$]*\s*=>)/
-export const EXPORTED_CONST_FUNCTION_REGEX = /export\s+(?:const|let|var)\s+[a-zA-Z_$][\w$]*(?:\s*:[^;]*[^;=\s])?\s*=\s*(?:async\s+)?(?:\(|[a-zA-Z_$][\w$]*\s*=>)/
+export const EXPORTED_CONST_FUNCTION_REGEX = /export\s+(?:const|let|var)\s+[a-zA-Z_$][\w$]*(?:\s*:[^;]*[^;=\s])?\s*=\s*(?:async\s+)?(?:function[\s*(]|\(|[a-zA-Z_$][\w$]*\s*=>)/
 
 export const TITLE_EXPORT_REGEX = /^export\s+const\s+title\s*=\s*['"](.+?)['"]/m
 export const DESCRIPTION_EXPORT_REGEX = /^export\s+const\s+description\s*=\s*['"](.+?)['"]/m

--- a/packages/rari/src/shared/regex-constants.ts
+++ b/packages/rari/src/shared/regex-constants.ts
@@ -49,7 +49,7 @@ export const EXPORT_DEFAULT_REGEX = /export\s+default\s+/
 export const EXPORT_NAMED_DECLARATION_REGEX = /export\s+(?:function|const|class)\s+(\w+)/
 export const EXPORTED_FUNCTION_REGEX = /export\s+(?:default\s+)?(?:async\s+)?(?:function|class)[\s{(]/
 export const EXPORTED_DEFAULT_ARROW_REGEX = /export\s+default\s+(?:(?:async\s+)?\(|(?:async\s+)?[a-zA-Z_$][\w$]*\s*=>)/
-export const EXPORTED_CONST_FUNCTION_REGEX = /export\s+(?:const|let|var)\s+[a-zA-Z_$][\w$]*(?:\s*:[^;]*[^;=\s])?\s*=\s*(?:async\s+)?(?:function[\s*(]|\(|[a-zA-Z_$][\w$]*\s*=>)/
+export const EXPORTED_CONST_FUNCTION_REGEX = /export\s+(?:const|let|var)\s+[a-zA-Z_$][\w$]*(?:\s*:[^;]*[^;=\s])?\s*=\s*(?:async\s+)?(?:function[\s*(]|\(\s*[)a-zA-Z_$.{[]|[a-zA-Z_$][\w$]*\s*=>)/
 
 export const TITLE_EXPORT_REGEX = /^export\s+const\s+title\s*=\s*['"](.+?)['"]/m
 export const DESCRIPTION_EXPORT_REGEX = /^export\s+const\s+description\s*=\s*['"](.+?)['"]/m

--- a/packages/rari/src/vite/server-build.ts
+++ b/packages/rari/src/vite/server-build.ts
@@ -6,6 +6,9 @@ import process from 'node:process'
 import { pathToFileURL } from 'node:url'
 import { build } from 'rolldown'
 import {
+  EXPORTED_ARROW_OR_CLASS_REGEX,
+  EXPORTED_CONST_FUNCTION_REGEX,
+  EXPORTED_FUNCTION_REGEX,
   FILE_PROTOCOL_REGEX,
   TSX_EXT_REGEX,
 } from '../shared/regex-constants'
@@ -1620,6 +1623,13 @@ function registerClientReference(clientReference, id, exportName) {
   }
 }
 
+export function hasComponentExport(code: string): boolean {
+  return hasDefaultExport(code)
+    || EXPORTED_FUNCTION_REGEX.test(code)
+    || EXPORTED_ARROW_OR_CLASS_REGEX.test(code)
+    || EXPORTED_CONST_FUNCTION_REGEX.test(code)
+}
+
 export function scanDirectory(dir: string, builder: ServerComponentBuilder, isTopLevel = true) {
   if (isTopLevel)
     builder.buildImportGraph(dir)
@@ -1650,8 +1660,12 @@ export function scanDirectory(dir: string, builder: ServerComponentBuilder, isTo
         if (builder.isOnlyImportedByClientComponents(fullPath))
           continue
 
-        if (builder.isServerComponent(fullPath, code))
+        if (builder.isServerComponent(fullPath, code)) {
+          if (!hasComponentExport(code))
+            continue
+
           builder.addServerComponent(fullPath, code)
+        }
       }
       catch (error) {
         console.warn(

--- a/packages/rari/src/vite/server-build.ts
+++ b/packages/rari/src/vite/server-build.ts
@@ -6,8 +6,8 @@ import process from 'node:process'
 import { pathToFileURL } from 'node:url'
 import { build } from 'rolldown'
 import {
-  EXPORTED_ARROW_OR_CLASS_REGEX,
   EXPORTED_CONST_FUNCTION_REGEX,
+  EXPORTED_DEFAULT_ARROW_REGEX,
   EXPORTED_FUNCTION_REGEX,
   FILE_PROTOCOL_REGEX,
   TSX_EXT_REGEX,
@@ -1626,7 +1626,7 @@ function registerClientReference(clientReference, id, exportName) {
 export function hasComponentExport(code: string): boolean {
   return hasDefaultExport(code)
     || EXPORTED_FUNCTION_REGEX.test(code)
-    || EXPORTED_ARROW_OR_CLASS_REGEX.test(code)
+    || EXPORTED_DEFAULT_ARROW_REGEX.test(code)
     || EXPORTED_CONST_FUNCTION_REGEX.test(code)
 }
 

--- a/test/unit/vite/server-build.test.ts
+++ b/test/unit/vite/server-build.test.ts
@@ -1,6 +1,6 @@
 import fsSync from 'node:fs'
 import path from 'node:path'
-import { ServerComponentBuilder } from '@rari/vite/server-build'
+import { hasComponentExport, ServerComponentBuilder } from '@rari/vite/server-build'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 
 vi.mock('node:fs')
@@ -685,6 +685,95 @@ export async function action() { return {} }`)
       builder.addServerComponent(filePath)
 
       await expect(builder.buildServerComponents()).rejects.toThrow(SyntaxError)
+    })
+  })
+})
+
+describe('hasComponentExport', () => {
+  describe('should return false for const-only modules', () => {
+    it('rejects single const export', () => {
+      expect(hasComponentExport('export const TEST_LABEL = "hello"')).toBe(false)
+    })
+
+    it('rejects multiple const exports', () => {
+      const code = `export const A = 1
+export const B = "test"
+export const C = { key: "value" }`
+      expect(hasComponentExport(code)).toBe(false)
+    })
+
+    it('rejects object const exports', () => {
+      expect(hasComponentExport('export const config = { port: 3000, host: "localhost" }')).toBe(false)
+    })
+
+    it('rejects array const exports', () => {
+      expect(hasComponentExport('export const items = [1, 2, 3]')).toBe(false)
+    })
+
+    it('rejects re-exports of values', () => {
+      expect(hasComponentExport('export { FOO, BAR } from "./constants"')).toBe(false)
+    })
+
+    it('rejects type-only exports', () => {
+      expect(hasComponentExport('export type Foo = { bar: string }')).toBe(false)
+    })
+
+    it('rejects interface exports', () => {
+      expect(hasComponentExport('export interface Config { port: number }')).toBe(false)
+    })
+
+    it('rejects enum exports', () => {
+      expect(hasComponentExport('export enum Status { Active, Inactive }')).toBe(false)
+    })
+  })
+
+  describe('should return true for modules with function/component exports', () => {
+    it('detects export default function', () => {
+      expect(hasComponentExport('export default function Page() { return <div/> }')).toBe(true)
+    })
+
+    it('detects named function export', () => {
+      expect(hasComponentExport('export function getData() { return 1 }')).toBe(true)
+    })
+
+    it('detects async function export', () => {
+      expect(hasComponentExport('export async function fetchData() { return await fetch("/") }')).toBe(true)
+    })
+
+    it('detects arrow function const export', () => {
+      expect(hasComponentExport('export const handler = () => {}')).toBe(true)
+    })
+
+    it('detects typed arrow function export', () => {
+      expect(hasComponentExport('export const handler: Handler = () => {}')).toBe(true)
+    })
+
+    it('detects async arrow function export', () => {
+      expect(hasComponentExport('export const handler = async () => {}')).toBe(true)
+    })
+
+    it('detects single-param arrow function', () => {
+      expect(hasComponentExport('export const fn = x => x')).toBe(true)
+    })
+
+    it('detects export default class', () => {
+      expect(hasComponentExport('export default class MyComponent {}')).toBe(true)
+    })
+
+    it('detects default anonymous function', () => {
+      expect(hasComponentExport('export default function() { return null }')).toBe(true)
+    })
+
+    it('detects function among consts', () => {
+      const code = `export const LABEL = "hello"
+export function Component() { return <div>{LABEL}</div> }`
+      expect(hasComponentExport(code)).toBe(true)
+    })
+
+    it('detects default export via variable assignment', () => {
+      const code = `function Page() { return <div/> }
+export default Page`
+      expect(hasComponentExport(code)).toBe(true)
     })
   })
 })


### PR DESCRIPTION
- Add three new regex patterns to detect exported functions, arrow functions, and classes
- Implement hasComponentExport() function to identify modules with function or component exports
- Update scanDirectory() to filter out server components lacking valid exports
- Add comprehensive test suite covering const-only modules and function/component exports
- Prevents invalid server components from being registered during build process
- Closes #198

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Server component discovery now skips files without detectable component exports, preventing invalid modules from being included in builds.

* **New Features**
  * Export-detection expanded to recognize many more function/arrow/class and const/let/var export patterns during scanning.

* **Tests**
  * Added comprehensive unit tests covering numerous export scenarios to validate detection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->