### PR TITLE
refactor(rari): consolidate clippy allow attributes to module level

### DIFF
--- a/crates/rari/src/lib.rs
+++ b/crates/rari/src/lib.rs
@@ -10,30 +10,6 @@
 #![expect(clippy::items_after_statements)]
 #![expect(clippy::unused_async)]
 #![expect(clippy::needless_pass_by_ref_mut)]
-#![cfg_attr(test, allow(clippy::allow_attributes))]
-#![cfg_attr(
-    test,
-    allow(
-        clippy::unreadable_literal,
-        clippy::needless_raw_string_hashes,
-        clippy::panic,
-        clippy::expect_used,
-        clippy::unwrap_used,
-        clippy::print_stdout,
-        clippy::float_cmp,
-        clippy::bool_assert_comparison,
-        clippy::redundant_clone,
-        clippy::redundant_closure_for_method_calls,
-        clippy::single_char_pattern,
-        clippy::approx_constant,
-        clippy::uninlined_format_args,
-        clippy::module_inception,
-        clippy::return_self_not_must_use,
-        clippy::disallowed_methods,
-        clippy::clone_on_ref_ptr,
-        clippy::get_unwrap,
-    )
-)]
 
 pub mod rsc;
 pub mod runtime;

--- a/crates/rari/src/rsc/actions/mod.rs
+++ b/crates/rari/src/rsc/actions/mod.rs
@@ -1009,9 +1009,27 @@ pub fn build_set_cookie_header(
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
-#[allow(clippy::bool_assert_comparison)]
-#[allow(clippy::approx_constant)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
     use crate::server::config::RedirectConfig;

--- a/crates/rari/src/rsc/components/mod.rs
+++ b/crates/rari/src/rsc/components/mod.rs
@@ -479,7 +479,27 @@ impl Default for ComponentRegistry {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
     use smallvec::smallvec;

--- a/crates/rari/src/rsc/flight/escape.rs
+++ b/crates/rari/src/rsc/flight/escape.rs
@@ -116,7 +116,27 @@ pub fn unescape_rsc_value(value: &Value) -> Value {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
     use serde_json::json;

--- a/crates/rari/src/rsc/flight/parser.rs
+++ b/crates/rari/src/rsc/flight/parser.rs
@@ -310,6 +310,27 @@ impl RscWireFormatParser {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/rsc/flight/serializer/mod.rs
+++ b/crates/rari/src/rsc/flight/serializer/mod.rs
@@ -1576,8 +1576,27 @@ impl SerializedReactElement {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
-#[allow(clippy::module_inception)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
     use crate::rsc::ServerComponentExecutor;

--- a/crates/rari/src/rsc/rendering/core/mod.rs
+++ b/crates/rari/src/rsc/rendering/core/mod.rs
@@ -9,8 +9,27 @@ pub use renderer::RscRenderer;
 pub use types::{ResourceLimits, ResourceMetrics, ResourceTracker};
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
-#[allow(clippy::module_inception)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use smallvec::SmallVec;
     use std::sync::Arc;

--- a/crates/rari/src/rsc/rendering/html/mod.rs
+++ b/crates/rari/src/rsc/rendering/html/mod.rs
@@ -2220,7 +2220,27 @@ impl Default for RscToHtmlConverter {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/rsc/rendering/layout/core.rs
+++ b/crates/rari/src/rsc/rendering/layout/core.rs
@@ -1258,7 +1258,27 @@ if (typeof window !== 'undefined') {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
     use crate::server::cache::handler::NoOpCacheHandler;

--- a/crates/rari/src/rsc/rendering/layout/mod.rs
+++ b/crates/rari/src/rsc/rendering/layout/mod.rs
@@ -12,7 +12,27 @@ pub use types::*;
 pub use utils::create_layout_context;
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
     use crate::rsc::rendering::core::RscRenderer;

--- a/crates/rari/src/rsc/rendering/layout/route_composer.rs
+++ b/crates/rari/src/rsc/rendering/layout/route_composer.rs
@@ -259,6 +259,27 @@ impl RouteComposer {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/rsc/rendering/sanitizer.rs
+++ b/crates/rari/src/rsc/rendering/sanitizer.rs
@@ -20,6 +20,27 @@ pub fn sanitize_component_output(html: &str) -> String {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/rsc/rendering/streaming/mod.rs
+++ b/crates/rari/src/rsc/rendering/streaming/mod.rs
@@ -14,8 +14,27 @@ pub use types::*;
 pub use validation::validate_suspense_boundaries;
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
-#[allow(clippy::module_inception)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::boundary_manager::SuspenseBoundaryManager;
     use super::types::*;

--- a/crates/rari/src/rsc/rendering/streaming/renderer.rs
+++ b/crates/rari/src/rsc/rendering/streaming/renderer.rs
@@ -1671,7 +1671,27 @@ impl StreamingRenderer {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/rsc/types/elements.rs
+++ b/crates/rari/src/rsc/types/elements.rs
@@ -30,6 +30,7 @@ impl ReactElement {
     }
 
     #[cfg(test)]
+    #[must_use]
     pub fn with_key(mut self, key: impl Into<String>) -> Self {
         self.key = Some(key.into());
         self
@@ -47,7 +48,27 @@ impl ReactElement {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
     use serde_json::json;

--- a/crates/rari/src/rsc/types/tree.rs
+++ b/crates/rari/src/rsc/types/tree.rs
@@ -36,7 +36,7 @@ impl RSCTree {
     pub fn client_reference(id: &str, key: Option<&str>, props: FxHashMap<String, Value>) -> Self {
         RSCTree::ClientReference {
             id: id.to_string(),
-            key: key.map(|k| k.to_string()),
+            key: key.map(ToString::to_string),
             props,
         }
     }
@@ -52,7 +52,7 @@ impl RSCTree {
             tag: tag.to_string(),
             props,
             children,
-            key: key.map(|k| k.to_string()),
+            key: key.map(ToString::to_string),
         }
     }
 
@@ -396,7 +396,27 @@ impl RSCRenderResult {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
     use serde_json::json;

--- a/crates/rari/src/rsc/utils/dependencies.rs
+++ b/crates/rari/src/rsc/utils/dependencies.rs
@@ -45,6 +45,27 @@ pub fn hash_string(s: &str) -> String {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/runtime/module/loader/cache.rs
+++ b/crates/rari/src/runtime/module/loader/cache.rs
@@ -118,7 +118,27 @@ impl ModuleCaching {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/runtime/module/loader/resolver.rs
+++ b/crates/rari/src/runtime/module/loader/resolver.rs
@@ -80,6 +80,27 @@ impl Default for ModuleResolver {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/runtime/module/loader/transpiler.rs
+++ b/crates/rari/src/runtime/module/loader/transpiler.rs
@@ -21,6 +21,27 @@ pub fn get_module_type(_specifier: &str) -> &'static str {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/runtime/ops.rs
+++ b/crates/rari/src/runtime/ops.rs
@@ -223,7 +223,6 @@ pub fn create_element_operation(row_id: &str, element: &serde_json::Value) -> St
     .to_string()
 }
 
-#[allow(clippy::disallowed_methods)]
 #[cfg(test)]
 pub fn create_symbol_operation(row_id: &str, symbol_ref: &str) -> String {
     serde_json::json!({
@@ -234,7 +233,6 @@ pub fn create_symbol_operation(row_id: &str, symbol_ref: &str) -> String {
     .to_string()
 }
 
-#[allow(clippy::disallowed_methods)]
 #[cfg(test)]
 pub fn create_error_operation(
     row_id: &str,
@@ -661,7 +659,27 @@ pub fn op_cache_set(
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
     use tokio::sync::mpsc;

--- a/crates/rari/src/server/cache/handler.rs
+++ b/crates/rari/src/server/cache/handler.rs
@@ -499,7 +499,27 @@ impl CacheHandlerRegistry {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
     use std::sync::Arc;

--- a/crates/rari/src/server/cache/response.rs
+++ b/crates/rari/src/server/cache/response.rs
@@ -500,7 +500,27 @@ mod header_map_serde {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
     use crate::server::cache::handler::{CacheError, SetOutcome};

--- a/crates/rari/src/server/compression/stream.rs
+++ b/crates/rari/src/server/compression/stream.rs
@@ -258,7 +258,27 @@ impl GzipCompressor {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
     use futures::stream;

--- a/crates/rari/src/server/config/mod.rs
+++ b/crates/rari/src/server/config/mod.rs
@@ -972,7 +972,27 @@ pub enum ConfigError {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/server/core/types/request.rs
+++ b/crates/rari/src/server/core/types/request.rs
@@ -29,6 +29,27 @@ impl RequestTypeDetector {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
     use axum::http::{HeaderMap, HeaderValue};

--- a/crates/rari/src/server/core/utils/http.rs
+++ b/crates/rari/src/server/core/utils/http.rs
@@ -261,7 +261,27 @@ pub fn add_api_security_headers(headers: &mut axum::http::HeaderMap) {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/server/core/utils/path_validation.rs
+++ b/crates/rari/src/server/core/utils/path_validation.rs
@@ -133,7 +133,27 @@ pub fn validate_component_path(file_path: &str) -> Result<(), RariError> {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
     use std::fs;

--- a/crates/rari/src/server/image/cache.rs
+++ b/crates/rari/src/server/image/cache.rs
@@ -189,7 +189,27 @@ impl ImageCache {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
     use std::env::temp_dir;

--- a/crates/rari/src/server/middleware/request_context.rs
+++ b/crates/rari/src/server/middleware/request_context.rs
@@ -310,6 +310,27 @@ impl RequestContext {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/server/og/cache.rs
+++ b/crates/rari/src/server/og/cache.rs
@@ -168,7 +168,27 @@ impl OgImageCache {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
     use std::env::temp_dir;

--- a/crates/rari/src/server/og/generator.rs
+++ b/crates/rari/src/server/og/generator.rs
@@ -421,6 +421,7 @@ impl OgImageGenerator {
     }
 
     #[cfg(test)]
+    #[expect(clippy::expect_used)]
     pub async fn clear_cache(&self) {
         self.cache.clear().await.expect("clear");
     }
@@ -434,7 +435,27 @@ impl OgImageGenerator {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/server/og/layout/style/gradient.rs
+++ b/crates/rari/src/server/og/layout/style/gradient.rs
@@ -401,7 +401,27 @@ pub struct GradientParams {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/server/og/rendering/svg.rs
+++ b/crates/rari/src/server/og/rendering/svg.rs
@@ -265,7 +265,27 @@ fn escape_xml(s: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/server/og/resources/fonts.rs
+++ b/crates/rari/src/server/og/resources/fonts.rs
@@ -129,6 +129,27 @@ impl FontContext {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/server/rendering/metadata.rs
+++ b/crates/rari/src/server/rendering/metadata.rs
@@ -101,7 +101,27 @@ pub fn finalize_metadata(metadata: &mut Value) {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
     use serde_json::json;

--- a/crates/rari/src/server/rendering/metadata_injection.rs
+++ b/crates/rari/src/server/rendering/metadata_injection.rs
@@ -558,6 +558,27 @@ pub fn inject_metadata(
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
     use crate::rsc::rendering::layout::types::{

--- a/crates/rari/src/server/rendering/streaming_response.rs
+++ b/crates/rari/src/server/rendering/streaming_response.rs
@@ -77,7 +77,27 @@ impl IntoResponse for StreamingHtmlResponse {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
     use async_stream::stream;

--- a/crates/rari/src/server/routing/api_routes.rs
+++ b/crates/rari/src/server/routing/api_routes.rs
@@ -687,7 +687,27 @@ impl ApiRouteHandler {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
     use axum::http::HeaderValue;

--- a/crates/rari/src/server/routing/app_router.rs
+++ b/crates/rari/src/server/routing/app_router.rs
@@ -738,7 +738,27 @@ impl AppRouter {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/server/routing/types.rs
+++ b/crates/rari/src/server/routing/types.rs
@@ -57,7 +57,27 @@ impl ParamValue {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
     use rustc_hash::FxHashMap;

--- a/crates/rari/src/server/vite/mod.rs
+++ b/crates/rari/src/server/vite/mod.rs
@@ -427,6 +427,27 @@ pub async fn check_vite_server_health() -> Result<(), RariError> {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::unreadable_literal,
+    clippy::needless_raw_string_hashes,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::print_stdout,
+    clippy::float_cmp,
+    clippy::bool_assert_comparison,
+    clippy::redundant_clone,
+    clippy::redundant_closure_for_method_calls,
+    clippy::single_char_pattern,
+    clippy::approx_constant,
+    clippy::uninlined_format_args,
+    clippy::module_inception,
+    clippy::return_self_not_must_use,
+    clippy::disallowed_methods,
+    clippy::clone_on_ref_ptr,
+    clippy::get_unwrap
+)]
 mod tests {
     use super::*;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Cleaned up test lint settings across the codebase for consistency.
  * Standardized how test-only warnings are handled in several areas.

* **Style**
  * Expanded lint allowances for test code to reduce unnecessary warning noise during builds.

* **Chores**
  * Small internal maintenance updates only; no user-facing behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->