### PR TITLE
refactor: improve runtime path resolution across Rust and TypeScript modules

### DIFF
--- a/crates/rari/src/server/middleware/proxy_middleware.rs
+++ b/crates/rari/src/server/middleware/proxy_middleware.rs
@@ -241,7 +241,10 @@ pub async fn initialize_proxy(state: &ServerState) -> Result<(), Box<dyn std::er
 
     let rari_pkg_dir = match resolve_rari_package_dir() {
         Some(dir) => dir,
-        None => return Ok(()),
+        None => {
+            tracing::debug!("Proxy: rari package directory not found in node_modules");
+            return Ok(());
+        }
     };
 
     let executor_path = rari_pkg_dir.join("dist/proxy/runtime-executor.mjs");

--- a/crates/rari/src/server/middleware/proxy_middleware.rs
+++ b/crates/rari/src/server/middleware/proxy_middleware.rs
@@ -250,6 +250,10 @@ pub async fn initialize_proxy(state: &ServerState) -> Result<(), Box<dyn std::er
     let executor_path = rari_pkg_dir.join("dist/proxy/runtime-executor.mjs");
 
     if !executor_path.exists() {
+        tracing::debug!(
+            "Proxy: executor not found at {}, skipping proxy setup",
+            executor_path.display()
+        );
         return Ok(());
     }
 

--- a/crates/rari/src/server/middleware/proxy_middleware.rs
+++ b/crates/rari/src/server/middleware/proxy_middleware.rs
@@ -218,6 +218,19 @@ where
     }
 }
 
