### PR TITLE
feat(cli): add clean command to rari CLI

### DIFF
--- a/packages/create-rari-app/package.json
+++ b/packages/create-rari-app/package.json
@@ -40,7 +40,7 @@
     "templates"
   ],
   "scripts": {
-    "build": "pnpm clean && pnpm typecheck && vp pack",
+    "build": "pnpm --silent clean && pnpm typecheck && vp pack",
     "dev": "vp pack --watch",
     "clean": "node --eval \"import('node:fs').then(fs => fs.rmSync('dist', { recursive: true, force: true }))\"",
     "lint": "vp lint",

--- a/packages/create-rari-app/templates/default/package.json
+++ b/packages/create-rari-app/templates/default/package.json
@@ -14,7 +14,7 @@
     "start": "rari start",
     "deploy:railway": "rari deploy railway",
     "deploy:render": "rari deploy render",
-    "clean": "node --eval \"import('node:fs').then(fs => fs.rmSync('dist', { recursive: true, force: true }))\"",
+    "clean": "rari clean",
     "typecheck": "tsgo"
   },
   "dependencies": {

--- a/packages/rari/package.json
+++ b/packages/rari/package.json
@@ -107,7 +107,7 @@
     "node": ">=22.12.0"
   },
   "scripts": {
-    "build": "pnpm clean && pnpm typecheck && vp pack",
+    "build": "pnpm --silent clean && pnpm typecheck && vp pack",
     "clean": "node --eval \"import('node:fs').then(fs => fs.rmSync('dist', { recursive: true, force: true }))\"",
     "lint": "vp lint",
     "lint:fix": "vp lint --fix",

--- a/packages/rari/src/cli.ts
+++ b/packages/rari/src/cli.ts
@@ -217,15 +217,7 @@ function getDeploymentConfig() {
 }
 
 async function runViteBuild() {
-  const { existsSync, rmSync } = await import('node:fs')
-  const { resolve } = await import('node:path')
-
-  const distPath = resolve(process.cwd(), 'dist')
-
-  if (existsSync(distPath)) {
-    logInfo('Cleaning dist folder...')
-    rmSync(distPath, { recursive: true, force: true })
-  }
+  await cleanDistFolder()
 
   logInfo('Type checking...')
   const typecheckProcess = crossPlatformSpawn('npx', ['tsgo'], {
@@ -458,6 +450,22 @@ async function deployToRender() {
   await createRenderDeployment()
 }
 
+async function cleanDistFolder() {
+  const { existsSync, rmSync } = await import('node:fs')
+  const { resolve } = await import('node:path')
+
+  const distPath = resolve(process.cwd(), 'dist')
+
+  if (existsSync(distPath)) {
+    logInfo('Cleaning dist folder...')
+    rmSync(distPath, { recursive: true, force: true })
+    logSuccess('Cleaned dist folder')
+  }
+  else {
+    logInfo('No dist folder to clean')
+  }
+}
+
 async function main() {
   switch (command) {
     case undefined:
@@ -470,6 +478,7 @@ ${styleText('bold', 'Usage:')}
   ${styleText('cyan', 'rari dev')}                 Start the development server with Vite
   ${styleText('cyan', 'rari build')}               Build for production
   ${styleText('cyan', 'rari start')}               Start the rari server (defaults to production)
+  ${styleText('cyan', 'rari clean')}               Remove the dist folder
   ${styleText('cyan', 'rari deploy railway')}      Setup Railway deployment
   ${styleText('cyan', 'rari deploy render')}       Setup Render deployment
   ${styleText('cyan', 'rari help')}                Show this help message
@@ -486,6 +495,9 @@ ${styleText('bold', 'Examples:')}
 
   ${styleText('gray', '# Build for production')}
   ${styleText('cyan', 'rari build')}
+
+  ${styleText('gray', '# Clean dist folder')}
+  ${styleText('cyan', 'rari clean')}
 
   ${styleText('gray', '# Start production server (default)')}
   ${styleText('cyan', 'rari start')}
@@ -540,6 +552,10 @@ ${styleText('bold', 'Notes:')}
 
     case 'start':
       await startRustServer()
+      break
+
+    case 'clean':
+      await cleanDistFolder()
       break
 
     case 'deploy':

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,7 @@
     "build": "rari build",
     "dev": "rari dev",
     "start": "rari start",
-    "clean": "node --eval \"import('node:fs').then(fs => fs.rmSync('dist', { recursive: true, force: true }))\"",
+    "clean": "rari clean",
     "lint": "vp lint",
     "lint:fix": "vp lint --fix",
     "typecheck": "tsgo"


### PR DESCRIPTION
- Extract dist folder cleanup logic into reusable cleanDistFolder function
- Add `rari clean` command to remove dist folder via CLI
- Update package.json scripts to use `rari clean` instead of inline Node.js code in create-rari-app, default template, and web packages
- Add `--silent` flag to pnpm clean commands in build scripts to reduce output noise
- Update help text and examples to document the new clean command
- Consolidates cleanup logic and provides consistent cross-platform behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `rari clean` command to the CLI for streamlined dist directory cleanup.

* **Chores**
  * Updated build scripts across packages to run silently, reducing console output.
  * Unified cleanup commands to leverage the new `rari clean` command, improving consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->