### PR TITLE
ci(release): add use-cache addon build and platform-specific npm releases

### DIFF
--- a/.github/templates/package-json/use-cache-platform.json
+++ b/.github/templates/package-json/use-cache-platform.json
@@ -1,8 +1,8 @@
 {
-  "name": "@rari/{NAME}",
+  "name": "@rari/use-cache-{PLATFORM}",
   "type": "module",
   "version": "{VERSION}",
-  "description": "Native 'use cache' transform addon for rari ({DESCRIPTION})",
+  "description": "Native 'use cache' transform addon for rari ({PLATFORM})",
   "author": "Ryan Skinner",
   "license": "MIT",
   "main": "./index.js",
@@ -20,7 +20,7 @@
   ],
   "homepage": "https://github.com/rari-build/rari#readme",
   "repository": {
-    "directory": "packages/{NAME}",
+    "directory": "packages/use-cache-{PLATFORM}",
     "type": "git",
     "url": "git+https://github.com/rari-build/rari.git"
   },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,9 +304,8 @@ jobs:
           mkdir -p packages/use-cache-linux-x64
           cp crates/rari-use-cache/*.linux-x64-gnu.node packages/use-cache-linux-x64/rari_use_cache.node
           cp .github/templates/js/use-cache-platform.js packages/use-cache-linux-x64/index.js
-          sed -e 's/{NAME}/use-cache-linux-x64/g' \
+          sed -e 's/{PLATFORM}/linux-x64/g' \
               -e 's/{VERSION}/0.0.0/g' \
-              -e 's/{DESCRIPTION}/linux-x64/g' \
               -e 's/{OS}/linux/g' \
               -e 's/{CPU}/x64/g' \
               .github/templates/package-json/use-cache-platform.json > packages/use-cache-linux-x64/package.json
@@ -319,9 +318,8 @@ jobs:
           Copy-Item crates/rari-use-cache/*.win32-x64-msvc.node packages/use-cache-win32-x64/rari_use_cache.node
           Copy-Item .github/templates/js/use-cache-platform.js packages/use-cache-win32-x64/index.js
           (Get-Content .github/templates/package-json/use-cache-platform.json) `
-            -replace '\{NAME\}', 'use-cache-win32-x64' `
+            -replace '\{PLATFORM\}', 'win32-x64' `
             -replace '\{VERSION\}', '0.0.0' `
-            -replace '\{DESCRIPTION\}', 'win32-x64' `
             -replace '\{OS\}', 'win32' `
             -replace '\{CPU\}', 'x64' |
             Out-File -FilePath packages/use-cache-win32-x64/package.json -Encoding UTF8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -634,10 +634,24 @@ jobs:
       - name: Publish platform package
         run: |
           PACKAGE_DIR="packages/use-cache-${{ matrix.platform }}"
+          VERSION="${GITHUB_REF#refs/tags/use-cache-binaries@}"
+
           cd "${PACKAGE_DIR}"
           npm pkg fix
-          echo "Publishing @rari/use-cache-${{ matrix.platform }}..."
-          npm publish --access public
+
+          IS_PRERELEASE=$(node -e "
+            const v = '${VERSION}';
+            process.stdout.write(v.includes('-') ? 'true' : 'false');
+          ")
+
+          if [[ "${IS_PRERELEASE}" == "true" ]]; then
+            echo "Publishing @rari/use-cache-${{ matrix.platform }} with tag 'next'..."
+            npm publish --access public --tag next
+          else
+            echo "Publishing @rari/use-cache-${{ matrix.platform }} with tag 'latest'..."
+            npm publish --access public
+          fi
+
           echo "Successfully published @rari/use-cache-${{ matrix.platform }}"
 
   npm-release-use-cache:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
       - 'v*'
       - 'rari@*'
       - 'create-rari-app@*'
+      - '@rari/use-cache@*'
+      - 'use-cache-binaries@*'
   workflow_dispatch:
 
 permissions:
@@ -413,6 +415,286 @@ jobs:
           ")
 
           # pnpm pack resolves catalog: and workspace: protocols
+          TARBALL=$(pnpm pack | tail -1)
+          echo "Packed: ${TARBALL}"
+
+          if [[ "${IS_PRERELEASE}" == "true" ]]; then
+            echo "Publishing with tag 'next'..."
+            npm publish "${TARBALL}" --access public --tag next
+          else
+            echo "Publishing with tag 'latest'..."
+            npm publish "${TARBALL}" --access public
+          fi
+
+  build-use-cache-addons:
+    name: Build use-cache addon for ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    if: startsWith(github.ref, 'refs/tags/use-cache-binaries@') || github.event_name == 'workflow_dispatch'
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: namespace-profile-rari-linux-amd64
+            platform: linux-x64
+          - target: aarch64-unknown-linux-gnu
+            os: namespace-profile-rari-linux-arm64
+            platform: linux-arm64
+          - target: x86_64-apple-darwin
+            os: namespace-profile-rari-macos-arm64
+            platform: darwin-x64
+          - target: aarch64-apple-darwin
+            os: namespace-profile-rari-macos-arm64
+            platform: darwin-arm64
+          - target: x86_64-pc-windows-msvc
+            os: namespace-profile-rari-windows-amd64
+            platform: win32-x64
+          - target: aarch64-pc-windows-msvc
+            os: namespace-profile-rari-windows-amd64
+            platform: win32-arm64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: nightly
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo registry
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cargo/registry/cache
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache cargo index
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cargo/registry/index
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-index-
+
+      - name: Cache cargo build
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: target
+          key: ${{ runner.os }}-${{ matrix.target }}-addon-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-addon-build-
+
+      - name: Build addon
+        run: |
+          cargo build --release --target ${{ matrix.target }} --package rari-use-cache
+        env:
+          AWS_LC_SYS_PREBUILT_NASM: 1
+
+      - name: Prepare addon artifact
+        run: |
+          mkdir -p addon-output
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            cp target/${{ matrix.target }}/release/rari_use_cache.dll addon-output/rari_use_cache.node
+          elif [[ "${{ runner.os }}" == "macOS" ]]; then
+            cp target/${{ matrix.target }}/release/librari_use_cache.dylib addon-output/rari_use_cache.node
+          else
+            cp target/${{ matrix.target }}/release/librari_use_cache.so addon-output/rari_use_cache.node
+          fi
+        shell: bash
+
+      - name: Upload addon artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: use-cache-addon-${{ matrix.platform }}
+          path: addon-output/rari_use_cache.node
+
+  npm-release-use-cache-platform:
+    needs: build-use-cache-addons
+    runs-on: namespace-profile-rari-linux-amd64
+    if: startsWith(github.ref, 'refs/tags/use-cache-binaries@')
+    permissions:
+      contents: read
+      id-token: write
+
+    strategy:
+      matrix:
+        platform:
+          - linux-x64
+          - linux-arm64
+          - darwin-x64
+          - darwin-arm64
+          - win32-x64
+          - win32-arm64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.14.0
+          package-manager-cache: false
+
+      - name: Upgrade npm
+        run: npm install -g npm@latest
+
+      - name: Download platform addon
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: use-cache-addon-${{ matrix.platform }}
+          path: platform-addon
+
+      - name: Prepare platform package
+        run: |
+          PACKAGE_NAME="@rari/use-cache-${{ matrix.platform }}"
+          PACKAGE_DIR="packages/use-cache-${{ matrix.platform }}"
+          VERSION="${GITHUB_REF#refs/tags/use-cache-binaries@}"
+
+          mkdir -p "${PACKAGE_DIR}"
+
+          cp platform-addon/rari_use_cache.node "${PACKAGE_DIR}/rari_use_cache.node"
+          ls -la "${PACKAGE_DIR}/"
+
+          case "${{ matrix.platform }}" in
+            darwin-arm64)
+              OS="darwin"
+              CPU="arm64"
+              PLATFORM_NAME="macOS ARM64 (Apple Silicon)"
+              OS_NAME="macOS"
+              ARCH="ARM64"
+              DESCRIPTION="Apple Silicon Macs (M1, M2, M3, M4)"
+              ;;
+            darwin-x64)
+              OS="darwin"
+              CPU="x64"
+              PLATFORM_NAME="macOS x64 (Intel)"
+              OS_NAME="macOS"
+              ARCH="x64"
+              DESCRIPTION="Intel-based Macs"
+              ;;
+            linux-arm64)
+              OS="linux"
+              CPU="arm64"
+              PLATFORM_NAME="Linux ARM64"
+              OS_NAME="Linux"
+              ARCH="ARM64"
+              DESCRIPTION="ARM64/aarch64 Linux systems"
+              ;;
+            linux-x64)
+              OS="linux"
+              CPU="x64"
+              PLATFORM_NAME="Linux x64"
+              OS_NAME="Linux"
+              ARCH="x64"
+              DESCRIPTION="x86_64 Linux systems"
+              ;;
+            win32-x64)
+              OS="win32"
+              CPU="x64"
+              PLATFORM_NAME="Windows x64"
+              OS_NAME="Windows"
+              ARCH="x64"
+              DESCRIPTION="x86_64 Windows systems"
+              ;;
+            win32-arm64)
+              OS="win32"
+              CPU="arm64"
+              PLATFORM_NAME="Windows ARM64"
+              OS_NAME="Windows"
+              ARCH="ARM64"
+              DESCRIPTION="ARM64 Windows systems"
+              ;;
+          esac
+
+          cp .github/templates/package-json/use-cache-platform.json "${PACKAGE_DIR}/package.json"
+          sed -i "s|{VERSION}|${VERSION}|g" "${PACKAGE_DIR}/package.json"
+          sed -i "s|{PLATFORM}|${{ matrix.platform }}|g" "${PACKAGE_DIR}/package.json"
+          sed -i "s|{OS}|${OS}|g" "${PACKAGE_DIR}/package.json"
+          sed -i "s|{CPU}|${CPU}|g" "${PACKAGE_DIR}/package.json"
+
+          node --input-type=module -e "import { readFileSync, writeFileSync } from 'fs'; const f = '${PACKAGE_DIR}/package.json'; writeFileSync(f, JSON.stringify(JSON.parse(readFileSync(f, 'utf8')), null, 2) + '\n');"
+
+          cp .github/templates/js/use-cache-platform.js "${PACKAGE_DIR}/index.js"
+          sed -i "s|{PLATFORM}|${{ matrix.platform }}|g" "${PACKAGE_DIR}/index.js"
+
+          cp LICENSE "${PACKAGE_DIR}/LICENSE"
+
+          cp .github/templates/readme/use-cache-platform.md "${PACKAGE_DIR}/README.md"
+          sed -i "s|\${PACKAGE_NAME}|use-cache-${{ matrix.platform }}|g" "${PACKAGE_DIR}/README.md"
+          sed -i "s|\${PLATFORM_NAME}|${PLATFORM_NAME}|g" "${PACKAGE_DIR}/README.md"
+          sed -i "s|\${OS_NAME}|${OS_NAME}|g" "${PACKAGE_DIR}/README.md"
+          sed -i "s|\${ARCH}|${ARCH}|g" "${PACKAGE_DIR}/README.md"
+          sed -i "s|\${DESCRIPTION}|${DESCRIPTION}|g" "${PACKAGE_DIR}/README.md"
+
+          echo "✓ Generated package files for ${PACKAGE_NAME}@${VERSION}"
+
+      - name: Publish platform package
+        run: |
+          PACKAGE_DIR="packages/use-cache-${{ matrix.platform }}"
+          cd "${PACKAGE_DIR}"
+          npm pkg fix
+          echo "Publishing @rari/use-cache-${{ matrix.platform }}..."
+          npm publish --access public
+          echo "Successfully published @rari/use-cache-${{ matrix.platform }}"
+
+  npm-release-use-cache:
+    runs-on: namespace-profile-rari-linux-amd64
+    if: startsWith(github.ref, 'refs/tags/@rari/use-cache@')
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Determine package version
+        id: pkg
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#@rari/use-cache@}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "📦 Publishing @rari/use-cache@${VERSION}"
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.14.0
+          package-manager-cache: false
+
+      - name: Upgrade npm
+        run: npm install -g npm@latest
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        env:
+          npm_config_trust_lockfile: 'true'
+
+      - name: Build package
+        run: pnpm --filter "@rari/use-cache" build
+
+      - name: Generate LICENSE
+        run: |
+          PACKAGE_DIR="packages/use-cache"
+          cp LICENSE "${PACKAGE_DIR}/LICENSE"
+
+      - name: Publish to npm
+        run: |
+          cd "packages/use-cache"
+
+          IS_PRERELEASE=$(node -e "
+            const v = '${{ steps.pkg.outputs.version }}';
+            process.stdout.write(v.includes('-') ? 'true' : 'false');
+          ")
+
           TARBALL=$(pnpm pack | tail -1)
           echo "Packed: ${TARBALL}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -409,10 +409,12 @@ jobs:
         run: |
           cd "packages/${{ steps.pkg.outputs.name }}"
 
-          IS_PRERELEASE=$(node -e "
-            const v = '${{ steps.pkg.outputs.version }}';
-            process.stdout.write(v.includes('-') ? 'true' : 'false');
-          ")
+          VERSION="${{ steps.pkg.outputs.version }}"
+          if [[ "${VERSION}" == *"-"* ]]; then
+            IS_PRERELEASE="true"
+          else
+            IS_PRERELEASE="false"
+          fi
 
           # pnpm pack resolves catalog: and workspace: protocols
           TARBALL=$(pnpm pack | tail -1)
@@ -639,10 +641,11 @@ jobs:
           cd "${PACKAGE_DIR}"
           npm pkg fix
 
-          IS_PRERELEASE=$(node -e "
-            const v = '${VERSION}';
-            process.stdout.write(v.includes('-') ? 'true' : 'false');
-          ")
+          if [[ "${VERSION}" == *"-"* ]]; then
+            IS_PRERELEASE="true"
+          else
+            IS_PRERELEASE="false"
+          fi
 
           if [[ "${IS_PRERELEASE}" == "true" ]]; then
             echo "Publishing @rari/use-cache-${{ matrix.platform }} with tag 'next'..."
@@ -704,10 +707,12 @@ jobs:
         run: |
           cd "packages/use-cache"
 
-          IS_PRERELEASE=$(node -e "
-            const v = '${{ steps.pkg.outputs.version }}';
-            process.stdout.write(v.includes('-') ? 'true' : 'false');
-          ")
+          VERSION="${{ steps.pkg.outputs.version }}"
+          if [[ "${VERSION}" == *"-"* ]]; then
+            IS_PRERELEASE="true"
+          else
+            IS_PRERELEASE="false"
+          fi
 
           TARBALL=$(pnpm pack | tail -1)
           echo "Packed: ${TARBALL}"

--- a/tools/release/src/app.rs
+++ b/tools/release/src/app.rs
@@ -270,7 +270,8 @@ impl App {
                 }
                 PublishStep::GeneratingChangelog => {
                     let unit_name = unit.name();
-                    let generates_changelog = matches!(unit_name, "rari" | "create-rari-app");
+                    let generates_changelog =
+                        matches!(unit_name, "rari" | "create-rari-app" | "@rari/use-cache");
 
                     if generates_changelog {
                         if self.dry_run {
@@ -320,8 +321,10 @@ impl App {
                                 git::add_and_commit(&message, paths[0]).await?;
                             }
 
-                            let generates_changelog =
-                                matches!(unit.name(), "rari" | "create-rari-app");
+                            let generates_changelog = matches!(
+                                unit.name(),
+                                "rari" | "create-rari-app" | "@rari/use-cache"
+                            );
                             let mut files_to_add = Vec::new();
                             if generates_changelog {
                                 let changelog_path = unit.paths()[0].join("CHANGELOG.md");

--- a/tools/release/src/app.rs
+++ b/tools/release/src/app.rs
@@ -62,12 +62,21 @@ impl App {
         let binary_version = rari_pkg.current_version.clone();
         let binary_group = PackageGroup::new_virtual("rari-binaries".to_string(), binary_version);
 
+        let use_cache_pkg = Package::load("@rari/use-cache", "packages/use-cache").await?;
+        let use_cache_binary_version = use_cache_pkg.current_version.clone();
+        let use_cache_binary_group = PackageGroup::new_virtual(
+            "@rari/use-cache-binaries".to_string(),
+            use_cache_binary_version,
+        );
+
         let mut release_units = vec![
             ReleaseUnit::Single(rari_pkg),
             ReleaseUnit::Single(
                 Package::load("create-rari-app", "packages/create-rari-app").await?,
             ),
             ReleaseUnit::Virtual(binary_group),
+            ReleaseUnit::Single(use_cache_pkg),
+            ReleaseUnit::Virtual(use_cache_binary_group),
         ];
 
         if let Some(only_list) = only {
@@ -288,6 +297,8 @@ impl App {
                     let message = format!("release: {}@{}", unit.name(), version);
                     let tag = if unit.name() == "rari-binaries" {
                         format!("v{}", version)
+                    } else if unit.name() == "@rari/use-cache-binaries" {
+                        format!("use-cache-binaries@{}", version)
                     } else {
                         format!("{}@{}", unit.name(), version)
                     };
@@ -358,6 +369,8 @@ impl App {
 
                     let tag = if unit.name() == "rari-binaries" {
                         format!("v{}", version)
+                    } else if unit.name() == "@rari/use-cache-binaries" {
+                        format!("use-cache-binaries@{}", version)
                     } else {
                         format!("{}@{}", unit.name(), version)
                     };

--- a/tools/release/src/changelog.rs
+++ b/tools/release/src/changelog.rs
@@ -15,6 +15,9 @@ pub async fn generate(tag: &str, package_name: &str, package_path: &Path) -> Res
     if package_name == "rari" {
         args.push("--include-path".to_string());
         args.push("crates/rari/**".to_string());
+    } else if package_name == "@rari/use-cache" {
+        args.push("--include-path".to_string());
+        args.push("crates/rari-use-cache/**".to_string());
     }
 
     args.push("--output".to_string());
@@ -73,6 +76,20 @@ pub async fn generate_release_notes(
             args.push("packages/create-rari-app/**".to_string());
             args.push("--tag-pattern".to_string());
             args.push("^create-rari-app@".to_string());
+        } else if package_name == "@rari/use-cache" {
+            args.push("--include-path".to_string());
+            args.push("packages/use-cache/**".to_string());
+            args.push("--include-path".to_string());
+            args.push("crates/rari-use-cache/**".to_string());
+            args.push("--tag-pattern".to_string());
+            args.push("^@rari/use-cache@".to_string());
+        } else if package_name == "@rari/use-cache-binaries" {
+            args.push("--include-path".to_string());
+            args.push("crates/rari-use-cache/**".to_string());
+            args.push("--include-path".to_string());
+            args.push("packages/use-cache-*/**".to_string());
+            args.push("--tag-pattern".to_string());
+            args.push("^use-cache-binaries@".to_string());
         }
 
         if let Some(ref r) = range {

--- a/tools/release/src/git.rs
+++ b/tools/release/src/git.rs
@@ -3,7 +3,13 @@ use std::path::Path;
 use tokio::process::Command;
 
 fn tag_pattern_for(package_name: &str) -> String {
-    if package_name == "rari-binaries" { "v*".to_string() } else { format!("{}@*", package_name) }
+    if package_name == "rari-binaries" {
+        "v*".to_string()
+    } else if package_name == "@rari/use-cache-binaries" {
+        "use-cache-binaries@*".to_string()
+    } else {
+        format!("{}@*", package_name)
+    }
 }
 
 pub async fn get_recent_commits(package_path: &Path, limit: usize) -> Result<Vec<String>> {
@@ -64,6 +70,38 @@ pub async fn get_commits_since_tag(package_name: &str, package_path: &Path) -> R
                 let stdout = String::from_utf8_lossy(&output.stdout);
                 anyhow::bail!(
                     "Failed to get git log for rari-binaries (range: {}):\nstdout: {}\nstderr: {}",
+                    range,
+                    stdout,
+                    stderr
+                );
+            }
+
+            Ok(String::from_utf8_lossy(&output.stdout).lines().map(String::from).collect())
+        } else if package_name == "@rari/use-cache-binaries" {
+            let output = Command::new("git")
+                .args([
+                    "log",
+                    &range,
+                    "--oneline",
+                    "--grep=^release:",
+                    "--invert-grep",
+                    "--",
+                    "crates/rari-use-cache/",
+                    "packages/use-cache-darwin-arm64/",
+                    "packages/use-cache-darwin-x64/",
+                    "packages/use-cache-linux-arm64/",
+                    "packages/use-cache-linux-x64/",
+                    "packages/use-cache-win32-arm64/",
+                    "packages/use-cache-win32-x64/",
+                ])
+                .output()
+                .await?;
+
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                anyhow::bail!(
+                    "Failed to get git log for @rari/use-cache-binaries (range: {}):\nstdout: {}\nstderr: {}",
                     range,
                     stdout,
                     stderr

--- a/tools/release/src/main.rs
+++ b/tools/release/src/main.rs
@@ -125,10 +125,17 @@ async fn run_non_interactive(
     let binary_version = rari_pkg.current_version.clone();
     let binary_group = PackageGroup::new_virtual("rari-binaries".to_string(), binary_version);
 
+    let use_cache_pkg = Package::load("@rari/use-cache", "packages/use-cache").await?;
+    let use_cache_binary_version = use_cache_pkg.current_version.clone();
+    let use_cache_binary_group =
+        PackageGroup::new_virtual("@rari/use-cache-binaries".to_string(), use_cache_binary_version);
+
     let mut release_units = vec![
         ReleaseUnit::Single(rari_pkg),
         ReleaseUnit::Single(Package::load("create-rari-app", "packages/create-rari-app").await?),
         ReleaseUnit::Virtual(binary_group),
+        ReleaseUnit::Single(use_cache_pkg),
+        ReleaseUnit::Virtual(use_cache_binary_group),
     ];
 
     if let Some(only_list) = &only {
@@ -206,7 +213,8 @@ async fn run_non_interactive(
             println!("  {} Updated version", "✓".green());
         }
 
-        let generates_changelog = matches!(unit_name, "rari" | "create-rari-app");
+        let generates_changelog =
+            matches!(unit_name, "rari" | "create-rari-app" | "@rari/use-cache");
         if dry_run {
             if generates_changelog {
                 println!("  {} Would generate changelog...", "[DRY RUN]".yellow());
@@ -229,6 +237,8 @@ async fn run_non_interactive(
         let message = format!("release: {}@{}", unit_name, new_version);
         let tag = if unit_name == "rari-binaries" {
             format!("v{}", new_version)
+        } else if unit_name == "@rari/use-cache-binaries" {
+            format!("use-cache-binaries@{}", new_version)
         } else {
             format!("{}@{}", unit_name, new_version)
         };
@@ -246,7 +256,8 @@ async fn run_non_interactive(
                 crate::git::add_and_commit(&message, paths[0]).await?;
             }
 
-            let generates_changelog = matches!(unit_name, "rari" | "create-rari-app");
+            let generates_changelog =
+                matches!(unit_name, "rari" | "create-rari-app" | "@rari/use-cache");
             let mut files_to_add = Vec::new();
             if generates_changelog && let Some(first_path) = unit.paths().first() {
                 let changelog_path = first_path.join("CHANGELOG.md");

--- a/tools/release/src/package.rs
+++ b/tools/release/src/package.rs
@@ -197,6 +197,11 @@ impl ReleasedPackage {
     pub fn create_github_release_url(&self, owner: &str, repo: &str) -> String {
         let (title_text, tag_text) = if self.name == "rari-binaries" {
             (format!("v{}", self.version), format!("v{}", self.version))
+        } else if self.name == "@rari/use-cache-binaries" {
+            (
+                format!("use-cache-binaries@{}", self.version),
+                format!("use-cache-binaries@{}", self.version),
+            )
         } else {
             (format!("{}@{}", self.name, self.version), self.tag.clone())
         };


### PR DESCRIPTION
- Add use-cache-binaries tag trigger to release workflow for addon builds
- Implement build-use-cache-addons job to compile native bindings for all target platforms (linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64, win32-arm64)
- Add npm-release-use-cache-platform job to publish platform-specific @rari/use-cache-* packages with native bindings
- Update package.json template to use consistent {PLATFORM} placeholder instead of {NAME} and {DESCRIPTION}
- Refactor release tool to generate platform-specific package metadata and tarball creation
- Add git tag parsing for use-cache-binaries@ release trigger
- Support multi-platform addon distribution with proper artifact naming and OS-specific binary handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated releases for the `@rari/use-cache` ecosystem, publishing an umbrella `@rari/use-cache` package plus platform-scoped packages (`@rari/use-cache-{platform}`).
  * Platform-native artifacts are produced and released consistently per target, and release notes/changelogs now include `@rari/use-cache`.

* **Chores**
  * Updated release tooling and CI packaging templates so `use-cache` platform variants use correct platform-specific naming and metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->