### PR TITLE
chore(scripts): replace rm -rf with Node.js fs.rmSync for cross-platf…

### DIFF
--- a/packages/create-rari-app/package.json
+++ b/packages/create-rari-app/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "build": "pnpm clean && pnpm typecheck && vp pack",
     "dev": "vp pack --watch",
-    "clean": "rm -rf dist",
+    "clean": "node --eval \"import('node:fs').then(fs => fs.rmSync('dist', { recursive: true, force: true }))\"",
     "lint": "vp lint",
     "lint:fix": "vp lint --fix",
     "typecheck": "tsgo"

--- a/packages/create-rari-app/templates/default/package.json
+++ b/packages/create-rari-app/templates/default/package.json
@@ -14,7 +14,7 @@
     "start": "rari start",
     "deploy:railway": "rari deploy railway",
     "deploy:render": "rari deploy render",
-    "clean": "rm -rf dist",
+    "clean": "node --eval \"import('node:fs').then(fs => fs.rmSync('dist', { recursive: true, force: true }))\"",
     "typecheck": "tsgo"
   },
   "dependencies": {

--- a/packages/rari/package.json
+++ b/packages/rari/package.json
@@ -104,7 +104,7 @@
   },
   "scripts": {
     "build": "pnpm clean && pnpm typecheck && vp pack",
-    "clean": "rm -rf dist",
+    "clean": "node --eval \"import('node:fs').then(fs => fs.rmSync('dist', { recursive: true, force: true }))\"",
     "lint": "vp lint",
     "lint:fix": "vp lint --fix",
     "typecheck": "tsgo"

--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,7 @@
     "build": "rari build",
     "dev": "rari dev",
     "start": "rari start",
-    "clean": "rm -rf dist",
+    "clean": "node --eval \"import('node:fs').then(fs => fs.rmSync('dist', { recursive: true, force: true }))\"",
     "lint": "vp lint",
     "lint:fix": "vp lint --fix",
     "typecheck": "tsgo"


### PR DESCRIPTION
- Replace shell rm -rf commands with Node.js fs.rmSync in clean scripts
- Update clean script in packages/create-rari-app/package.json
- Update clean script in packages/create-rari-app/templates/default/package.json
- Update clean script in packages/rari/package.json
- Update clean script in web/package.json
- Improves cross-platform compatibility by removing Unix-specific shell command dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated clean scripts across packages to use Node.js-based file removal instead of shell commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->