### PR TITLE
feat(ssr): implement server-side rendering for client components

### DIFF
--- a/crates/rari/src/rsc/rendering/core/js/component_render.js
+++ b/crates/rari/src/rsc/rendering/core/js/component_render.js
@@ -106,7 +106,7 @@
 
     let htmlResult = null
     try {
-      htmlResult = renderToHTML(element)
+      htmlResult = await renderToHtml(element)
       htmlResult = sanitizeComponentOutput(htmlResult, '{component_id}')
     }
     catch (htmlError) {
@@ -162,7 +162,7 @@
 
           let htmlResult = null
           try {
-            htmlResult = renderToHTML(newElement)
+            htmlResult = await renderToHtml(newElement)
             htmlResult = sanitizeComponentOutput(htmlResult, '{component_id}')
           }
           catch (htmlError) {

--- a/crates/rari/src/rsc/rendering/html/mod.rs
+++ b/crates/rari/src/rsc/rendering/html/mod.rs
@@ -239,6 +239,35 @@ impl RscHtmlRenderer {
         Self { runtime, template_cache: parking_lot::Mutex::new(None) }
     }
 
+    async fn ssr_render_client_component(
+        &self,
+        module_path: &str,
+        export_name: &str,
+        props_json: &str,
+    ) -> Result<String, RariError> {
+        let script = format!(
+            r#"(async function() {{
+                const ssrRender = globalThis['~rari']?.ssrRenderComponent;
+                if (!ssrRender) return '';
+                try {{
+                    return await ssrRender({module_path}, {export_name}, {props_json});
+                }} catch (e) {{
+                    return '';
+                }}
+            }})()"#,
+            module_path = serde_json::to_string(module_path).unwrap_or_default(),
+            export_name = serde_json::to_string(export_name).unwrap_or_default(),
+            props_json = props_json,
+        );
+
+        let result = self.runtime.execute_script("ssr_render_client".to_string(), script).await?;
+
+        match result.as_str() {
+            Some(html) if !html.is_empty() => Ok(html.to_string()),
+            _ => Ok(String::new()),
+        }
+    }
+
     fn extract_script_tags(template: &str) -> String {
         use regex::Regex;
 
@@ -516,7 +545,20 @@ impl RscHtmlRenderer {
         let id = u32::from_str_radix(id_str, 16)
             .map_err(|e| RariError::internal(format!("Invalid row ID '{}': {}", id_str, e)))?;
 
-        if data_str.starts_with('I') {
+        if let Some(json_str) = data_str.strip_prefix('I') {
+            if let Ok(import_data) = serde_json::from_str::<serde_json::Value>(json_str) {
+                let module_path =
+                    import_data.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                let export_name = import_data
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("default")
+                    .to_string();
+                return Ok(RscRow {
+                    id,
+                    data: RscElement::ModuleImport { module_path, export_name },
+                });
+            }
             return Ok(RscRow { id, data: RscElement::Text(data_str.to_string()) });
         }
 
@@ -857,6 +899,8 @@ impl RscHtmlRenderer {
                 }
 
                 RscElement::Promise { promise_id: _ } => Ok(String::new()),
+
+                RscElement::ModuleImport { .. } => Ok(String::new()),
             }
         })
     }
