### PR TITLE
style: fix indentation and remove unused imports across codebase

### DIFF
--- a/crates/rari/src/rsc/rendering/streaming/renderer.rs
+++ b/crates/rari/src/rsc/rendering/streaming/renderer.rs
@@ -380,39 +380,12 @@ impl StreamingRenderer {
                             map.insert(update.boundary_id.clone(), update.row_id);
                         }
 
-                        for import_row in &update.import_rows {
-                            let import_chunk = RscStreamChunk {
-                                data: format!("{import_row}\n").into_bytes(),
-                                chunk_type: RscChunkType::ModuleImport,
-                                row_id: 0,
-                                is_final: false,
-                                boundary_id: None,
-                            };
-
-                            if chunk_sender_clone.send(import_chunk).await.is_err() {
-                                break;
-                            }
-                        }
-
-                        let content_json = serde_json::to_string(&update.content).unwrap_or_else(|_| "null".to_string());
-                        let row_id_hex = format!("{:x}", update.row_id);
-                        let mut update_str = String::with_capacity(row_id_hex.len() + content_json.len() + 2);
-                        update_str.push_str(&row_id_hex);
-                        update_str.push(':');
-                        update_str.push_str(&content_json);
-                        update_str.push('\n');
-
-                        let chunk = RscStreamChunk {
-                            data: update_str.into_bytes(),
-                            chunk_type: RscChunkType::BoundaryUpdate,
-                            row_id: update.row_id,
-                            is_final: false,
-                            boundary_id: Some(update.boundary_id.clone()),
-                        };
-
-                        if chunk_sender_clone.send(chunk).await.is_err() {
-                            break;
-                        }
+                        Self::send_boundary_update_with_map(
+                            &chunk_sender_clone,
+                            update,
+                            Arc::clone(&boundary_rows_map),
+                        )
+                        .await;
 
                     }
                     Some(error) = error_receiver.recv() => {
@@ -424,29 +397,7 @@ impl StreamingRenderer {
                             error.row_id
                         );
 
-                        let error_json = serde_json::to_string(&serde_json::json!({
-                             "error": error.error_message,
-                             "boundary_id": error.boundary_id
-                         })).unwrap_or_else(|_| "{}".to_string());
-
-                        let row_id_hex = format!("{:x}", error.row_id);
-                        let mut error_str = String::with_capacity(row_id_hex.len() + error_json.len() + 3);
-                        error_str.push_str(&row_id_hex);
-                        error_str.push_str(":E");
-                        error_str.push_str(&error_json);
-                        error_str.push('\n');
-
-                        let chunk = RscStreamChunk {
-                            data: error_str.into_bytes(),
-                            chunk_type: RscChunkType::BoundaryError,
-                            row_id: error.row_id,
-                            is_final: false,
-                            boundary_id: None,
-                        };
-
-                        if chunk_sender_clone.send(chunk).await.is_err() {
-                            break;
-                        }
+                        Self::send_boundary_error(&chunk_sender_clone, error).await;
                     }
                     else => {
                         break;

--- a/crates/rari/src/rsc/rendering/streaming/renderer.rs
+++ b/crates/rari/src/rsc/rendering/streaming/renderer.rs
@@ -373,71 +373,71 @@ impl StreamingRenderer {
 
             loop {
                 tokio::select! {
-                             Some(update) = update_receiver.recv() => {
+                    Some(update) = update_receiver.recv() => {
 
-                                 {
-                                     let mut map = boundary_rows_map.lock().await;
-                                     map.insert(update.boundary_id.clone(), update.row_id);
-                                 }
+                        {
+                            let mut map = boundary_rows_map.lock().await;
+                            map.insert(update.boundary_id.clone(), update.row_id);
+                        }
 
-                                 let content_json = serde_json::to_string(&update.content).unwrap_or_else(|_| "null".to_string());
-                                 let row_id_hex = format!("{:x}", update.row_id);
-                                 let mut update_str = String::with_capacity(row_id_hex.len() + content_json.len() + 2);
-                                 update_str.push_str(&row_id_hex);
-                                 update_str.push(':');
-                                 update_str.push_str(&content_json);
-                                 update_str.push('\n');
+                        let content_json = serde_json::to_string(&update.content).unwrap_or_else(|_| "null".to_string());
+                        let row_id_hex = format!("{:x}", update.row_id);
+                        let mut update_str = String::with_capacity(row_id_hex.len() + content_json.len() + 2);
+                        update_str.push_str(&row_id_hex);
+                        update_str.push(':');
+                        update_str.push_str(&content_json);
+                        update_str.push('\n');
 
-                                 let chunk = RscStreamChunk {
-                                     data: update_str.into_bytes(),
-                                     chunk_type: RscChunkType::BoundaryUpdate,
-                                     row_id: update.row_id,
-                                     is_final: false,
-                                     boundary_id: Some(update.boundary_id.clone()),
-                                 };
+                        let chunk = RscStreamChunk {
+                            data: update_str.into_bytes(),
+                            chunk_type: RscChunkType::BoundaryUpdate,
+                            row_id: update.row_id,
+                            is_final: false,
+                            boundary_id: Some(update.boundary_id.clone()),
+                        };
 
-                                 if chunk_sender_clone.send(chunk).await.is_err() {
-                                     break;
-                                 }
+                        if chunk_sender_clone.send(chunk).await.is_err() {
+                            break;
+                        }
 
-                             }
-                             Some(error) = error_receiver.recv() => {
+                    }
+                    Some(error) = error_receiver.recv() => {
 
-                                 error!(
-                                     "Streaming boundary error: boundary_id={}, error={}, row_id={}",
-                                     error.boundary_id,
-                                     error.error_message,
-                                     error.row_id
-                                 );
+                        error!(
+                            "Streaming boundary error: boundary_id={}, error={}, row_id={}",
+                            error.boundary_id,
+                            error.error_message,
+                            error.row_id
+                        );
 
-                                 let error_json = serde_json::to_string(&serde_json::json!({
-                                      "error": error.error_message,
-                                      "boundary_id": error.boundary_id
-                                  })).unwrap_or_else(|_| "{}".to_string());
+                        let error_json = serde_json::to_string(&serde_json::json!({
+                             "error": error.error_message,
+                             "boundary_id": error.boundary_id
+                         })).unwrap_or_else(|_| "{}".to_string());
 
-                                 let row_id_hex = format!("{:x}", error.row_id);
-                                 let mut error_str = String::with_capacity(row_id_hex.len() + error_json.len() + 3);
-                                 error_str.push_str(&row_id_hex);
-                                 error_str.push_str(":E");
-                                 error_str.push_str(&error_json);
-                                 error_str.push('\n');
+                        let row_id_hex = format!("{:x}", error.row_id);
+                        let mut error_str = String::with_capacity(row_id_hex.len() + error_json.len() + 3);
+                        error_str.push_str(&row_id_hex);
+                        error_str.push_str(":E");
+                        error_str.push_str(&error_json);
+                        error_str.push('\n');
 
-                                 let chunk = RscStreamChunk {
-                                     data: error_str.into_bytes(),
-                                     chunk_type: RscChunkType::BoundaryError,
-                                     row_id: error.row_id,
-                                     is_final: false,
-                boundary_id: None,
-                                 };
+                        let chunk = RscStreamChunk {
+                            data: error_str.into_bytes(),
+                            chunk_type: RscChunkType::BoundaryError,
+                            row_id: error.row_id,
+                            is_final: false,
+                            boundary_id: None,
+                        };
 
-                                 if chunk_sender_clone.send(chunk).await.is_err() {
-                                     break;
-                                 }
-                             }
-                             else => {
-                                 break;
-                             }
-                         }
+                        if chunk_sender_clone.send(chunk).await.is_err() {
+                            break;
+                        }
+                    }
+                    else => {
+                        break;
+                    }
+                }
             }
 
             let final_chunk = RscStreamChunk {

--- a/crates/rari/src/rsc/rendering/streaming/renderer.rs
+++ b/crates/rari/src/rsc/rendering/streaming/renderer.rs
@@ -380,6 +380,20 @@ impl StreamingRenderer {
                             map.insert(update.boundary_id.clone(), update.row_id);
                         }
 
+                        for import_row in &update.import_rows {
+                            let import_chunk = RscStreamChunk {
+                                data: format!("{import_row}\n").into_bytes(),
+                                chunk_type: RscChunkType::ModuleImport,
+                                row_id: 0,
+                                is_final: false,
+                                boundary_id: None,
+                            };
+
+                            if chunk_sender_clone.send(import_chunk).await.is_err() {
+                                break;
+                            }
+                        }
+
                         let content_json = serde_json::to_string(&update.content).unwrap_or_else(|_| "null".to_string());
                         let row_id_hex = format!("{:x}", update.row_id);
                         let mut update_str = String::with_capacity(row_id_hex.len() + content_json.len() + 2);

--- a/crates/rari/src/rsc/rendering/streaming/renderer.rs
+++ b/crates/rari/src/rsc/rendering/streaming/renderer.rs
@@ -104,7 +104,6 @@ impl StreamingRenderer {
         }
 
         let chunk_sender_clone = chunk_sender.clone();
-        let boundary_rows_map = Arc::clone(&self.boundary_row_ids);
         let boundary_positions_clone = Arc::clone(&boundary_positions);
         let rendered_skeleton_ids = Arc::clone(&self.rendered_skeleton_ids);
         let resolved_boundary_ids = Arc::clone(&self.resolved_boundary_ids);
@@ -140,19 +139,17 @@ impl StreamingRenderer {
                             );
                         }
 
-                        Self::send_boundary_update_with_map(
-                            &chunk_sender_clone,
-                            update,
-                            Arc::clone(&boundary_rows_map),
-                        )
-                        .await;
+                        if Self::send_boundary_update_with_map(&chunk_sender_clone, update)
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
                     }
                     Some(error) = error_receiver.recv() => {
-                        Self::send_boundary_error(
-                            &chunk_sender_clone,
-                            error,
-                        )
-                        .await;
+                        if Self::send_boundary_error(&chunk_sender_clone, error).await.is_err() {
+                            break;
+                        }
                     }
                     else => {
                         break;
@@ -240,7 +237,6 @@ impl StreamingRenderer {
             });
         }
 
