### PR TITLE
refactor(routing): remove deprecated is_layout_ancestor method

### DIFF
--- a/crates/rari/src/server/routing/app_router.rs
+++ b/crates/rari/src/server/routing/app_router.rs
@@ -301,14 +301,6 @@ impl AppRouter {
         route_dir == boundary_dir || route_dir.starts_with(&format!("{}/", boundary_dir))
     }
 
-    #[deprecated(
-        note = "Use is_boundary_ancestor instead — works for layouts, templates, loading, error, not-found, og-image"
-    )]
-    #[allow(dead_code)]
-    fn is_layout_ancestor(layout_file_path: &str, route_file_path: &str) -> bool {
-        Self::is_boundary_ancestor(layout_file_path, route_file_path)
-    }
-
     fn file_path_depth(file_path: &str) -> usize {
         let dir = Self::normalized_dir(file_path);
         if dir.is_empty() { 0 } else { dir.split('/').count() }


### PR DESCRIPTION
- Remove deprecated is_layout_ancestor function that delegated to is_boundary_ancestor
- Consolidate boundary detection logic by eliminating redundant wrapper method
- is_boundary_ancestor now serves as the single source of truth for all boundary type checks (layouts, templates, loading, error, not-found, og-image)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed deprecated internal code to improve codebase maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->