+fn resolve_rari_package_dir() -> Option<std::path::PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    let mut search_dir = cwd.as_path();
+
+    loop {
+        let candidate = search_dir.join("node_modules").join("rari");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        search_dir = search_dir.parent()?;
+    }
+}
+
 pub async fn initialize_proxy(state: &ServerState) -> Result<(), Box<dyn std::error::Error>> {
     if !is_proxy_enabled() {
         return Ok(());
@@ -226,24 +239,26 @@ pub async fn initialize_proxy(state: &ServerState) -> Result<(), Box<dyn std::er
     let renderer = state.renderer.lock().await;
     let runtime = &renderer.runtime;
 
-    let executor_path = std::path::Path::new("node_modules/rari/dist/proxy/runtime-executor.mjs");
+    let rari_pkg_dir = match resolve_rari_package_dir() {
+        Some(dir) => dir,
+        None => return Ok(()),
+    };
+
+    let executor_path = rari_pkg_dir.join("dist/proxy/runtime-executor.mjs");
 
     if !executor_path.exists() {
         return Ok(());
     }
 
-    let executor_absolute = if let Ok(canonical) = executor_path.canonicalize() {
-        canonical
-    } else {
-        std::env::current_dir()?.join(executor_path)
-    };
+    let executor_absolute =
+        if let Ok(canonical) = executor_path.canonicalize() { canonical } else { executor_path };
     let executor_specifier = path_to_file_url(&executor_absolute);
 
-    let rari_request_path = std::path::Path::new("node_modules/rari/dist/proxy/RariRequest.mjs");
+    let rari_request_path = rari_pkg_dir.join("dist/proxy/RariRequest.mjs");
     let rari_request_absolute = if let Ok(canonical) = rari_request_path.canonicalize() {
         canonical
     } else {
-        std::env::current_dir()?.join(rari_request_path)
+        rari_request_path
     };
     let rari_request_specifier = path_to_file_url(&rari_request_absolute);
 

--- a/packages/rari/src/platform.ts
+++ b/packages/rari/src/platform.ts
@@ -83,16 +83,16 @@ export function getBinaryPath(): string {
   const selfDir = dirname(fileURLToPath(import.meta.url))
   let searchDir = selfDir
   while (true) {
-    const parent = dirname(searchDir)
-    if (parent === searchDir)
-      break
-    searchDir = parent
     if (existsSync(join(searchDir, 'pnpm-workspace.yaml'))) {
       const localBinary = join(searchDir, 'packages', packageName, 'bin', binaryName)
       if (existsSync(localBinary))
         return localBinary
       break
     }
+    const parent = dirname(searchDir)
+    if (parent === searchDir)
+      break
+    searchDir = parent
   }
 
   try {

--- a/packages/rari/src/platform.ts
+++ b/packages/rari/src/platform.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { dirname, join, parse } from 'node:path'
+import { dirname, join } from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
@@ -80,36 +80,21 @@ function getPlatformInfo(): PlatformInfo {
 export function getBinaryPath(): string {
   const { packageName, binaryName } = getPlatformInfo()
 
-  try {
-    let currentDir = process.cwd()
-    let workspaceRoot = null
-
-    /* v8 ignore start - workspace search logic, tested in actual workspace */
-    const rootDir = parse(currentDir).root
-    while (currentDir !== rootDir && currentDir !== '') {
-      const packagesDir = join(currentDir, 'packages')
-      if (existsSync(packagesDir)) {
-        workspaceRoot = currentDir
-        break
-      }
-      const parentDir = dirname(currentDir)
-      if (parentDir === currentDir)
-        break
-      currentDir = parentDir
+  const selfDir = dirname(fileURLToPath(import.meta.url))
+  let searchDir = selfDir
+  while (true) {
+    const parent = dirname(searchDir)
+    if (parent === searchDir)
+      break
+    searchDir = parent
+    if (existsSync(join(searchDir, 'pnpm-workspace.yaml'))) {
+      const localBinary = join(searchDir, 'packages', packageName, 'bin', binaryName)
+      if (existsSync(localBinary))
+        return localBinary
+      break
     }
-
-    if (workspaceRoot) {
-      const packageDir = join(workspaceRoot, 'packages', packageName)
-      const binaryPath = join(packageDir, 'bin', binaryName)
-
-      if (existsSync(binaryPath))
-        return binaryPath
-    }
-    /* v8 ignore stop */
   }
-  catch {}
 
-  /* v8 ignore start - fallback to import.meta.resolve, tested in workspace */
   try {
     const packagePath = import.meta.resolve(`${packageName}/package.json`)
     const packageDir = fileURLToPath(new URL('.', packagePath))
@@ -126,7 +111,6 @@ export function getBinaryPath(): string {
       + `Please ensure the platform package is installed: npm install ${packageName}`,
     )
   }
-  /* v8 ignore stop */
 }
 
 export function getInstallationInstructions(): string {

--- a/packages/rari/src/vite/index.ts
+++ b/packages/rari/src/vite/index.ts
@@ -170,6 +170,26 @@ async function loadRuntimeFile(filename: string): Promise<string> {
   throw new Error(`Could not find ${filename}. Tried: ${possiblePaths.join(', ')}`)
 }
 
+const RARI_DIST_DIR = path.dirname(fileURLToPath(import.meta.url))
+
+function resolveRuntimeDistFile(filename: string): string | null {
+  const possiblePaths = [
+    path.join(RARI_DIST_DIR, 'runtime', filename),
+    path.join(RARI_DIST_DIR, '../runtime', filename),
+  ]
+
+  for (const filePath of possiblePaths) {
+    if (fs.existsSync(filePath))
+      return filePath
+  }
+
+  return null
+}
+
+function isRariInternalFile(filePath: string): boolean {
+  return filePath.startsWith(RARI_DIST_DIR)
+}
+
 async function loadRscClientRuntime(): Promise<string> {
   return loadRuntimeFile('rsc-client-runtime.mjs')
 }
@@ -286,7 +306,7 @@ export function rari(options: RariOptions = {}): Plugin[] {
   }
 
   function isServerComponent(filePath: string): boolean {
-    if (filePath.includes('node_modules') || (filePath.includes('/rari/dist/') || filePath.includes('\\rari\\dist\\')))
+    if (filePath.includes('node_modules') || isRariInternalFile(filePath))
       return false
 
     const projectRoot = options.projectRoot || process.cwd()
@@ -1869,72 +1889,47 @@ for (const [path, config] of Object.entries(lazyComponentRegistry)) {
         return await loadReactServerDomShim()
 
       if (id === 'virtual:app-router-provider.tsx') {
-        const possiblePaths = [
-          path.join(process.cwd(), 'packages/rari/dist/runtime/AppRouterProvider.mjs'),
-          path.join(process.cwd(), 'node_modules/rari/dist/runtime/AppRouterProvider.mjs'),
-        ]
-
-        for (const providerSourcePath of possiblePaths) {
-          if (fs.existsSync(providerSourcePath))
-            return fs.readFileSync(providerSourcePath, 'utf-8')
-        }
+        const runtimeFile = resolveRuntimeDistFile('AppRouterProvider.mjs')
+        if (runtimeFile)
+          return fs.readFileSync(runtimeFile, 'utf-8')
 
         return 'export function AppRouterProvider({ children }) { return children; }'
       }
 
       if (id === 'virtual:default-loading-indicator.tsx') {
-        const possiblePaths = [
-          path.join(process.cwd(), 'packages/rari/dist/runtime/DefaultLoadingIndicator.mjs'),
-          path.join(process.cwd(), 'node_modules/rari/dist/runtime/DefaultLoadingIndicator.mjs'),
-        ]
-
-        for (const sourcePath of possiblePaths) {
-          if (fs.existsSync(sourcePath))
-            return fs.readFileSync(sourcePath, 'utf-8')
-        }
+        const runtimeFile = resolveRuntimeDistFile('DefaultLoadingIndicator.mjs')
+        if (runtimeFile)
+          return fs.readFileSync(runtimeFile, 'utf-8')
 
         return 'export function DefaultLoadingIndicator() { return null; }'
       }
 
       if (id === 'virtual:loading-error-boundary.tsx') {
-        const possiblePaths = [
-          path.join(process.cwd(), 'packages/rari/dist/runtime/LoadingErrorBoundary.mjs'),
-          path.join(process.cwd(), 'node_modules/rari/dist/runtime/LoadingErrorBoundary.mjs'),
-        ]
-
-        for (const sourcePath of possiblePaths) {
-          if (fs.existsSync(sourcePath))
-            return fs.readFileSync(sourcePath, 'utf-8')
-        }
+        const runtimeFile = resolveRuntimeDistFile('LoadingErrorBoundary.mjs')
+        if (runtimeFile)
+          return fs.readFileSync(runtimeFile, 'utf-8')
 
         return 'export class LoadingErrorBoundary extends React.Component { render() { return this.props.children; } }'
       }
 
       if (id === 'virtual:error-boundary-wrapper.tsx') {
-        const possiblePaths = [
-          path.join(process.cwd(), 'packages/rari/dist/runtime/ErrorBoundaryWrapper.mjs'),
-          path.join(process.cwd(), 'node_modules/rari/dist/runtime/ErrorBoundaryWrapper.mjs'),
-          path.join(process.cwd(), 'packages/rari/src/runtime/ErrorBoundaryWrapper.tsx'),
-        ]
-
-        for (const possiblePath of possiblePaths) {
-          if (fs.existsSync(possiblePath)) {
-            const content = fs.readFileSync(possiblePath, 'utf-8')
-            if (!content.includes('import React') && !content.includes('from "react"') && !content.includes('from \'react\'')) {
-              const useClientMatch = content.match(USE_CLIENT_DIRECTIVE_LINE_REGEX)
-              if (useClientMatch) {
-                const directive = useClientMatch[0]
-                const rest = content.slice(directive.length)
-                return `
-${directive}import * as React from 'react';\n${rest}`
-              }
-
+        const runtimeFile = resolveRuntimeDistFile('ErrorBoundaryWrapper.mjs')
+        if (runtimeFile) {
+          const content = fs.readFileSync(runtimeFile, 'utf-8')
+          if (!content.includes('import React') && !content.includes('from "react"') && !content.includes('from \'react\'')) {
+            const useClientMatch = content.match(USE_CLIENT_DIRECTIVE_LINE_REGEX)
+            if (useClientMatch) {
+              const directive = useClientMatch[0]
+              const rest = content.slice(directive.length)
               return `
-import * as React from 'react';\n${content}`
+${directive}import * as React from 'react';\n${rest}`
             }
 
-            return content
+            return `
+import * as React from 'react';\n${content}`
           }
+
+          return content
         }
 
         return `'use client';

--- a/packages/rari/src/vite/index.ts
+++ b/packages/rari/src/vite/index.ts
@@ -171,6 +171,7 @@ async function loadRuntimeFile(filename: string): Promise<string> {
 }
 
 const RARI_DIST_DIR = path.dirname(fileURLToPath(import.meta.url))
+const RARI_PACKAGE_ROOT = path.dirname(RARI_DIST_DIR)
 
 function resolveRuntimeDistFile(filename: string): string | null {
   const possiblePaths = [
@@ -187,7 +188,7 @@ function resolveRuntimeDistFile(filename: string): string | null {
 }
 
 function isRariInternalFile(filePath: string): boolean {
-  return filePath.startsWith(RARI_DIST_DIR)
+  return filePath.startsWith(RARI_PACKAGE_ROOT)
 }
 
 async function loadRscClientRuntime(): Promise<string> {
@@ -1909,7 +1910,7 @@ for (const [path, config] of Object.entries(lazyComponentRegistry)) {
         if (runtimeFile)
           return fs.readFileSync(runtimeFile, 'utf-8')
 
-        return 'export class LoadingErrorBoundary extends React.Component { render() { return this.props.children; } }'
+        return 'import * as React from \'react\';\nexport class LoadingErrorBoundary extends React.Component { render() { return this.props.children; } }'
       }
 
       if (id === 'virtual:error-boundary-wrapper.tsx') {

--- a/packages/rari/src/vite/server-build.ts
+++ b/packages/rari/src/vite/server-build.ts
@@ -3,7 +3,7 @@ import type { ServerCacheControlConfig, ServerConfig, ServerCSPConfig } from '..
 import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
-import { pathToFileURL } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { build } from 'rolldown'
 import {
   EXPORTED_CONST_FUNCTION_REGEX,
@@ -30,6 +30,11 @@ const SPECIAL_FILE_REGEX = /^(?:robots|sitemap)\.(?:tsx?|jsx?)$/
 const NODE_PROTOCOL_REGEX = /^node:/
 const PATH_SEPARATOR_NORMALIZE_REGEX = /\\/g
 export const RARI_CSS_MODULES_PATTERN = '[hash]_[local]'
+
+const RARI_DIST_DIR = path.dirname(fileURLToPath(import.meta.url))
+function isRariInternalPath(filePath: string): boolean {
+  return filePath.startsWith(RARI_DIST_DIR)
+}
 
 interface BuiltComponent {
   code: string
@@ -711,7 +716,7 @@ const ${importName} = (props) => {
       {
         name: 'resolve-client-server-boundaries',
         resolveId: (source: string, importer: string | undefined) => {
-          if (!importer || importer.includes('node_modules') || importer.includes('/packages/rari/dist'))
+          if (!importer || importer.includes('node_modules') || isRariInternalPath(importer))
             return null
 
           if (
@@ -927,13 +932,9 @@ export default registerClientReference(null, ${JSON.stringify(componentId)}, "de
         name: 'resolve-rari-proxy',
         resolveId: (source: string) => {
           if (isProxyFile && source === 'rari') {
-            const rariResponsePath = path.resolve(self.projectRoot, 'node_modules/rari/dist/proxy/RariResponse.mjs')
+            const rariResponsePath = path.join(RARI_DIST_DIR, 'proxy/RariResponse.mjs')
             if (fs.existsSync(rariResponsePath))
               return rariResponsePath
-
-            const rariResponseSrcPath = path.resolve(self.projectRoot, 'node_modules/rari/src/proxy/RariResponse.ts')
-            if (fs.existsSync(rariResponseSrcPath))
-              return rariResponseSrcPath
           }
 
           return null

--- a/packages/rari/src/vite/server-build.ts
+++ b/packages/rari/src/vite/server-build.ts
@@ -32,8 +32,9 @@ const PATH_SEPARATOR_NORMALIZE_REGEX = /\\/g
 export const RARI_CSS_MODULES_PATTERN = '[hash]_[local]'
 
 const RARI_DIST_DIR = path.dirname(fileURLToPath(import.meta.url))
+const RARI_PACKAGE_ROOT = path.dirname(RARI_DIST_DIR)
 function isRariInternalPath(filePath: string): boolean {
-  return filePath.startsWith(RARI_DIST_DIR)
+  return filePath.startsWith(RARI_PACKAGE_ROOT)
 }
 
 interface BuiltComponent {
@@ -935,6 +936,10 @@ export default registerClientReference(null, ${JSON.stringify(componentId)}, "de
             const rariResponsePath = path.join(RARI_DIST_DIR, 'proxy/RariResponse.mjs')
             if (fs.existsSync(rariResponsePath))
               return rariResponsePath
+
+            const rariResponseSrcPath = path.join(RARI_PACKAGE_ROOT, 'src/proxy/RariResponse.ts')
+            if (fs.existsSync(rariResponseSrcPath))
+              return rariResponseSrcPath
           }
 
           return null


### PR DESCRIPTION
- Add resolve_rari_package_dir() function in proxy middleware to walk up directory tree and locate rari package in node_modules
- Update initialize_proxy() to use dynamic rari package resolution instead of hardcoded relative paths
- Simplify getBinaryPath() in platform.ts to resolve workspace root by checking for pnpm-workspace.yaml file
- Remove try-catch wrapper and workspace search logic in favor of file existence checks
- Consolidate runtime file resolution in vite/index.ts with RARI_DIST_DIR constant and helper functions
- Add resolveRuntimeDistFile() to check multiple possible runtime file locations
- Add isRariInternalFile() helper to detect internal rari distribution files
- Replace inline path checking logic with isRariInternalFile() in isServerComponent()
- Refactor virtual module handlers to use resolveRuntimeDistFile() for cleaner path resolution
- Centralize path resolution logic to reduce duplication across multiple files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved resolution of runtime and proxy assets so the app more reliably finds and loads Rari runtime files from the local package layout.
  * Enhanced platform binary discovery to locate workspace roots relative to the codebase, making binary lookup more robust across setups.
  * Strengthened Vite build/plugin logic to better detect internal runtime modules, prefer local runtime implementations, and fall back to minimal stubs when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->