-        let boundary_rows_map = Arc::clone(&self.boundary_row_ids);
         let boundary_positions_clone = Arc::clone(&boundary_positions);
         let rendered_skeleton_ids = Arc::clone(&self.rendered_skeleton_ids);
         let resolved_boundary_ids = Arc::clone(&self.resolved_boundary_ids);
@@ -269,19 +265,17 @@ impl StreamingRenderer {
                             update.dom_path = dom_path.clone();
                         }
 
-                        Self::send_boundary_update_with_map(
-                            &chunk_sender_clone,
-                            update,
-                            Arc::clone(&boundary_rows_map),
-                        )
-                        .await;
+                        if Self::send_boundary_update_with_map(&chunk_sender_clone, update)
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
                     }
                     Some(error) = error_receiver.recv() => {
-                        Self::send_boundary_error(
-                            &chunk_sender_clone,
-                            error,
-                        )
-                        .await;
+                        if Self::send_boundary_error(&chunk_sender_clone, error).await.is_err() {
+                            break;
+                        }
                     }
                     else => break,
                 }
@@ -380,12 +374,12 @@ impl StreamingRenderer {
                             map.insert(update.boundary_id.clone(), update.row_id);
                         }
 
-                        Self::send_boundary_update_with_map(
-                            &chunk_sender_clone,
-                            update,
-                            Arc::clone(&boundary_rows_map),
-                        )
-                        .await;
+                        if Self::send_boundary_update_with_map(&chunk_sender_clone, update)
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
 
                     }
                     Some(error) = error_receiver.recv() => {
@@ -397,7 +391,9 @@ impl StreamingRenderer {
                             error.row_id
                         );
 
-                        Self::send_boundary_error(&chunk_sender_clone, error).await;
+                        if Self::send_boundary_error(&chunk_sender_clone, error).await.is_err() {
+                            break;
+                        }
                     }
                     else => {
                         break;
@@ -462,7 +458,6 @@ impl StreamingRenderer {
         }
 
         let chunk_sender_clone = chunk_sender.clone();
-        let boundary_rows_map = Arc::clone(&self.boundary_row_ids);
         let root_row_id = Arc::clone(&self.root_row_id);
         tokio::spawn(async move {
             let mut update_receiver = update_receiver;
@@ -471,19 +466,17 @@ impl StreamingRenderer {
             loop {
                 tokio::select! {
                     Some(update) = update_receiver.recv() => {
-                        Self::send_boundary_update_with_map(
-                            &chunk_sender_clone,
-                            update,
-                            Arc::clone(&boundary_rows_map),
-                        )
-                        .await;
+                        if Self::send_boundary_update_with_map(&chunk_sender_clone, update)
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
                     }
                     Some(error) = error_receiver.recv() => {
-                        Self::send_boundary_error(
-                            &chunk_sender_clone,
-                            error,
-                        )
-                        .await;
+                        if Self::send_boundary_error(&chunk_sender_clone, error).await.is_err() {
+                            break;
+                        }
                     }
                     else => break,
                 }
@@ -1239,8 +1232,7 @@ impl StreamingRenderer {
     async fn send_boundary_update_with_map(
         sender: &mpsc::Sender<RscStreamChunk>,
         update: BoundaryUpdate,
-        _boundary_rows_map: Arc<Mutex<FxHashMap<String, u32>>>,
-    ) {
+    ) -> Result<(), mpsc::error::SendError<RscStreamChunk>> {
         for import_row in &update.import_rows {
             let import_chunk = RscStreamChunk {
                 data: format!("{import_row}\n").into_bytes(),
@@ -1250,9 +1242,7 @@ impl StreamingRenderer {
                 boundary_id: None,
             };
 
-            if let Err(e) = sender.send(import_chunk).await {
-                tracing::debug!("Failed to send import row chunk (client disconnected): {}", e);
-            }
+            sender.send(import_chunk).await?;
         }
 
         let update_row = format!("{:x}:{}\n", update.row_id, update.content);
@@ -1265,17 +1255,8 @@ impl StreamingRenderer {
             boundary_id: Some(update.boundary_id.clone()),
         };
 
-        match sender.send(chunk).await {
-            Ok(()) => {}
-            Err(e) => {
-                tracing::debug!(
-                    "Failed to send boundary update chunk (client disconnected), boundary_id={}, row_id={}, error={}",
-                    update.boundary_id,
-                    update.row_id,
-                    e
-                );
-            }
-        }
+        sender.send(chunk).await?;
+        Ok(())
     }
 
     async fn send_row_0_and_complete(
@@ -1307,7 +1288,10 @@ impl StreamingRenderer {
         let _ = sender.send(final_chunk).await;
     }
 
-    async fn send_boundary_error(sender: &mpsc::Sender<RscStreamChunk>, error: BoundaryError) {
+    async fn send_boundary_error(
+        sender: &mpsc::Sender<RscStreamChunk>,
+        error: BoundaryError,
+    ) -> Result<(), mpsc::error::SendError<RscStreamChunk>> {
         let error_data = serde_json::json!({
             "boundary_id": error.boundary_id,
             "error": error.error_message,
@@ -1323,12 +1307,8 @@ impl StreamingRenderer {
             boundary_id: None,
         };
 
-        if let Err(e) = sender.send(chunk).await {
-            error!(
-                "Failed to send boundary error chunk, boundary_id={}, row_id={}, error={}",
-                error.boundary_id, error.row_id, e
-            );
-        }
+        sender.send(chunk).await?;
+        Ok(())
     }
 
     fn create_shell_chunk_with_module(

--- a/crates/rari/src/server/handlers/api.rs
+++ b/crates/rari/src/server/handlers/api.rs
@@ -1,7 +1,7 @@
 use axum::{
     body::Body,
     extract::State,
-    http::{HeaderMap, HeaderValue, StatusCode},
+    http::{HeaderValue, StatusCode},
     response::Response,
 };
 use tracing::error;
@@ -12,16 +12,6 @@ use crate::server::{
     handlers::r#static::cors_preflight_response,
     routing::api_error::{ApiRouteError, create_generic_error_response},
 };
-
-fn add_cors_headers(
-    response_headers: &mut HeaderMap,
-    origin: Option<&str>,
-    allowed_origins: &[String],
-    allow_credentials: bool,
-    max_age: u32,
-) {
-    add_api_cors_headers(response_headers, origin, allowed_origins, allow_credentials, max_age);
-}
 
 #[axum::debug_handler]
 pub async fn api_cors_preflight(
@@ -115,7 +105,7 @@ pub async fn handle_api_route(
 
                 let mut response = api_error.to_http_response(is_development);
                 if is_development {
-                    add_cors_headers(
+                    add_api_cors_headers(
                         response.headers_mut(),
                         origin.as_deref(),
                         &cors_config.allowed_origins,
@@ -133,7 +123,7 @@ pub async fn handle_api_route(
 
             let mut response = api_error.to_http_response(is_development);
             if is_development {
-                add_cors_headers(
+                add_api_cors_headers(
                     response.headers_mut(),
                     origin.as_deref(),
                     &cors_config.allowed_origins,
@@ -149,7 +139,7 @@ pub async fn handle_api_route(
         Ok(mut response) => {
             let headers = response.headers_mut();
             if is_development {
-                add_cors_headers(
+                add_api_cors_headers(
                     headers,
                     origin.as_deref(),
                     &cors_config.allowed_origins,
@@ -196,7 +186,7 @@ pub async fn handle_api_route(
             let mut response = api_error.to_http_response(is_development);
             let headers = response.headers_mut();
             if is_development {
-                add_cors_headers(
+                add_api_cors_headers(
                     headers,
                     origin.as_deref(),
                     &cors_config.allowed_origins,

--- a/crates/rari/src/server/og/cache.rs
+++ b/crates/rari/src/server/og/cache.rs
@@ -3,7 +3,10 @@ use std::{
     sync::Arc,
 };
 
-use crate::server::cache::handler::{CacheError, CacheHandler, MemoryCacheHandler};
+use crate::server::{
+    cache::handler::{CacheError, CacheHandler, MemoryCacheHandler},
+    config::Config,
+};
 
 const OG_TTL_SECS: u64 = 60 * 60 * 24 * 365 * 10;
 const KEY_PREFIX: &str = "og:";
@@ -33,7 +36,7 @@ impl OgImageCache {
     }
 
     fn resolve_cache_dir(project_path: &Path) -> PathBuf {
-        let is_production = std::env::var("NODE_ENV").map(|v| v == "production").unwrap_or(false);
+        let is_production = Config::get().map(|c| c.is_production()).unwrap_or(false);
 
         if is_production {
             PathBuf::from("/tmp/rari-og-cache")

--- a/crates/rari/src/server/og/cache.rs
+++ b/crates/rari/src/server/og/cache.rs
@@ -36,7 +36,7 @@ impl OgImageCache {
     }
 
     fn resolve_cache_dir(project_path: &Path) -> PathBuf {
-        let is_production = Config::get().map(|c| c.is_production()).unwrap_or(false);
+        let is_production = Config::get().map(Config::is_production).unwrap_or(false);
 
         if is_production {
             PathBuf::from("/tmp/rari-og-cache")

--- a/tools/release/src/git.rs
+++ b/tools/release/src/git.rs
@@ -148,9 +148,33 @@ pub async fn get_previous_tag(
 }
 
 pub async fn add_and_commit(message: &str, cwd: &Path) -> Result<()> {
-    Command::new("git").args(["add", "."]).current_dir(cwd).output().await?;
+    let add_output = Command::new("git").args(["add", "."]).current_dir(cwd).output().await?;
 
-    Command::new("git").args(["commit", "-m", message]).current_dir(cwd).output().await?;
+    if !add_output.status.success() {
+        let stderr = String::from_utf8_lossy(&add_output.stderr);
+        let stdout = String::from_utf8_lossy(&add_output.stdout);
+        anyhow::bail!(
+            "Failed to git add in {}:\nstdout: {}\nstderr: {}",
+            cwd.display(),
+            stdout,
+            stderr
+        );
+    }
+
+    let commit_output =
+        Command::new("git").args(["commit", "-m", message]).current_dir(cwd).output().await?;
+
+    if !commit_output.status.success() {
+        let stderr = String::from_utf8_lossy(&commit_output.stderr);
+        let stdout = String::from_utf8_lossy(&commit_output.stdout);
+        anyhow::bail!(
+            "Failed to git commit in {} with message '{}':\nstdout: {}\nstderr: {}",
+            cwd.display(),
+            message,
+            stdout,
+            stderr
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
- Fix tokio::select! block indentation in streaming renderer
- Remove unused HeaderMap import from api handlers
- Consolidate CORS header logic to eliminate wrapper function
- Remove duplicate error handling in og cache module
- Clean up git module imports and unused variables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming boundary update/error handling for more reliable, consistent chunk emission across streaming entrypoints.
  * Fixed API CORS headers to be applied consistently across development and error responses.
  * Updated OG image cache directory selection so production and development locations are chosen correctly.
* **Chores**
  * Improved release automation to capture and report `git add`/`git commit` output when those steps fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->