### PR TITLE
refactor(use-cache): remove internal runtime exports from public API

### DIFF
--- a/packages/use-cache/src/index.ts
+++ b/packages/use-cache/src/index.ts
@@ -1,10 +1,5 @@
 export { detectUseCache, transformUseCache } from './native'
 export type { NativeAddon, TransformOptions, TransformResult } from './native'
 
-export { $$cache__, encodeBoundArgs } from './runtime/cache-wrapper'
-export type { CacheEntry } from './runtime/cache-wrapper'
-
-export { deterministicStringify } from './runtime/deterministic-stringify'
-
 export { transformUseCacheModule } from './transform'
 export type { UseCacheTransformOptions } from './transform'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `detectUseCache` and `transformUseCache` functions to the public API.
  * Added `transformUseCacheModule` utility with `UseCacheTransformOptions` configuration.

* **Breaking Changes**
  * Removed internal cache-wrapper utilities and stringify function from public exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->