@@ -879,6 +923,34 @@ impl RscHtmlRenderer {
                 || tag.contains('#')
                 || tag.contains('/');
             if is_client_component {
+                let children_are_rsc = props
+                    .as_object()
+                    .and_then(|o| o.get("children"))
+                    .and_then(|c| c.as_array())
+                    .map(|arr| {
+                        arr.first()
+                            .map(|first| first.as_str() == Some("$") || first.is_array())
+                            .unwrap_or(false)
+                    })
+                    .unwrap_or(false);
+
+                if !children_are_rsc
+                    && let Some(stripped) =
+                        tag.strip_prefix("$L").or_else(|| tag.strip_prefix("$@"))
+                    && let Ok(module_row_id) = u32::from_str_radix(stripped, 16)
+                    && let Some(RscElement::ModuleImport { module_path, export_name }) =
+                        row_map.get(&module_row_id).copied()
+                {
+                    let props_json = serde_json::to_string(props).unwrap_or_default();
+                    if let Ok(html) = self
+                        .ssr_render_client_component(module_path, export_name, &props_json)
+                        .await
+                        && !html.is_empty()
+                    {
+                        return Ok(html);
+                    }
+                }
+
                 if let Some(props_obj) = props.as_object()
                     && let Some(children) = props_obj.get("children")
                 {
@@ -1086,6 +1158,8 @@ impl RscHtmlRenderer {
 
 pub struct RscToHtmlConverter {
     row_cache: FxHashMap<u32, String>,
+    module_imports: FxHashMap<u32, (String, String)>,
+    renderer: Arc<RscHtmlRenderer>,
     shell_sent: bool,
     asset_links: Option<String>,
     boundary_id_generator: BoundaryIdGenerator,
@@ -1099,9 +1173,11 @@ pub struct RscToHtmlConverter {
 }
 
 impl RscToHtmlConverter {
-    pub fn new(_renderer: Arc<RscHtmlRenderer>) -> Self {
+    pub fn new(renderer: Arc<RscHtmlRenderer>) -> Self {
         Self {
             row_cache: FxHashMap::default(),
+            module_imports: FxHashMap::default(),
+            renderer,
             shell_sent: false,
             asset_links: None,
             boundary_id_generator: BoundaryIdGenerator::new(),
@@ -1115,9 +1191,11 @@ impl RscToHtmlConverter {
         }
     }
 
-    pub fn with_assets(asset_links: String, _renderer: Arc<RscHtmlRenderer>) -> Self {
+    pub fn with_assets(asset_links: String, renderer: Arc<RscHtmlRenderer>) -> Self {
         Self {
             row_cache: FxHashMap::default(),
+            module_imports: FxHashMap::default(),
+            renderer,
             shell_sent: false,
             asset_links: Some(asset_links),
             boundary_id_generator: BoundaryIdGenerator::new(),
@@ -1134,10 +1212,12 @@ impl RscToHtmlConverter {
     pub fn with_custom_shell(
         custom_shell: String,
         body_scripts: Option<String>,
-        _renderer: Arc<RscHtmlRenderer>,
+        renderer: Arc<RscHtmlRenderer>,
     ) -> Self {
         Self {
             row_cache: FxHashMap::default(),
+            module_imports: FxHashMap::default(),
+            renderer,
             shell_sent: false,
             asset_links: None,
             boundary_id_generator: BoundaryIdGenerator::new(),
@@ -1345,35 +1425,6 @@ impl RscToHtmlConverter {
 </script>"#
     }
 
-    fn contains_client_reference(value: &serde_json::Value) -> bool {
-        match value {
-            serde_json::Value::Array(arr) => {
-                if arr.len() >= 4
-                    && arr[0] == "$"
-                    && let Some(id) = arr[1].as_str()
-                {
-                    if id.starts_with("$L")
-                        || id.starts_with("$@")
-                        || id.contains('#')
-                        || id.contains('/')
-                    {
-                        return true;
-                    }
-
-                    if id.starts_with('$')
-                        && id.len() > 1
-                        && id[1..].chars().all(|c| c.is_ascii_hexdigit())
-                    {
-                        return true;
-                    }
-                }
-                arr.iter().any(Self::contains_client_reference)
-            }
-            serde_json::Value::Object(obj) => obj.values().any(Self::contains_client_reference),
-            _ => false,
-        }
-    }
-
     fn generate_html_shell(&self) -> Vec<u8> {
         if let Some(custom_shell) = &self.custom_shell {
             let bridge_script = Self::streaming_bridge_script();
@@ -1512,7 +1563,21 @@ if (typeof window !== 'undefined') {{
             return Ok(Vec::new());
         }
 
-        if json_str.starts_with('I') || json_str.starts_with('S') || json_str.starts_with('E') {
+        if let Some(i_data) = json_str.strip_prefix('I') {
+            if let Ok(import_data) = serde_json::from_str::<serde_json::Value>(i_data) {
+                let module_path =
+                    import_data.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                let export_name = import_data
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("default")
+                    .to_string();
+                self.module_imports.insert(row_id, (module_path, export_name));
+            }
+            return Ok(Vec::new());
+        }
+
+        if json_str.starts_with('S') || json_str.starts_with('E') {
             return Ok(Vec::new());
         }
 
@@ -1648,9 +1713,29 @@ if (typeof window !== 'undefined') {{
 
     async fn render_client_component_placeholder(
         &self,
-        _component_ref: &str,
+        component_ref: &str,
         props: Option<&serde_json::Map<String, serde_json::Value>>,
     ) -> Result<String, RariError> {
+        if let Some(stripped) =
+            component_ref.strip_prefix("$L").or_else(|| component_ref.strip_prefix("$@"))
+            && let Ok(module_row_id) = u32::from_str_radix(stripped, 16)
+            && let Some((module_path, export_name)) = self.module_imports.get(&module_row_id)
+        {
+            let props_json = if let Some(p) = props {
+                serde_json::to_string(&serde_json::Value::Object(p.clone())).unwrap_or_default()
+            } else {
+                "{}".to_string()
+            };
+            if let Ok(html) = self
+                .renderer
+                .ssr_render_client_component(module_path, export_name, &props_json)
+                .await
+                && !html.is_empty()
+            {
+                return Ok(html);
+            }
+        }
+
         if let Some(props) = props
             && let Some(children) = props.get("children")
         {
@@ -1874,16 +1959,10 @@ if (typeof window !== 'undefined') {{
                 escape_html(text)
             } else {
                 match serde_json::from_str::<serde_json::Value>(content_json) {
-                    Ok(content) => {
-                        if Self::contains_client_reference(&content) {
-                            String::new()
-                        } else {
-                            match self.rsc_element_to_html(&content).await {
-                                Ok(html) if !html.is_empty() => html,
-                                _ => String::new(),
-                            }
-                        }
-                    }
+                    Ok(content) => match self.rsc_element_to_html(&content).await {
+                        Ok(html) if !html.is_empty() => html,
+                        _ => String::new(),
+                    },
                     Err(_) => String::new(),
                 }
             };

--- a/crates/rari/src/rsc/rendering/html/mod.rs
+++ b/crates/rari/src/rsc/rendering/html/mod.rs
@@ -1716,8 +1716,19 @@ if (typeof window !== 'undefined') {{
         component_ref: &str,
         props: Option<&serde_json::Map<String, serde_json::Value>>,
     ) -> Result<String, RariError> {
-        if let Some(stripped) =
-            component_ref.strip_prefix("$L").or_else(|| component_ref.strip_prefix("$@"))
+        let children_are_rsc = props
+            .and_then(|p| p.get("children"))
+            .and_then(|c| c.as_array())
+            .map(|arr| {
+                arr.first()
+                    .map(|first| first.as_str() == Some("$") || first.is_array())
+                    .unwrap_or(false)
+            })
+            .unwrap_or(false);
+
+        if !children_are_rsc
+            && let Some(stripped) =
+                component_ref.strip_prefix("$L").or_else(|| component_ref.strip_prefix("$@"))
             && let Ok(module_row_id) = u32::from_str_radix(stripped, 16)
             && let Some((module_path, export_name)) = self.module_imports.get(&module_row_id)
         {

--- a/crates/rari/src/rsc/rendering/html/mod.rs
+++ b/crates/rari/src/rsc/rendering/html/mod.rs
@@ -929,7 +929,10 @@ impl RscHtmlRenderer {
                     .and_then(|c| c.as_array())
                     .map(|arr| {
                         arr.first()
-                            .map(|first| first.as_str() == Some("$") || first.is_array())
+                            .map(|first| {
+                                first.as_str().map(|s| s.starts_with('$')).unwrap_or(false)
+                                    || first.is_array()
+                            })
                             .unwrap_or(false)
                     })
                     .unwrap_or(false);
@@ -1662,6 +1665,7 @@ if (typeof window !== 'undefined') {{
                         && element_type[1..].chars().all(|c| c.is_ascii_hexdigit());
 
                     let is_client_component = element_type.starts_with("$L")
+                        || element_type.starts_with("$@")
                         || element_type.contains('#')
                         || element_type.contains('/');
 
@@ -1721,7 +1725,10 @@ if (typeof window !== 'undefined') {{
             .and_then(|c| c.as_array())
             .map(|arr| {
                 arr.first()
-                    .map(|first| first.as_str() == Some("$") || first.is_array())
+                    .map(|first| {
+                        first.as_str().map(|s| s.starts_with('$')).unwrap_or(false)
+                            || first.is_array()
+                    })
                     .unwrap_or(false)
             })
             .unwrap_or(false);

--- a/crates/rari/src/rsc/rendering/html/mod.rs
+++ b/crates/rari/src/rsc/rendering/html/mod.rs
@@ -1718,11 +1718,25 @@ if (typeof window !== 'undefined') {{
                 {
                     let props_obj = props.as_object();
 
+                    let is_suspense_symbol = type_str.starts_with('$')
+                        && type_str.len() > 1
+                        && type_str[1..].chars().all(|c| c.is_ascii_hexdigit());
+
+                    let is_client_component = type_str.starts_with("$L")
+                        || type_str.starts_with("$@")
+                        || type_str.contains('#')
+                        || type_str.contains('/');
+
                     if type_str == "$Sreact.suspense"
                         || type_str == "react.suspense"
                         || type_str == "suspense"
+                        || is_suspense_symbol
                     {
                         return self.render_suspense_boundary(type_str, props_obj).await;
+                    }
+
+                    if is_client_component {
+                        return self.render_client_component_placeholder(type_str, props_obj).await;
                     }
 
                     return self.render_html_element(type_str, props_obj).await;

--- a/crates/rari/src/rsc/rendering/html/mod.rs
+++ b/crates/rari/src/rsc/rendering/html/mod.rs
@@ -1,6 +1,7 @@
 use crate::error::{RariError, StreamingError};
 use crate::rsc::rendering::streaming::{RscChunkType, RscStreamChunk};
 use crate::rsc::types::RscElement;
+use crate::rsc::wire_format::escape::unescape_rsc_value;
 use crate::runtime::JsExecutionRuntime;
 use crate::server::routing::app_router::AppRouteMatch;
 use cow_utils::CowUtils;
@@ -239,13 +240,18 @@ impl RscHtmlRenderer {
         Self { runtime, template_cache: parking_lot::Mutex::new(None) }
     }
 
+    fn string_looks_like_rsc(s: &str) -> bool {
+        s.starts_with('$') && !s.starts_with("$$")
+    }
+
     fn value_looks_like_rsc(value: &serde_json::Value) -> bool {
         match value {
-            serde_json::Value::String(s) => s.starts_with('$'),
+            serde_json::Value::String(s) => Self::string_looks_like_rsc(s),
             serde_json::Value::Array(arr) => arr
                 .first()
                 .map(|first| {
-                    first.as_str().map(|s| s.starts_with('$')).unwrap_or(false) || first.is_array()
+                    first.as_str().map(Self::string_looks_like_rsc).unwrap_or(false)
+                        || first.is_array()
                 })
                 .unwrap_or(false),
             _ => false,
@@ -949,7 +955,8 @@ impl RscHtmlRenderer {
                     && let Some(RscElement::ModuleImport { module_path, export_name }) =
                         row_map.get(&module_row_id).copied()
                 {
-                    let props_json = serde_json::to_string(props).unwrap_or_default();
+                    let props_json =
+                        serde_json::to_string(&unescape_rsc_value(props)).unwrap_or_default();
                     if let Ok(html) = self
                         .ssr_render_client_component(module_path, export_name, &props_json)
                         .await
@@ -1639,6 +1646,10 @@ if (typeof window !== 'undefined') {{
     {
         Box::pin(async move {
             if let Some(s) = element.as_str() {
+                if s.starts_with("$$") {
+                    return Ok(escape_html(&s[1..]));
+                }
+
                 if let Some(stripped) = s.strip_prefix("$L").or_else(|| s.strip_prefix("$@"))
                     && let Ok(row_id) = u32::from_str_radix(stripped, 16)
                 {
@@ -1767,7 +1778,8 @@ if (typeof window !== 'undefined') {{
             && let Some((module_path, export_name)) = self.module_imports.get(&module_row_id)
         {
             let props_json = if let Some(p) = props {
-                serde_json::to_string(&serde_json::Value::Object(p.clone())).unwrap_or_default()
+                serde_json::to_string(&unescape_rsc_value(&serde_json::Value::Object(p.clone())))
+                    .unwrap_or_default()
             } else {
                 "{}".to_string()
             };

--- a/crates/rari/src/rsc/rendering/html/mod.rs
+++ b/crates/rari/src/rsc/rendering/html/mod.rs
@@ -1259,6 +1259,22 @@ impl RscToHtmlConverter {
                     self.rsc_wire_format.push(rsc_line.trim().to_string());
                 }
 
+                let parts: Vec<&str> = rsc_line.trim().splitn(2, ':').collect();
+                if parts.len() == 2
+                    && let Ok(row_id) = u32::from_str_radix(parts[0], 16)
+                    && let Some(i_data) = parts[1].trim().strip_prefix('I')
+                    && let Ok(import_data) = serde_json::from_str::<serde_json::Value>(i_data)
+                {
+                    let module_path =
+                        import_data.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                    let export_name = import_data
+                        .get("name")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("default")
+                        .to_string();
+                    self.module_imports.insert(row_id, (module_path, export_name));
+                }
+
                 Ok(Vec::new())
             }
 

--- a/crates/rari/src/rsc/rendering/html/mod.rs
+++ b/crates/rari/src/rsc/rendering/html/mod.rs
@@ -239,6 +239,19 @@ impl RscHtmlRenderer {
         Self { runtime, template_cache: parking_lot::Mutex::new(None) }
     }
 
+    fn value_looks_like_rsc(value: &serde_json::Value) -> bool {
+        match value {
+            serde_json::Value::String(s) => s.starts_with('$'),
+            serde_json::Value::Array(arr) => arr
+                .first()
+                .map(|first| {
+                    first.as_str().map(|s| s.starts_with('$')).unwrap_or(false) || first.is_array()
+                })
+                .unwrap_or(false),
+            _ => false,
+        }
+    }
+
     async fn ssr_render_client_component(
         &self,
         module_path: &str,
@@ -926,15 +939,7 @@ impl RscHtmlRenderer {
                 let children_are_rsc = props
                     .as_object()
                     .and_then(|o| o.get("children"))
-                    .and_then(|c| c.as_array())
-                    .map(|arr| {
-                        arr.first()
-                            .map(|first| {
-                                first.as_str().map(|s| s.starts_with('$')).unwrap_or(false)
-                                    || first.is_array()
-                            })
-                            .unwrap_or(false)
-                    })
+                    .map(Self::value_looks_like_rsc)
                     .unwrap_or(false);
 
                 if !children_are_rsc
@@ -1722,15 +1727,7 @@ if (typeof window !== 'undefined') {{
     ) -> Result<String, RariError> {
         let children_are_rsc = props
             .and_then(|p| p.get("children"))
-            .and_then(|c| c.as_array())
-            .map(|arr| {
-                arr.first()
-                    .map(|first| {
-                        first.as_str().map(|s| s.starts_with('$')).unwrap_or(false)
-                            || first.is_array()
-                    })
-                    .unwrap_or(false)
-            })
+            .map(RscHtmlRenderer::value_looks_like_rsc)
             .unwrap_or(false);
 
         if !children_are_rsc

--- a/crates/rari/src/rsc/rendering/html/mod.rs
+++ b/crates/rari/src/rsc/rendering/html/mod.rs
@@ -247,13 +247,8 @@ impl RscHtmlRenderer {
     fn value_looks_like_rsc(value: &serde_json::Value) -> bool {
         match value {
             serde_json::Value::String(s) => Self::string_looks_like_rsc(s),
-            serde_json::Value::Array(arr) => arr
-                .first()
-                .map(|first| {
-                    first.as_str().map(Self::string_looks_like_rsc).unwrap_or(false)
-                        || first.is_array()
-                })
-                .unwrap_or(false),
+            serde_json::Value::Array(arr) => arr.iter().any(Self::value_looks_like_rsc),
+            serde_json::Value::Object(obj) => obj.values().any(Self::value_looks_like_rsc),
             _ => false,
         }
     }
@@ -942,13 +937,9 @@ impl RscHtmlRenderer {
                 || tag.contains('#')
                 || tag.contains('/');
             if is_client_component {
-                let children_are_rsc = props
-                    .as_object()
-                    .and_then(|o| o.get("children"))
-                    .map(Self::value_looks_like_rsc)
-                    .unwrap_or(false);
+                let props_are_rsc = Self::value_looks_like_rsc(props);
 
-                if !children_are_rsc
+                if !props_are_rsc
                     && let Some(stripped) =
                         tag.strip_prefix("$L").or_else(|| tag.strip_prefix("$@"))
                     && let Ok(module_row_id) = u32::from_str_radix(stripped, 16)
@@ -1766,12 +1757,10 @@ if (typeof window !== 'undefined') {{
         component_ref: &str,
         props: Option<&serde_json::Map<String, serde_json::Value>>,
     ) -> Result<String, RariError> {
-        let children_are_rsc = props
-            .and_then(|p| p.get("children"))
-            .map(RscHtmlRenderer::value_looks_like_rsc)
-            .unwrap_or(false);
+        let props_are_rsc =
+            props.is_some_and(|p| p.values().any(RscHtmlRenderer::value_looks_like_rsc));
 
-        if !children_are_rsc
+        if !props_are_rsc
             && let Some(stripped) =
                 component_ref.strip_prefix("$L").or_else(|| component_ref.strip_prefix("$@"))
             && let Ok(module_row_id) = u32::from_str_radix(stripped, 16)

--- a/crates/rari/src/rsc/rendering/layout/js/html_render.js
+++ b/crates/rari/src/rsc/rendering/layout/js/html_render.js
@@ -168,4 +168,31 @@ if (typeof globalThis !== 'undefined') {
   globalThis.renderToHtml = renderToHtml
   globalThis.escapeHtml = escapeHtml
   globalThis.kebabCase = kebabCase
+
+  if (!globalThis['~rari'])
+    globalThis['~rari'] = {}
+  if (!globalThis['~rari'].ssrModules)
+    globalThis['~rari'].ssrModules = {}
+
+  globalThis['~rari'].ssrRenderComponent = async function (modulePath, exportName, props) {
+    const mod = globalThis['~rari'].ssrModules[modulePath.replace(/\\/g, '/')]
+      || globalThis['~rari'].ssrModules[modulePath]
+    if (!mod)
+      return ''
+
+    const Component = exportName === 'default' ? (mod.default || mod) : mod[exportName]
+    if (typeof Component !== 'function')
+      return ''
+
+    try {
+      let element = Component(props)
+      if (element && typeof element.then === 'function')
+        element = await element
+
+      return await renderToHtml(element, 0)
+    }
+    catch {
+      return ''
+    }
+  }
 }

--- a/crates/rari/src/rsc/types/mod.rs
+++ b/crates/rari/src/rsc/types/mod.rs
@@ -20,6 +20,10 @@ pub enum RscElement {
     Promise {
         promise_id: String,
     },
+    ModuleImport {
+        module_path: String,
+        export_name: String,
+    },
     Reference(String),
     Text(String),
     Fragment {

--- a/crates/rari/src/server/core/mod.rs
+++ b/crates/rari/src/server/core/mod.rs
@@ -91,6 +91,8 @@ impl Server {
             ComponentLoader::load_server_actions_from_source(&mut renderer).await?;
         }
 
+        ComponentLoader::load_ssr_client_components(&renderer.runtime).await?;
+
         let app_router = {
             let manifest_path = "dist/server/routes.json";
 

--- a/crates/rari/src/server/loaders/component_loader.rs
+++ b/crates/rari/src/server/loaders/component_loader.rs
@@ -1,11 +1,13 @@
 use crate::error::RariError;
 use crate::rsc::rendering::core::RscRenderer;
 use crate::rsc::utils::dependency_utils::extract_dependencies;
+use crate::runtime::JsExecutionRuntime;
 use crate::server::utils::component_utils::{
     has_use_client_directive, has_use_server_directive, wrap_server_action_module,
 };
 use crate::utils::path_url::path_to_file_url;
 use cow_utils::CowUtils;
+use std::sync::Arc;
 use tracing::error;
 
 const DIST_DIR: &str = "dist";
@@ -922,5 +924,73 @@ impl ComponentLoader {
             .register_component(component_id, &component_code)
             .await
             .map_err(|e| RariError::internal(format!("Failed to register component: {e}")))
+    }
+
+    pub async fn load_ssr_client_components(
+        runtime: &Arc<JsExecutionRuntime>,
+    ) -> Result<(), RariError> {
+        let manifest_path = std::path::Path::new("dist/ssr/manifest.json");
+        if !manifest_path.exists() {
+            return Ok(());
+        }
+
+        let manifest_content = std::fs::read_to_string(manifest_path)
+            .map_err(|e| RariError::io(format!("Failed to read SSR manifest: {e}")))?;
+
+        let manifest: serde_json::Value = serde_json::from_str(&manifest_content)
+            .map_err(|e| RariError::internal(format!("Failed to parse SSR manifest: {e}")))?;
+
+        let Some(entries) = manifest.as_object() else {
+            return Ok(());
+        };
+
+        for (module_path, info) in entries {
+            let bundle_path = info.get("bundlePath").and_then(|v| v.as_str()).unwrap_or_default();
+
+            let component_file = std::path::Path::new(DIST_DIR).join(bundle_path);
+            if !component_file.exists() {
+                continue;
+            }
+
+            let code = match std::fs::read_to_string(&component_file) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+
+            let module_specifier = format!("file:///{}", bundle_path.cow_replace('\\', "/"));
+            if let Err(e) = runtime.add_module_to_loader_only(&module_specifier, code).await {
+                error!("Failed to add SSR module {}: {}", module_path, e);
+                continue;
+            }
+
+            let module_path_json = serde_json::to_string(module_path).unwrap_or_default();
+            let register_script = format!(
+                r#"(async function() {{
+                    try {{
+                        const mod = await import({specifier});
+                        if (globalThis['~rari'] && globalThis['~rari'].ssrModules) {{
+                            globalThis['~rari'].ssrModules[{path}] = mod;
+                        }}
+                        return true;
+                    }} catch (e) {{
+                        return false;
+                    }}
+                }})()"#,
+                specifier = serde_json::to_string(&module_specifier).unwrap_or_default(),
+                path = module_path_json,
+            );
+
+            if let Err(e) = runtime
+                .execute_script(
+                    format!("ssr_load_{}.js", module_path.cow_replace('/', "_")),
+                    register_script,
+                )
+                .await
+            {
+                error!("Failed to load SSR module {}: {}", module_path, e);
+            }
+        }
+
+        Ok(())
     }
 }

--- a/crates/rari/src/server/loaders/component_loader.rs
+++ b/crates/rari/src/server/loaders/component_loader.rs
@@ -968,9 +968,10 @@ impl ComponentLoader {
                 r#"(async function() {{
                     try {{
                         const mod = await import({specifier});
-                        if (globalThis['~rari'] && globalThis['~rari'].ssrModules) {{
-                            globalThis['~rari'].ssrModules[{path}] = mod;
+                        if (!globalThis['~rari'] || !globalThis['~rari'].ssrModules) {{
+                            return false;
                         }}
+                        globalThis['~rari'].ssrModules[{path}] = mod;
                         return true;
                     }} catch (e) {{
                         return false;

--- a/packages/rari/src/runtime/entry-client.ts
+++ b/packages/rari/src/runtime/entry-client.ts
@@ -7,7 +7,7 @@ import { ClientRouter } from 'rari/client'
 import { RouterProvider } from 'rari/router'
 import * as React from 'react'
 import { Suspense } from 'react'
-import { createRoot } from 'react-dom/client'
+import { createRoot, hydrateRoot } from 'react-dom/client'
 // @ts-expect-error - virtual module resolved by Vite
 import { AppRouterProvider } from 'virtual:app-router-provider'
 // @ts-expect-error - virtual module resolved by Vite
@@ -517,8 +517,13 @@ export async function renderApp(): Promise<void> {
     )
     /* eslint-enable react/jsx-no-children-prop */
 
-    const root = createRoot(rootElement)
-    root.render(wrappedContent)
+    if (hasServerRenderedContent) {
+      hydrateRoot(rootElement, wrappedContent)
+    }
+    else {
+      const root = createRoot(rootElement)
+      root.render(wrappedContent)
+    }
   }
   catch (error) {
     console.error('[rari] Error rendering app:', error)

--- a/packages/rari/src/vite/server-build.ts
+++ b/packages/rari/src/vite/server-build.ts
@@ -1263,6 +1263,216 @@ export default registerClientReference(null, ${JSON.stringify(componentId)}, "de
     return manifest
   }
 
+  async buildSSRClientComponents(): Promise<void> {
+    const ssrOutDir = path.join(this.options.outDir, 'ssr')
+    await fs.promises.mkdir(ssrOutDir, { recursive: true })
+
+    const clientFiles: Array<{ filePath: string, code: string }> = []
+    const srcDir = path.join(this.projectRoot, 'src')
+
+    const scanForClientComponents = (dir: string) => {
+      if (!fs.existsSync(dir))
+        return
+      const entries = fs.readdirSync(dir, { withFileTypes: true })
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name)
+        if (entry.isDirectory()) {
+          if (entry.name === 'node_modules')
+            continue
+          scanForClientComponents(fullPath)
+        }
+        else if (entry.isFile() && TSX_EXT_REGEX.test(entry.name)) {
+          try {
+            const code = fs.readFileSync(fullPath, 'utf-8')
+            if (hasTopLevelUseClientDirective(code))
+              clientFiles.push({ filePath: fullPath, code })
+          }
+          catch {}
+        }
+      }
+    }
+
+    scanForClientComponents(srcDir)
+
+    if (clientFiles.length === 0)
+      return
+
+    const manifest: Record<string, { id: string, filePath: string, bundlePath: string, exports: string[] }> = {}
+    const concurrency = Math.min(8, Math.max(1, (await import('node:os')).cpus().length))
+    let active = 0
+    let index = 0
+    const errors: Error[] = []
+
+    await new Promise<void>((resolve) => {
+      const next = () => {
+        while (active < concurrency && index < clientFiles.length) {
+          const { filePath, code } = clientFiles[index++]
+          const componentId = path.relative(this.projectRoot, filePath).replace(BACKSLASH_REGEX, '/')
+          const bundleName = this.getComponentId(filePath)
+          const bundlePath = `ssr/${bundleName}.js`
+          const fullBundlePath = path.join(this.options.outDir, bundlePath)
+
+          active++
+          ;(async () => {
+            try {
+              const bundleDir = path.dirname(fullBundlePath)
+              await fs.promises.mkdir(bundleDir, { recursive: true })
+
+              await this.buildSSRSingleClient(filePath, fullBundlePath)
+
+              const exports = this.extractExportNames(code)
+              manifest[componentId] = {
+                id: componentId,
+                filePath,
+                bundlePath,
+                exports,
+              }
+            }
+            catch (error) {
+              console.warn(`[rari] SSR build failed for ${componentId}:`, error instanceof Error ? error.message : error)
+            }
+            finally {
+              active--
+              if (index >= clientFiles.length && active === 0)
+                resolve()
+              else
+                next()
+            }
+          })()
+        }
+
+        if (clientFiles.length === 0)
+          resolve()
+      }
+
+      next()
+    })
+
+    if (errors.length > 0)
+      throw errors[0]
+
+    const manifestPath = path.join(ssrOutDir, 'manifest.json')
+    await fs.promises.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8')
+  }
+
+  private extractExportNames(code: string): string[] {
+    const exports: string[] = []
+    if (/export\s+default\b/.test(code))
+      exports.push('default')
+    const namedExportRegex = /export\s+(?:function|const|let|var|class)\s+(\w+)/g
+    for (const m of code.matchAll(namedExportRegex)) {
+      exports.push(m[1])
+    }
+
+    return exports.length > 0 ? exports : ['default']
+  }
+
+  private async buildSSRSingleClient(
+    inputPath: string,
+    outputPath: string,
+  ): Promise<{ code: string }> {
+    const originalCode = await fs.promises.readFile(inputPath, 'utf-8')
+    const strippedCode = originalCode.replace(/^['"]use client['"];?\s*/m, '')
+
+    const ext = path.extname(inputPath)
+    let loader: 'tsx' | 'jsx' | 'ts' | 'js'
+    if (ext === '.tsx')
+      loader = 'tsx'
+    else if (ext === '.ts')
+      loader = 'ts'
+    else if (ext === '.jsx')
+      loader = 'jsx'
+    else
+      loader = 'js'
+
+    const virtualModuleId = `\0ssr-virtual:${inputPath}`
+    const projectRoot = this.projectRoot
+
+    const VIRTUAL_REACT = '\0ssr-react'
+    const VIRTUAL_JSX_RUNTIME = '\0ssr-jsx-runtime'
+
+    const result = await build({
+      input: virtualModuleId,
+      platform: 'node',
+      write: false,
+      external: [
+        NODE_PROTOCOL_REGEX,
+        'react-dom',
+        /^rari/,
+      ],
+      output: {
+        format: 'esm',
+        minify: false,
+      },
+      moduleTypes: {
+        [`.${loader}`]: loader,
+      },
+      resolve: {
+        mainFields: ['module', 'main'],
+        conditionNames: ['import', 'module', 'default'],
+        extensions: ['.ts', '.tsx', '.js', '.jsx'],
+      },
+      transform: {
+        jsx: 'react-jsx',
+        define: {
+          'global': 'globalThis',
+          'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'production'),
+        },
+      },
+      plugins: [
+        {
+          name: 'ssr-client-virtual',
+          resolveId(id) {
+            if (id === virtualModuleId)
+              return id
+            if (id === 'react')
+              return VIRTUAL_REACT
+            if (id === 'react/jsx-runtime' || id === 'react/jsx-dev-runtime')
+              return VIRTUAL_JSX_RUNTIME
+
+            return null
+          },
+          load(id) {
+            if (id === virtualModuleId)
+              return { code: strippedCode, moduleType: loader }
+            if (id === VIRTUAL_REACT)
+              return { code: 'const React = globalThis.React; export default React; export const { createElement, Fragment, Suspense, createContext, useContext, useState, useEffect, useRef, useMemo, useCallback, useReducer, useId, useTransition, useActionState, useDeferredValue, useImperativeHandle, useLayoutEffect, useDebugValue, useSyncExternalStore, useOptimistic, use, forwardRef, memo, lazy, startTransition, Children, cloneElement, isValidElement, createRef, act, cache, Component, PureComponent } = React;', moduleType: 'js' }
+            if (id === VIRTUAL_JSX_RUNTIME)
+              return { code: 'const React = globalThis.React; export const jsx = React.createElement; export const jsxs = React.createElement; export const jsxDEV = React.createElement; export const Fragment = React.Fragment;', moduleType: 'js' }
+
+            return null
+          },
+        },
+        {
+          name: 'ssr-client-resolve',
+          resolveId(id, importer) {
+            if (id.startsWith('.') || id.startsWith('/') || id.startsWith('@/')) {
+              let resolved = id
+              if (id.startsWith('@/'))
+                resolved = path.join(projectRoot, 'src', id.slice(2))
+              else if (importer === virtualModuleId)
+                resolved = path.resolve(path.dirname(inputPath), id)
+              else if (importer)
+                resolved = path.resolve(path.dirname(importer.replace('\0ssr-virtual:', '')), id)
+
+              const found = resolveWithExtensions(resolved, ['.ts', '.tsx', '.js', '.jsx'])
+                || resolveIndexFile(resolved, ['.ts', '.tsx', '.js', '.jsx'])
+              return found || null
+            }
+
+            return null
+          },
+        },
+      ],
+    })
+
+    const output = result.output[0]
+    const code = typeof output === 'object' && 'code' in output ? output.code : ''
+
+    await fs.promises.writeFile(outputPath, code, 'utf-8')
+    return { code }
+  }
+
   private async buildSingleComponent(
     inputPath: string,
     outputPath: string,
@@ -1783,6 +1993,7 @@ export function createServerBuildPlugin(
     async closeBundle() {
       if (builder) {
         await builder.buildServerComponents()
+        await builder.buildSSRClientComponents()
 
         try {
           const { generateRobotsFile } = await import('../router/robots-generator')

--- a/packages/rari/src/vite/server-build.ts
+++ b/packages/rari/src/vite/server-build.ts
@@ -1294,14 +1294,16 @@ export default registerClientReference(null, ${JSON.stringify(componentId)}, "de
 
     scanForClientComponents(srcDir)
 
-    if (clientFiles.length === 0)
+    if (clientFiles.length === 0) {
+      const manifestPath = path.join(ssrOutDir, 'manifest.json')
+      await fs.promises.writeFile(manifestPath, '{}', 'utf-8')
       return
+    }
 
     const manifest: Record<string, { id: string, filePath: string, bundlePath: string, exports: string[] }> = {}
     const concurrency = Math.min(8, Math.max(1, (await import('node:os')).cpus().length))
     let active = 0
     let index = 0
-    const errors: Error[] = []
 
     await new Promise<void>((resolve) => {
       const next = () => {
@@ -1347,9 +1349,6 @@ export default registerClientReference(null, ${JSON.stringify(componentId)}, "de
 
       next()
     })
-
-    if (errors.length > 0)
-      throw errors[0]
 
     const manifestPath = path.join(ssrOutDir, 'manifest.json')
     await fs.promises.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8')


### PR DESCRIPTION
Added support for server-side rendering (SSR) of client components by introducing a new `ssrRenderComponent` function. This function dynamically imports and renders client components based on the SSR manifest, allowing for improved hydration and rendering of client-side content. Updated the rendering logic to handle module imports and ensure proper execution of client components during SSR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side rendering available for client components via generated SSR bundles and manifest loaded at startup.
  * Client now hydrates existing server-rendered DOM when present to preserve state.

* **Refactor**
  * Streaming renderer can invoke JS-backed SSR for referenced client components and falls back to placeholders/children when unavailable.
  * Added runtime support to register and invoke SSR client component modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->