### PR TITLE
feat(runtime): implement a pooled runtime for JavaScript execution

### DIFF
--- a/crates/rari-utils/src/lib.rs
+++ b/crates/rari-utils/src/lib.rs
@@ -73,7 +73,7 @@ mod tests {
         let url = path_to_file_url(&path);
         assert!(url.starts_with("file:///"));
         assert!(url.contains("C:/"));
-        assert!(!url.contains("\\"));
+        assert!(!url.contains('\\'));
     }
 
     #[test]

--- a/crates/rari/src/runtime/ext/http/runtime.rs
+++ b/crates/rari/src/runtime/ext/http/runtime.rs
@@ -15,7 +15,7 @@ pub enum HttpStartError {
     #[class("Busy")]
     TlsStreamInUse,
     #[class("Busy")]
-    #[cfg_attr(not(unix), allow(dead_code))]
+    #[cfg_attr(not(unix), expect(dead_code))]
     UnixSocketInUse,
     #[class(generic)]
     ReuniteTcp(tokio::net::tcp::ReuniteError),

--- a/crates/rari/src/runtime/ext/io/tty_windows.rs
+++ b/crates/rari/src/runtime/ext/io/tty_windows.rs
@@ -8,7 +8,10 @@ use deno_io::WinTtyState;
 use rustyline::{
     Cmd, Editor, KeyCode, KeyEvent, Modifiers, config::Configurer, error::ReadlineError,
 };
-use windows_sys::Win32::{Foundation::FALSE, System::Console as wincon};
+use windows_sys::Win32::{
+    Foundation::{FALSE, INVALID_HANDLE_VALUE},
+    System::Console as wincon,
+};
 
 deno_core::extension!(deno_tty, ops = [op_set_raw, op_console_size, op_read_line_prompt],);
 
@@ -25,9 +28,9 @@ pub enum TtyError {
 impl std::fmt::Display for TtyError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TtyError::Resource(err) => write!(f, "{}", err),
-            TtyError::Io(err) => write!(f, "{}", err),
-            TtyError::Other(err) => write!(f, "{}", err),
+            TtyError::Resource(err) => write!(f, "{err}"),
+            TtyError::Io(err) => write!(f, "{err}"),
+            TtyError::Other(err) => write!(f, "{err}"),
         }
     }
 }
@@ -89,7 +92,7 @@ fn op_set_raw(state: &mut OpState, rid: u32, is_raw: bool, cbreak: bool) -> Resu
 
     let mut original_mode: u32 = 0;
     // SAFETY: Win32 call
-    if unsafe { wincon::GetConsoleMode(handle, &mut original_mode) } == FALSE {
+    if unsafe { wincon::GetConsoleMode(handle, &raw mut original_mode) } == FALSE {
         return Err(TtyError::Io(Error::last_os_error()));
     }
 
@@ -100,7 +103,7 @@ fn op_set_raw(state: &mut OpState, rid: u32, is_raw: bool, cbreak: bool) -> Resu
     let mut stdin_state = stdin_state.lock();
 
     if stdin_state.reading {
-        let cvar = stdin_state.cvar.clone();
+        let cvar = Arc::clone(&stdin_state.cvar);
 
         /* Trick to unblock an ongoing line-buffered read operation if not already pending.
         See https://github.com/libuv/libuv/pull/866 for prior art */
@@ -119,7 +122,7 @@ fn op_set_raw(state: &mut OpState, rid: u32, is_raw: bool, cbreak: bool) -> Resu
                 record.Event.KeyEvent.uChar.UnicodeChar = '\r' as u16;
                 record.Event.KeyEvent.dwControlKeyState = 0;
                 record.Event.KeyEvent.wVirtualScanCode =
-                    MapVirtualKeyW(VK_RETURN as u32, MAPVK_VK_TO_VSC) as u16;
+                    MapVirtualKeyW(u32::from(VK_RETURN), MAPVK_VK_TO_VSC) as u16;
                 record
             };
             stdin_state.cancelled = true;
@@ -144,15 +147,26 @@ fn op_set_raw(state: &mut OpState, rid: u32, is_raw: bool, cbreak: bool) -> Resu
                     std::ptr::null_mut(),
                 );
 
-                let mut active_screen_buffer = std::mem::zeroed();
-                wincon::GetConsoleScreenBufferInfo(handle, &mut active_screen_buffer);
-                windows_sys::Win32::Foundation::CloseHandle(handle);
-                active_screen_buffer
+                if handle == INVALID_HANDLE_VALUE {
+                    None
+                } else {
+                    let mut active_screen_buffer = std::mem::zeroed();
+                    let ok =
+                        wincon::GetConsoleScreenBufferInfo(handle, &raw mut active_screen_buffer)
+                            != 0;
+                    let _ = windows_sys::Win32::Foundation::CloseHandle(handle);
+                    ok.then_some(active_screen_buffer)
+                }
             };
-            stdin_state.screen_buffer_info = Some(active_screen_buffer);
+            if let Some(buf) = active_screen_buffer {
+                stdin_state.screen_buffer_info = Some(buf);
+            }
 
-            // SAFETY: Win32 call to write the VK_RETURN event.
-            if unsafe { wincon::WriteConsoleInputW(handle, &record, 1, &mut 0) } == FALSE {
+            let mut events_written: u32 = 0;
+            if unsafe {
+                wincon::WriteConsoleInputW(handle, &raw const record, 1, &raw mut events_written)
+            } == FALSE
+            {
                 return Err(TtyError::Io(Error::last_os_error()));
             }
 
@@ -211,19 +225,21 @@ fn console_size_from_fd(
     unsafe {
         let mut bufinfo: wincon::CONSOLE_SCREEN_BUFFER_INFO = std::mem::zeroed();
 
-        if wincon::GetConsoleScreenBufferInfo(handle, &mut bufinfo) == 0 {
+        if wincon::GetConsoleScreenBufferInfo(handle, &raw mut bufinfo) == 0 {
             return Err(Error::last_os_error());
         }
 
         // calculate the size of the visible window
         // * use over/under-flow protections b/c MSDN docs only imply that srWindow components are all non-negative
         // * ref: <https://docs.microsoft.com/en-us/windows/console/console-screen-buffer-info-str> @@ <https://archive.is/sfjnm>
-        let cols =
-            std::cmp::max(bufinfo.srWindow.Right as i32 - bufinfo.srWindow.Left as i32 + 1, 0)
-                as u32;
-        let rows =
-            std::cmp::max(bufinfo.srWindow.Bottom as i32 - bufinfo.srWindow.Top as i32 + 1, 0)
-                as u32;
+        let cols = std::cmp::max(
+            i32::from(bufinfo.srWindow.Right) - i32::from(bufinfo.srWindow.Left) + 1,
+            0,
+        ) as u32;
+        let rows = std::cmp::max(
+            i32::from(bufinfo.srWindow.Bottom) - i32::from(bufinfo.srWindow.Top) + 1,
+            0,
+        ) as u32;
 
         Ok(ConsoleSize { cols, rows })
     }
@@ -246,8 +262,10 @@ pub fn op_read_line_prompt(
     #[string] prompt_text: &str,
     #[string] default_value: &str,
 ) -> Result<Option<String>, JsReadlineError> {
-    let mut editor =
-        Editor::<(), rustyline::history::DefaultHistory>::new().expect("Failed to create editor.");
+    let mut editor = match Editor::<(), rustyline::history::DefaultHistory>::new() {
+        Ok(editor) => editor,
+        Err(err) => return Err(JsReadlineError(err)),
+    };
 
     editor.set_keyseq_timeout(Some(1));
     editor.bind_sequence(KeyEvent(KeyCode::Esc, Modifiers::empty()), Cmd::Interrupt);
@@ -255,8 +273,7 @@ pub fn op_read_line_prompt(
     let read_result = editor.readline_with_initial(prompt_text, (default_value, ""));
     match read_result {
         Ok(line) => Ok(Some(line)),
-        Err(ReadlineError::Interrupted) => Ok(None),
-        Err(ReadlineError::Eof) => Ok(None),
+        Err(ReadlineError::Interrupted | ReadlineError::Eof) => Ok(None),
         Err(err) => Err(JsReadlineError(err)),
     }
 }

--- a/crates/rari/src/runtime/factory/mod.rs
+++ b/crates/rari/src/runtime/factory/mod.rs
@@ -2,6 +2,7 @@
 
 mod executor;
 mod interface;
+pub mod pool;
 mod runtime;
 mod runtime_builder;
 pub(crate) mod utils;

--- a/crates/rari/src/runtime/factory/pool/broadcast.rs
+++ b/crates/rari/src/runtime/factory/pool/broadcast.rs
@@ -1,0 +1,201 @@
+use std::{
+    future::Future,
+    sync::{Arc, atomic::Ordering},
+};
+
+use rari_error::RariError;
+
+use super::{
+    super::interface::JsRuntimeInterface,
+    JsRuntimePool,
+    component_helpers::{build_invalidate_script, dispatch_load_component, sanitize},
+};
+
+type DynRuntime = Arc<dyn JsRuntimeInterface>;
+
+impl JsRuntimePool {
+    async fn broadcast_to_healthy<F, Fut, T, FormatError, MakeAggregateError>(
+        &self,
+        mut format_error: FormatError,
+        make_aggregate_error: MakeAggregateError,
+        mut op: F,
+    ) -> Result<(), RariError>
+    where
+        F: FnMut(usize, DynRuntime) -> Fut,
+        Fut: Future<Output = Result<T, RariError>>,
+        FormatError: FnMut(usize, &RariError) -> String,
+        MakeAggregateError: FnOnce(usize, &[String]) -> RariError,
+    {
+        let healthy_snapshot: Vec<bool> =
+            self.healthy.iter().map(|h| h.load(Ordering::Acquire)).collect();
+        let mut errors: Vec<String> = Vec::new();
+        let mut executed: usize = 0;
+        for (idx, runtime) in self.runtimes.iter().cloned().enumerate() {
+            if !healthy_snapshot[idx] {
+                continue;
+            }
+            executed += 1;
+            match op(idx, runtime).await {
+                Ok(_) => {}
+                Err(e) => {
+                    self.mark_unhealthy(idx);
+                    errors.push(format_error(idx, &e));
+                }
+            }
+        }
+        if executed == 0 {
+            Err(RariError::js_runtime("No healthy JS runtime available in pool".to_string()))
+        } else if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(make_aggregate_error(executed, &errors))
+        }
+    }
+
+    pub async fn invalidate_component_all(&self, component_id: &str) -> Result<(), RariError> {
+        let script = build_invalidate_script(component_id);
+        let script_name = format!("invalidate_{}", sanitize(component_id));
+        let component_id_msg = component_id.to_string();
+        self.broadcast_to_healthy(
+            |idx, err: &RariError| format!("runtime[{idx}]: {err}"),
+            |total, errors: &[String]| RariError::js_runtime(format!(
+                "Failed to invalidate component {component_id_msg} on {} of {total} runtimes: {}",
+                errors.len(),
+                errors.join("; ")
+            )),
+            |_idx, runtime: DynRuntime| {
+                let script_name_local = script_name.clone();
+                let script_local = script.clone();
+                async move { runtime.execute_script(script_name_local, script_local).await }
+            }
+        )
+        .await
+    }
+
+    pub async fn load_component_code_all(
+        &self,
+        component_id: &str,
+        code: &str,
+    ) -> Result<(), RariError> {
+        let component_id_msg = component_id.to_string();
+        let component_id_op = component_id.to_string();
+        let code = code.to_string();
+        self.broadcast_to_healthy(
+            |idx, err: &RariError| format!("runtime[{idx}]: {err}"),
+            |total, errors: &[String]| RariError::js_runtime(format!(
+                "Failed to load component code for {component_id_msg} on {} of {total} runtimes: {}",
+                errors.len(),
+                errors.join("; ")
+            )),
+            |_idx, runtime: DynRuntime| {
+                let component_id_local = component_id_op.clone();
+                let code_local = code.clone();
+                async move {
+                    dispatch_load_component(runtime.as_ref(), &component_id_local, &code_local)
+                        .await
+                }
+            }
+        )
+        .await
+    }
+
+    pub async fn broadcast_script(
+        &self,
+        script_name: &str,
+        script_code: &str,
+    ) -> Result<(), RariError> {
+        let script_name_msg = script_name.to_string();
+        let script_name_op = script_name.to_string();
+        let script_code = script_code.to_string();
+        self.broadcast_to_healthy(
+            |idx, err: &RariError| format!("runtime[{idx}]: {err}"),
+            |total, errors: &[String]| {
+                RariError::js_runtime(format!(
+                    "Failed to broadcast script {script_name_msg} on {} of {total} runtimes: {}",
+                    errors.len(),
+                    errors.join("; ")
+                ))
+            },
+            |_idx, runtime: DynRuntime| {
+                let name_local = script_name_op.clone();
+                let code_local = script_code.clone();
+                async move { runtime.execute_script(name_local, code_local).await }
+            },
+        )
+        .await
+    }
+
+    pub async fn broadcast_add_module_to_loader_only(
+        &self,
+        specifier: &str,
+        code: &str,
+    ) -> Result<(), RariError> {
+        let specifier = specifier.to_string();
+        let code = code.to_string();
+        self.broadcast_to_healthy(
+            |idx, err: &RariError| format!("runtime[{idx}]: {err}"),
+            |total, errors: &[String]| {
+                RariError::js_runtime(format!(
+                    "Failed to broadcast add_module_to_loader_only on {} of {total} runtimes: {}",
+                    errors.len(),
+                    errors.join("; ")
+                ))
+            },
+            |_idx, runtime: DynRuntime| {
+                let specifier_local = specifier.clone();
+                let code_local = code.clone();
+                async move { runtime.add_module_to_loader_only(&specifier_local, code_local).await }
+            },
+        )
+        .await
+    }
+
+    pub async fn broadcast_load_and_evaluate_module(
+        &self,
+        specifier: &str,
+    ) -> Result<(), RariError> {
+        let specifier = specifier.to_string();
+        self.broadcast_to_healthy(
+            |_idx, err: &RariError| err.to_string(),
+            |total, errors: &[String]| RariError::js_runtime(format!(
+                "Failed to broadcast load+evaluate module {specifier} on {} of {total} runtimes: {}",
+                errors.len(),
+                errors.join("; ")
+            )),
+            |idx, runtime: DynRuntime| {
+                let specifier_local = specifier.clone();
+                async move {
+                    let module_id =
+                        runtime.load_es_module(&specifier_local).await.map_err(|e| {
+                            RariError::js_execution(format!("runtime[{idx}].load_es_module: {e}"))
+                        })?;
+                    runtime.evaluate_module(module_id).await.map_err(|e| {
+                        RariError::js_execution(format!("runtime[{idx}].evaluate_module: {e}"))
+                    })
+                }
+            }
+        )
+        .await
+    }
+
+    pub async fn broadcast_clear_module_loader_caches(
+        &self,
+        component_id: &str,
+    ) -> Result<(), RariError> {
+        let component_id_msg = component_id.to_string();
+        let component_id_op = component_id.to_string();
+        self.broadcast_to_healthy(
+            |idx, err: &RariError| format!("runtime[{idx}]: {err}"),
+            |total, errors: &[String]| RariError::js_runtime(format!(
+                "Failed to broadcast clear_module_loader_caches for {component_id_msg} on {} of {total} runtimes: {}",
+                errors.len(),
+                errors.join("; ")
+            )),
+            |_idx, runtime: DynRuntime| {
+                let component_id_local = component_id_op.clone();
+                async move { runtime.clear_module_loader_caches(&component_id_local).await }
+            }
+        )
+        .await
+    }
+}

--- a/crates/rari/src/runtime/factory/pool/component_helpers.rs
+++ b/crates/rari/src/runtime/factory/pool/component_helpers.rs
@@ -1,0 +1,205 @@
+use std::{
+    sync::OnceLock,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use cow_utils::CowUtils;
+use rari_error::RariError;
+use serde_json::Value as JsonValue;
+
+use super::super::interface::JsRuntimeInterface;
+
+pub(super) fn sanitize(s: &str) -> String {
+    s.replace(['/', '\\', ':', '?', '#'], "_")
+}
+
+pub(super) fn build_invalidate_script(component_id: &str) -> String {
+    let escaped = component_id.cow_replace('\\', "\\\\").cow_replace('"', r#"\""#).into_owned();
+    format!(
+        r#"
+        (function() {{
+            const componentId = "{escaped}";
+            let deleted = false;
+
+            if (globalThis[componentId]) {{
+                delete globalThis[componentId];
+                deleted = true;
+            }}
+
+            const moduleNamespace = globalThis['~rsc']?.modules?.[componentId];
+            if (moduleNamespace) {{
+                for (const key in moduleNamespace) {{
+                    if (key !== 'default' && typeof moduleNamespace[key] === 'function' && globalThis[key] === moduleNamespace[key]) {{
+                        delete globalThis[key];
+                        deleted = true;
+                    }}
+                }}
+            }}
+
+            if (globalThis['~rsc']?.functions?.[componentId]) {{
+                delete globalThis['~rsc'].functions[componentId];
+                deleted = true;
+            }}
+
+            if (globalThis['~serverFunctions']?.all) {{
+                const prefix = componentId + ':';
+                for (const key in globalThis['~serverFunctions'].all) {{
+                    if (key === componentId || key.startsWith(prefix)) {{
+                        delete globalThis['~serverFunctions'].all[key];
+                        deleted = true;
+                    }}
+                }}
+            }}
+
+            if (globalThis['~serverFunctions']?.exported) {{
+                const prefix = componentId + ':';
+                for (const key in globalThis['~serverFunctions'].exported) {{
+                    if (key === componentId || key.startsWith(prefix)) {{
+                        delete globalThis['~serverFunctions'].exported[key];
+                        deleted = true;
+                    }}
+                }}
+            }}
+
+            if (globalThis['~rsc']?.modules?.[componentId]) {{
+                delete globalThis['~rsc'].modules[componentId];
+                deleted = true;
+            }}
+
+            if (globalThis.PromiseManager && globalThis.PromiseManager.clear) {{
+                try {{
+                    globalThis.PromiseManager.clear(componentId);
+                    deleted = true;
+                }} catch (e) {{
+                    console.warn('Failed to clear PromiseManager for component:', componentId, e);
+                }}
+            }}
+
+            if (globalThis['~rsc']?.components?.[componentId]) {{
+                delete globalThis['~rsc'].components[componentId];
+                deleted = true;
+            }}
+
+            if (globalThis.RscModuleManager && globalThis.RscModuleManager.unregister) {{
+                try {{
+                    globalThis.RscModuleManager.unregister(componentId);
+                    deleted = true;
+                }} catch (e) {{
+                    console.warn('Failed to unregister from RscModuleManager:', e);
+                }}
+            }}
+
+            return {{ success: true, deleted: deleted }};
+        }})()
+        "#
+    )
+}
+
+pub(super) async fn dispatch_load_component(
+    runtime: &dyn JsRuntimeInterface,
+    component_id: &str,
+    code: &str,
+) -> Result<(), RariError> {
+    static ESM_REGEX: OnceLock<regex::Regex> = OnceLock::new();
+    let esm_regex = ESM_REGEX.get_or_init(|| {
+        #[expect(clippy::expect_used, reason = "Infallible operation with valid inputs")]
+        regex::Regex::new(r"(?m)^\s*export[\s{]").expect("Valid ESM detection regex")
+    });
+    let is_esm = esm_regex.is_match(code);
+
+    if is_esm {
+        let timestamp =
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis();
+        let hmr_specifier = format!("file:///rari_hmr/server/{component_id}.js?v={timestamp}");
+
+        if let Err(e) = runtime.clear_module_loader_caches(component_id).await {
+            tracing::warn!("Failed to clear module loader caches for {}: {}", component_id, e);
+        }
+
+        runtime.add_module_to_loader_only(&hmr_specifier, code.to_string()).await.map_err(|e| {
+            RariError::js_execution(format!(
+                "Failed to add component module to loader for {component_id}: {e}"
+            ))
+        })?;
+
+        let module_id = runtime.load_es_module(component_id).await.map_err(|e| {
+            RariError::js_execution(format!("Failed to load ES module for {component_id}: {e}"))
+        })?;
+
+        runtime.evaluate_module(module_id).await.map_err(|e| {
+            RariError::js_execution(format!("Failed to evaluate ES module for {component_id}: {e}"))
+        })?;
+
+        let escaped_component_id = component_id.replace('\\', "\\\\").replace('"', r#"\""#);
+        let escaped_hmr_specifier = hmr_specifier.replace('\\', "\\\\").replace('"', r#"\""#);
+
+        let registration_script = format!(
+            r#"(async function() {{
+                try {{
+                    const moduleNamespace = await import("{escaped_hmr_specifier}");
+                    const componentId = "{escaped_component_id}";
+
+                    if (!globalThis['~rsc']) globalThis['~rsc'] = {{}};
+                    if (!globalThis['~rsc'].modules) globalThis['~rsc'].modules = {{}};
+                    if (!globalThis['~rsc'].functions) globalThis['~rsc'].functions = {{}};
+
+                    globalThis['~rsc'].modules[componentId] = moduleNamespace;
+
+                    if (moduleNamespace.default) {{
+                        globalThis[componentId] = moduleNamespace.default;
+                    }} else {{
+                        const exports = Object.values(moduleNamespace).filter(v => typeof v === 'function');
+                        if (exports.length > 0) {{
+                            globalThis[componentId] = exports[0];
+                        }}
+                    }}
+
+                    const namedExports = {{}};
+                    for (const [key, value] of Object.entries(moduleNamespace)) {{
+                        if (key !== 'default' && typeof value === 'function') {{
+                            namedExports[key] = value;
+                        }}
+                    }}
+
+                    if (Object.keys(namedExports).length > 0) {{
+                        globalThis['~rsc'].functions[componentId] = namedExports;
+                    }}
+
+                    return {{ success: true }};
+                }} catch (error) {{
+                    console.error('[rari] Failed to register component {escaped_component_id}:', error);
+                    return {{ success: false, error: error.message }};
+                }}
+            }})()"#
+        );
+
+        let result = runtime
+            .execute_script(
+                format!("register_component_{}.js", component_id.cow_replace('/', "_")),
+                registration_script,
+            )
+            .await
+            .map_err(|e| {
+                RariError::js_execution(format!(
+                    "Failed to register component {component_id} to globalThis: {e}"
+                ))
+            })?;
+
+        let success = result.get("success").and_then(JsonValue::as_bool).unwrap_or(false);
+        if !success {
+            let error_msg = result.get("error").and_then(|v| v.as_str()).unwrap_or("Unknown error");
+            return Err(RariError::js_execution(format!(
+                "Component registration failed for {component_id}: {error_msg}"
+            )));
+        }
+
+        Ok(())
+    } else {
+        let script_name = format!("load_component_{}", component_id.cow_replace('/', "_"));
+        runtime.execute_script(script_name, code.to_string()).await.map(|_| ()).map_err(|e| {
+            RariError::js_execution(format!(
+                "Failed to execute component code for {component_id}: {e}"
+            ))
+        })
+    }
+}

--- a/crates/rari/src/runtime/factory/pool/handle.rs
+++ b/crates/rari/src/runtime/factory/pool/handle.rs
@@ -1,0 +1,56 @@
+use std::sync::Arc;
+
+use deno_core::ModuleId;
+use rari_error::RariError;
+use serde_json::Value as JsonValue;
+
+use super::super::interface::{AsyncBatchResult, JsRuntimeInterface};
+
+macro_rules! forward_async_to_runtime {
+    ($(
+        pub async fn $name:ident(&self $(, $($arg:ident: $arg_ty:ty),*)?) -> $ret:ty;
+    )*) => {
+        $(
+            pub async fn $name(&self $(, $($arg: $arg_ty),*)?) -> $ret {
+                self.runtime.$name($($($arg),*)?).await
+            }
+        )*
+    };
+}
+
+pub struct PooledRuntime {
+    idx: usize,
+    runtime: Arc<dyn JsRuntimeInterface>,
+}
+
+impl PooledRuntime {
+    pub(super) fn new(idx: usize, runtime: Arc<dyn JsRuntimeInterface>) -> Self {
+        Self { idx, runtime }
+    }
+
+    pub fn idx(&self) -> usize {
+        self.idx
+    }
+
+    pub fn runtime(&self) -> &Arc<dyn JsRuntimeInterface> {
+        &self.runtime
+    }
+
+    pub fn execute_script_batch(&self, scripts: Vec<(String, String)>) -> AsyncBatchResult {
+        self.runtime.execute_script_batch(scripts)
+    }
+
+    forward_async_to_runtime! {
+        pub async fn execute_script(&self, script_name: String, script_code: String) -> Result<JsonValue, RariError>;
+        pub async fn execute_function(&self, function_name: &str, args: Vec<JsonValue>) -> Result<JsonValue, RariError>;
+        pub async fn add_module_to_loader(&self, specifier: &str) -> Result<(), RariError>;
+        pub async fn add_module_to_loader_only(&self, specifier: &str, code: String) -> Result<(), RariError>;
+        pub async fn clear_module_loader_caches(&self, component_id: &str) -> Result<(), RariError>;
+        pub async fn load_es_module(&self, specifier: &str) -> Result<ModuleId, RariError>;
+        pub async fn evaluate_module(&self, module_id: ModuleId) -> Result<JsonValue, RariError>;
+        pub async fn get_module_namespace(&self, module_id: ModuleId) -> Result<JsonValue, RariError>;
+        pub async fn set_request_context(&self, request_context: Arc<crate::server::middleware::request_context::RequestContext>) -> Result<(), RariError>;
+        pub async fn clear_request_context(&self) -> Result<(), RariError>;
+        pub async fn clear_request_context_if_matches(&self, expected_context: Arc<crate::server::middleware::request_context::RequestContext>) -> Result<(), RariError>;
+    }
+}

--- a/crates/rari/src/runtime/factory/pool/interface.rs
+++ b/crates/rari/src/runtime/factory/pool/interface.rs
@@ -1,0 +1,209 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, atomic::Ordering},
+};
+
+use rari_error::RariError;
+use serde_json::Value as JsonValue;
+
+use super::{super::interface::AsyncBatchResult, JsRuntimePool};
+
+fn pool_unavailable_error() -> RariError {
+    RariError::js_runtime("No healthy JS runtime available in pool".to_string())
+}
+
+fn unavailable_future<T>() -> Pin<Box<dyn Future<Output = Result<T, RariError>> + Send>>
+where
+    T: Send + 'static,
+{
+    Box::pin(async move { Err(pool_unavailable_error()) })
+}
+
+impl JsRuntimePool {
+    pub fn execute_script(
+        &self,
+        script_name: String,
+        script_code: String,
+    ) -> Pin<Box<dyn Future<Output = Result<JsonValue, RariError>> + Send>> {
+        if self.setup_mode.load(Ordering::Acquire) {
+            let runtimes = self.runtimes.clone();
+            let healthy_snapshot: Vec<bool> =
+                self.healthy.iter().map(|h| h.load(Ordering::Acquire)).collect();
+            Box::pin(async move {
+                let mut errors: Vec<String> = Vec::new();
+                let mut first_value: Option<JsonValue> = None;
+                let mut executed: usize = 0;
+                for (idx, runtime) in runtimes.iter().enumerate() {
+                    if !healthy_snapshot[idx] {
+                        continue;
+                    }
+                    executed += 1;
+                    match runtime.execute_script(script_name.clone(), script_code.clone()).await {
+                        Ok(v) => {
+                            if first_value.is_none() {
+                                first_value = Some(v);
+                            }
+                        }
+                        Err(e) => {
+                            errors.push(format!("runtime[{idx}]: {e}"));
+                        }
+                    }
+                }
+
+                if executed == 0 {
+                    Err(pool_unavailable_error())
+                } else if errors.is_empty() {
+                    Ok(first_value.unwrap_or(JsonValue::Null))
+                } else {
+                    Err(RariError::js_runtime(format!(
+                        "Failed to broadcast execute_script {script_name} on {} of {} runtimes: {}",
+                        errors.len(),
+                        executed,
+                        errors.join("; ")
+                    )))
+                }
+            })
+        } else {
+            let runtime = match self.pick() {
+                Some(idx) => Arc::clone(&self.runtimes[idx]),
+                None => return unavailable_future(),
+            };
+            Box::pin(async move { runtime.execute_script(script_name, script_code).await })
+        }
+    }
+
+    pub fn execute_script_batch(&self, scripts: Vec<(String, String)>) -> AsyncBatchResult {
+        let runtime = match self.pick() {
+            Some(idx) => Arc::clone(&self.runtimes[idx]),
+            None => {
+                let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+                for (idx, _) in scripts.iter().enumerate() {
+                    let _ = tx.send((idx, Err(pool_unavailable_error())));
+                }
+                return Box::pin(async move { rx });
+            }
+        };
+        Box::pin(async move { runtime.execute_script_batch(scripts).await })
+    }
+
+    pub fn execute_function(
+        &self,
+        function_name: &str,
+        args: Vec<JsonValue>,
+    ) -> Pin<Box<dyn Future<Output = Result<JsonValue, RariError>> + Send + 'static>> {
+        let runtime = match self.pick() {
+            Some(idx) => Arc::clone(&self.runtimes[idx]),
+            None => return unavailable_future(),
+        };
+        let function_name = function_name.to_string();
+        Box::pin(async move { runtime.execute_function(&function_name, args).await })
+    }
+
+    pub fn add_module_to_loader(
+        &self,
+        specifier: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        let runtimes = self.runtimes.clone();
+        let specifier = specifier.to_string();
+        let healthy_snapshot: Vec<bool> =
+            self.healthy.iter().map(|h| h.load(Ordering::Acquire)).collect();
+        Box::pin(async move {
+            let mut errors: Vec<String> = Vec::new();
+            let mut executed: usize = 0;
+            for (idx, runtime) in runtimes.iter().enumerate() {
+                if !healthy_snapshot[idx] {
+                    continue;
+                }
+                executed += 1;
+                if let Err(e) = runtime.add_module_to_loader(&specifier).await {
+                    errors.push(format!("runtime[{idx}]: {e}"));
+                }
+            }
+
+            if executed == 0 {
+                Err(pool_unavailable_error())
+            } else if errors.is_empty() {
+                Ok(())
+            } else {
+                Err(RariError::js_runtime(format!(
+                    "Failed to broadcast add_module_to_loader on {} of {} runtimes: {}",
+                    errors.len(),
+                    executed,
+                    errors.join("; ")
+                )))
+            }
+        })
+    }
+
+    pub fn add_module_to_loader_only(
+        &self,
+        specifier: &str,
+        code: String,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        let runtimes = self.runtimes.clone();
+        let specifier = specifier.to_string();
+        let healthy_snapshot: Vec<bool> =
+            self.healthy.iter().map(|h| h.load(Ordering::Acquire)).collect();
+        Box::pin(async move {
+            let mut errors: Vec<String> = Vec::new();
+            let mut executed: usize = 0;
+            for (idx, runtime) in runtimes.iter().enumerate() {
+                if !healthy_snapshot[idx] {
+                    continue;
+                }
+                executed += 1;
+                if let Err(e) = runtime.add_module_to_loader_only(&specifier, code.clone()).await {
+                    errors.push(format!("runtime[{idx}]: {e}"));
+                }
+            }
+            if executed == 0 {
+                Err(pool_unavailable_error())
+            } else if errors.is_empty() {
+                Ok(())
+            } else {
+                Err(RariError::js_runtime(format!(
+                    "Failed to broadcast add_module_to_loader_only on {} of {} runtimes: {}",
+                    errors.len(),
+                    executed,
+                    errors.join("; ")
+                )))
+            }
+        })
+    }
+
+    pub fn clear_module_loader_caches(
+        &self,
+        component_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        let runtimes = self.runtimes.clone();
+        let component_id = component_id.to_string();
+        let healthy_snapshot: Vec<bool> =
+            self.healthy.iter().map(|h| h.load(Ordering::Acquire)).collect();
+        Box::pin(async move {
+            let mut errors: Vec<String> = Vec::new();
+            let mut executed: usize = 0;
+            for (idx, runtime) in runtimes.iter().enumerate() {
+                if !healthy_snapshot[idx] {
+                    continue;
+                }
+                executed += 1;
+                if let Err(e) = runtime.clear_module_loader_caches(&component_id).await {
+                    errors.push(format!("runtime[{idx}]: {e}"));
+                }
+            }
+            if executed == 0 {
+                Err(pool_unavailable_error())
+            } else if errors.is_empty() {
+                Ok(())
+            } else {
+                Err(RariError::js_runtime(format!(
+                    "Failed to broadcast clear_module_loader_caches for {component_id} on {} of {} runtimes: {}",
+                    errors.len(),
+                    executed,
+                    errors.join("; ")
+                )))
+            }
+        })
+    }
+}

--- a/crates/rari/src/runtime/factory/pool/mod.rs
+++ b/crates/rari/src/runtime/factory/pool/mod.rs
@@ -1,0 +1,206 @@
+use std::{
+    fmt::{self, Formatter, Result as FmtResult},
+    future::Future,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+};
+
+use deno_core::ModuleId;
+use rari_error::RariError;
+use rustc_hash::FxHashMap;
+use serde_json::Value as JsonValue;
+
+use super::runtime::RariRuntime;
+
+mod broadcast;
+mod component_helpers;
+mod handle;
+mod interface;
+mod strategy;
+#[cfg(test)]
+mod tests;
+
+pub use handle::PooledRuntime;
+pub use strategy::{PickStrategy, RoundRobinStrategy};
+
+use super::interface::JsRuntimeInterface;
+use crate::server::middleware::request_context::RequestContext;
+
+pub struct JsRuntimePool {
+    runtimes: Vec<Arc<dyn JsRuntimeInterface>>,
+    pick_strategy: Arc<dyn PickStrategy>,
+    next_index: AtomicUsize,
+    healthy: Vec<AtomicBool>,
+    setup_mode: AtomicBool,
+}
+
+#[expect(
+    clippy::missing_fields_in_debug,
+    reason = "Debug impl intentionally omits non-trivial fields"
+)]
+impl fmt::Debug for JsRuntimePool {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.debug_struct("JsRuntimePool")
+            .field("size", &self.runtimes.len())
+            .field(
+                "healthy_count",
+                &self.healthy.iter().filter(|h| h.load(Ordering::Acquire)).count(),
+            )
+            .finish()
+    }
+}
+
+impl JsRuntimePool {
+    pub fn new(
+        pool_size: usize,
+        env_vars: Option<FxHashMap<String, String>>,
+    ) -> Result<Arc<Self>, RariError> {
+        Self::with_strategy(pool_size, env_vars, Arc::new(RoundRobinStrategy))
+    }
+
+    pub fn with_strategy(
+        pool_size: usize,
+        env_vars: Option<FxHashMap<String, String>>,
+        strategy: Arc<dyn PickStrategy>,
+    ) -> Result<Arc<Self>, RariError> {
+        if pool_size == 0 {
+            return Err(RariError::configuration(
+                "JS runtime pool size must be at least 1".to_string(),
+            ));
+        }
+
+        let runtimes: Vec<Arc<dyn JsRuntimeInterface>> = (0..pool_size)
+            .map(|_| Arc::new(RariRuntime::new(env_vars.clone())) as Arc<dyn JsRuntimeInterface>)
+            .collect();
+
+        let healthy = runtimes.iter().map(|_| AtomicBool::new(true)).collect();
+
+        Ok(Arc::new(Self {
+            runtimes,
+            pick_strategy: strategy,
+            next_index: AtomicUsize::new(0),
+            healthy,
+            setup_mode: AtomicBool::new(false),
+        }))
+    }
+
+    pub fn size(&self) -> usize {
+        self.runtimes.len()
+    }
+
+    pub fn runtime_at(&self, idx: usize) -> Option<Arc<dyn JsRuntimeInterface>> {
+        self.runtimes.get(idx).map(Arc::clone)
+    }
+
+    pub fn pick(&self) -> Option<usize> {
+        let healthy_indices: Vec<usize> = self
+            .healthy
+            .iter()
+            .enumerate()
+            .filter_map(|(i, h)| if h.load(Ordering::Acquire) { Some(i) } else { None })
+            .collect();
+
+        let idx = self.pick_strategy.pick(&healthy_indices, &self.next_index)?;
+        if idx >= self.runtimes.len() {
+            tracing::error!(
+                idx,
+                pool_size = self.runtimes.len(),
+                "PickStrategy returned out-of-range index"
+            );
+            return None;
+        }
+        Some(idx)
+    }
+
+    pub fn mark_unhealthy(&self, idx: usize) {
+        if let Some(h) = self.healthy.get(idx) {
+            h.store(false, Ordering::Release);
+            tracing::warn!("Marked JS runtime pool slot {} as unhealthy", idx);
+        }
+    }
+
+    pub fn mark_healthy(&self, idx: usize) {
+        if let Some(h) = self.healthy.get(idx) {
+            h.store(true, Ordering::Release);
+            tracing::info!("Marked JS runtime pool slot {} as healthy", idx);
+        }
+    }
+
+    pub fn is_healthy(&self, idx: usize) -> bool {
+        self.healthy.get(idx).map(|h| h.load(Ordering::Acquire)).unwrap_or(false)
+    }
+
+    pub fn healthy_count(&self) -> usize {
+        self.healthy.iter().filter(|h| h.load(Ordering::Acquire)).count()
+    }
+
+    pub fn all_healthy_indices(&self) -> Vec<usize> {
+        self.healthy
+            .iter()
+            .enumerate()
+            .filter_map(|(i, h)| if h.load(Ordering::Acquire) { Some(i) } else { None })
+            .collect()
+    }
+
+    pub fn set_setup_mode(&self, on: bool) {
+        self.setup_mode.store(on, Ordering::Release);
+        tracing::info!("JS runtime pool setup_mode = {}", on);
+    }
+
+    pub fn is_setup_mode(&self) -> bool {
+        self.setup_mode.load(Ordering::Acquire)
+    }
+
+    pub fn pick_runtime(&self) -> Result<PooledRuntime, RariError> {
+        let idx = self.pick().ok_or_else(|| {
+            RariError::js_runtime("No healthy JS runtime available in pool".to_string())
+        })?;
+        let runtime = Arc::clone(&self.runtimes[idx]);
+        Ok(PooledRuntime::new(idx, runtime))
+    }
+
+    pub async fn load_and_evaluate_module(
+        &self,
+        specifier: &str,
+    ) -> Result<(ModuleId, JsonValue), RariError> {
+        let handle = self.pick_runtime()?;
+        let module_id = handle.load_es_module(specifier).await?;
+        let value = handle.evaluate_module(module_id).await?;
+        Ok((module_id, value))
+    }
+
+    pub async fn with_request_context<F, Fut, T>(
+        &self,
+        ctx: Arc<RequestContext>,
+        op: F,
+    ) -> Result<T, RariError>
+    where
+        F: FnOnce(Arc<dyn JsRuntimeInterface>) -> Fut,
+        Fut: Future<Output = Result<T, RariError>>,
+    {
+        let handle = self.pick_runtime()?;
+        handle.set_request_context(Arc::clone(&ctx)).await?;
+        let result = op(Arc::clone(handle.runtime())).await;
+        let cleanup = handle.clear_request_context_if_matches(ctx).await;
+        match (result, cleanup) {
+            (Ok(value), Ok(())) => Ok(value),
+            (Ok(value), Err(cleanup_err)) => {
+                tracing::error!(
+                    "Failed to clear request context after successful operation: {}",
+                    cleanup_err
+                );
+                Ok(value)
+            }
+            (Err(op_err), Ok(())) => Err(op_err),
+            (Err(op_err), Err(cleanup_err)) => {
+                tracing::error!(
+                    "Failed to clear request context after operation error: {}",
+                    cleanup_err
+                );
+                Err(op_err)
+            }
+        }
+    }
+}

--- a/crates/rari/src/runtime/factory/pool/strategy.rs
+++ b/crates/rari/src/runtime/factory/pool/strategy.rs
@@ -1,0 +1,19 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+pub trait PickStrategy: Send + Sync {
+    fn pick(&self, healthy_indices: &[usize], next: &AtomicUsize) -> Option<usize>;
+}
+
+#[non_exhaustive]
+pub struct RoundRobinStrategy;
+
+impl PickStrategy for RoundRobinStrategy {
+    fn pick(&self, healthy_indices: &[usize], next: &AtomicUsize) -> Option<usize> {
+        if healthy_indices.is_empty() {
+            None
+        } else {
+            let pos = next.fetch_add(1, Ordering::Relaxed) % healthy_indices.len();
+            Some(healthy_indices[pos])
+        }
+    }
+}

--- a/crates/rari/src/runtime/factory/pool/tests.rs
+++ b/crates/rari/src/runtime/factory/pool/tests.rs
@@ -1,0 +1,912 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+};
+
+use rari_error::RariError;
+use serde_json::{Value as JsonValue, json};
+use tokio::sync::mpsc;
+
+use super::*;
+use crate::server::middleware::request_context::RequestContext;
+
+struct CountingRuntime {
+    calls: Arc<AtomicUsize>,
+}
+
+impl JsRuntimeInterface for CountingRuntime {
+    fn execute_script(
+        &self,
+        _script_name: String,
+        _script_code: String,
+    ) -> Pin<Box<dyn Future<Output = Result<JsonValue, RariError>> + Send>> {
+        let calls = Arc::clone(&self.calls);
+        Box::pin(async move {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(json!({"ok": true}))
+        })
+    }
+
+    fn execute_script_batch(
+        &self,
+        _scripts: Vec<(String, String)>,
+    ) -> Pin<
+        Box<
+            dyn Future<Output = mpsc::UnboundedReceiver<(usize, Result<JsonValue, RariError>)>>
+                + Send,
+        >,
+    > {
+        let (_tx, rx) = mpsc::unbounded_channel();
+        Box::pin(async move { rx })
+    }
+
+    fn execute_function(
+        &self,
+        _function_name: &str,
+        _args: Vec<JsonValue>,
+    ) -> Pin<Box<dyn Future<Output = Result<JsonValue, RariError>> + Send + 'static>> {
+        Box::pin(async move { Ok(json!(null)) })
+    }
+
+    fn add_module_to_loader(
+        &self,
+        _specifier: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn load_es_module(
+        &self,
+        _specifier: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<deno_core::ModuleId, RariError>> + Send>> {
+        Box::pin(async move { Ok(0) })
+    }
+
+    fn evaluate_module(
+        &self,
+        _module_id: deno_core::ModuleId,
+    ) -> Pin<Box<dyn Future<Output = Result<JsonValue, RariError>> + Send>> {
+        Box::pin(async move { Ok(json!(null)) })
+    }
+
+    fn get_module_namespace(
+        &self,
+        _module_id: deno_core::ModuleId,
+    ) -> Pin<Box<dyn Future<Output = Result<JsonValue, RariError>> + Send>> {
+        Box::pin(async move { Ok(json!(null)) })
+    }
+
+    fn add_module_to_loader_only(
+        &self,
+        _specifier: &str,
+        _code: String,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn clear_module_loader_caches(
+        &self,
+        _component_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn set_request_context(
+        &self,
+        _request_context: Arc<RequestContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn clear_request_context(&self) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn clear_request_context_if_matches(
+        &self,
+        _expected_context: Arc<RequestContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+}
+
+fn build_pool_with_counters(size: usize) -> (Arc<JsRuntimePool>, Vec<Arc<AtomicUsize>>) {
+    let mut runtimes: Vec<Arc<dyn JsRuntimeInterface>> = Vec::with_capacity(size);
+    let mut counters: Vec<Arc<AtomicUsize>> = Vec::with_capacity(size);
+
+    for _ in 0..size {
+        let counter = Arc::new(AtomicUsize::new(0));
+        counters.push(Arc::clone(&counter));
+        let runtime = CountingRuntime { calls: Arc::clone(&counter) };
+        runtimes.push(Arc::new(runtime));
+    }
+
+    let healthy = (0..size).map(|_| AtomicBool::new(true)).collect();
+
+    let pool = Arc::new(JsRuntimePool {
+        runtimes,
+        pick_strategy: Arc::new(RoundRobinStrategy),
+        next_index: AtomicUsize::new(0),
+        healthy,
+        setup_mode: AtomicBool::new(false),
+    });
+
+    (pool, counters)
+}
+
+#[tokio::test]
+async fn round_robin_distributes_across_runtimes() -> Result<(), RariError> {
+    let (pool, counters) = build_pool_with_counters(3);
+
+    for _ in 0..9 {
+        pool.execute_script("test".into(), "1+1".into()).await?;
+    }
+
+    assert_eq!(counters[0].load(Ordering::SeqCst), 3);
+    assert_eq!(counters[1].load(Ordering::SeqCst), 3);
+    assert_eq!(counters[2].load(Ordering::SeqCst), 3);
+    Ok(())
+}
+
+#[tokio::test]
+async fn pool_size_zero_is_rejected() {
+    let result = JsRuntimePool::new(0, None);
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn pool_size_one_picks_always_index_zero() -> Result<(), RariError> {
+    let (pool, counters) = build_pool_with_counters(1);
+
+    for _ in 0..5 {
+        pool.execute_script("test".into(), "1+1".into()).await?;
+    }
+
+    assert_eq!(counters[0].load(Ordering::SeqCst), 5);
+    Ok(())
+}
+
+#[tokio::test]
+async fn mark_unhealthy_changes_round_robin_distribution() -> Result<(), RariError> {
+    let (pool, counters) = build_pool_with_counters(3);
+
+    pool.mark_unhealthy(0);
+    pool.mark_unhealthy(2);
+
+    for _ in 0..6 {
+        pool.execute_script("test".into(), "1+1".into()).await?;
+    }
+
+    assert_eq!(counters[0].load(Ordering::SeqCst), 0);
+    assert_eq!(counters[2].load(Ordering::SeqCst), 0);
+    assert!(counters[1].load(Ordering::SeqCst) >= 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn mark_healthy_restores_round_robin() -> Result<(), RariError> {
+    let (pool, counters) = build_pool_with_counters(3);
+
+    pool.mark_unhealthy(1);
+
+    for _ in 0..3 {
+        pool.execute_script("test".into(), "1+1".into()).await?;
+    }
+    let before = counters[1].load(Ordering::SeqCst);
+    assert_eq!(before, 0);
+
+    pool.mark_healthy(1);
+
+    for _ in 0..3 {
+        pool.execute_script("test".into(), "1+1".into()).await?;
+    }
+
+    assert!(counters[1].load(Ordering::SeqCst) > before);
+    Ok(())
+}
+
+#[test]
+fn healthy_count_tracks_marks() {
+    let (pool, _) = build_pool_with_counters(4);
+    assert_eq!(pool.healthy_count(), 4);
+
+    pool.mark_unhealthy(1);
+    pool.mark_unhealthy(3);
+    assert_eq!(pool.healthy_count(), 2);
+
+    pool.mark_healthy(1);
+    assert_eq!(pool.healthy_count(), 3);
+
+    assert_eq!(pool.all_healthy_indices(), vec![0, 1, 2]);
+}
+
+struct BroadcastingRuntime {
+    fail_next: Arc<AtomicBool>,
+}
+
+impl JsRuntimeInterface for BroadcastingRuntime {
+    fn execute_script(
+        &self,
+        _script_name: String,
+        _script_code: String,
+    ) -> Pin<Box<dyn Future<Output = Result<JsonValue, RariError>> + Send>> {
+        let fail = Arc::clone(&self.fail_next);
+        Box::pin(async move {
+            if fail.load(Ordering::SeqCst) {
+                Err(RariError::js_runtime("simulated failure".to_string()))
+            } else {
+                Ok(json!({"ok": true}))
+            }
+        })
+    }
+
+    fn execute_script_batch(
+        &self,
+        _scripts: Vec<(String, String)>,
+    ) -> Pin<
+        Box<
+            dyn Future<Output = mpsc::UnboundedReceiver<(usize, Result<JsonValue, RariError>)>>
+                + Send,
+        >,
+    > {
+        let (_tx, rx) = mpsc::unbounded_channel();
+        Box::pin(async move { rx })
+    }
+
+    fn execute_function(
+        &self,
+        _function_name: &str,
+        _args: Vec<JsonValue>,
+    ) -> Pin<Box<dyn Future<Output = Result<JsonValue, RariError>> + Send + 'static>> {
+        Box::pin(async move { Ok(json!(null)) })
+    }
+
+    fn add_module_to_loader(
+        &self,
+        _specifier: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn load_es_module(
+        &self,
+        _specifier: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<deno_core::ModuleId, RariError>> + Send>> {
+        Box::pin(async move { Ok(0) })
+    }
+
+    fn evaluate_module(
+        &self,
+        _module_id: deno_core::ModuleId,
+    ) -> Pin<Box<dyn Future<Output = Result<JsonValue, RariError>> + Send>> {
+        let fail = Arc::clone(&self.fail_next);
+        Box::pin(async move {
+            if fail.load(Ordering::SeqCst) {
+                Err(RariError::js_runtime("simulated evaluate failure".to_string()))
+            } else {
+                Ok(json!(null))
+            }
+        })
+    }
+
+    fn get_module_namespace(
+        &self,
+        _module_id: deno_core::ModuleId,
+    ) -> Pin<Box<dyn Future<Output = Result<JsonValue, RariError>> + Send>> {
+        Box::pin(async move { Ok(json!(null)) })
+    }
+
+    fn add_module_to_loader_only(
+        &self,
+        _specifier: &str,
+        _code: String,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        let fail = Arc::clone(&self.fail_next);
+        Box::pin(async move {
+            if fail.load(Ordering::SeqCst) {
+                Err(RariError::js_runtime("simulated load failure".to_string()))
+            } else {
+                Ok(())
+            }
+        })
+    }
+
+    fn clear_module_loader_caches(
+        &self,
+        _component_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn set_request_context(
+        &self,
+        _request_context: Arc<RequestContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn clear_request_context(&self) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn clear_request_context_if_matches(
+        &self,
+        _expected_context: Arc<RequestContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+}
+
+fn build_pool_with_fail_flags(size: usize) -> (Arc<JsRuntimePool>, Vec<Arc<AtomicBool>>) {
+    let mut runtimes: Vec<Arc<dyn JsRuntimeInterface>> = Vec::with_capacity(size);
+    let mut flags: Vec<Arc<AtomicBool>> = Vec::with_capacity(size);
+
+    for _ in 0..size {
+        let flag = Arc::new(AtomicBool::new(false));
+        flags.push(Arc::clone(&flag));
+        runtimes.push(Arc::new(BroadcastingRuntime { fail_next: Arc::clone(&flag) }));
+    }
+
+    let healthy = (0..size).map(|_| AtomicBool::new(true)).collect();
+
+    let pool = Arc::new(JsRuntimePool {
+        runtimes,
+        pick_strategy: Arc::new(RoundRobinStrategy),
+        next_index: AtomicUsize::new(0),
+        healthy,
+        setup_mode: AtomicBool::new(false),
+    });
+
+    (pool, flags)
+}
+
+#[tokio::test]
+async fn setup_mode_broadcasts_to_all_runtimes() -> Result<(), RariError> {
+    let (pool, counters) = build_pool_with_counters(3);
+
+    pool.set_setup_mode(true);
+    pool.execute_script("setup.js".into(), "init".into()).await?;
+
+    assert_eq!(counters[0].load(Ordering::SeqCst), 1);
+    assert_eq!(counters[1].load(Ordering::SeqCst), 1);
+    assert_eq!(counters[2].load(Ordering::SeqCst), 1);
+
+    pool.set_setup_mode(false);
+    for _ in 0..6 {
+        pool.execute_script("req.js".into(), "go".into()).await?;
+    }
+
+    assert_eq!(counters[0].load(Ordering::SeqCst), 3);
+    assert_eq!(counters[1].load(Ordering::SeqCst), 3);
+    assert_eq!(counters[2].load(Ordering::SeqCst), 3);
+    Ok(())
+}
+
+#[tokio::test]
+async fn setup_mode_aggregates_errors() {
+    let (pool, flags) = build_pool_with_fail_flags(3);
+
+    pool.set_setup_mode(true);
+    flags[1].store(true, Ordering::SeqCst);
+
+    let result = pool.execute_script("setup.js".into(), "init".into()).await;
+    assert!(result.is_err());
+    let err_msg = match result {
+        Ok(_) => String::new(),
+        Err(e) => e.to_string(),
+    };
+    assert!(err_msg.contains("1 of 3 runtimes"), "got: {err_msg}");
+}
+
+#[tokio::test]
+async fn setup_mode_returns_pool_unavailable_when_all_unhealthy() {
+    let (pool, _counters) = build_pool_with_counters(2);
+    pool.mark_unhealthy(0);
+    pool.mark_unhealthy(1);
+    pool.set_setup_mode(true);
+
+    let result = pool.execute_script("setup.js".into(), "init".into()).await;
+    assert!(result.is_err(), "setup-mode broadcast with zero healthy runtimes must not return Ok");
+    let err_msg = match result {
+        Ok(_) => String::new(),
+        Err(e) => e.to_string(),
+    };
+    assert!(err_msg.contains("No healthy JS runtime available in pool"), "got: {err_msg}");
+}
+
+#[tokio::test]
+async fn invalidate_component_all_returns_error_when_some_runtime_fails() {
+    let (pool, flags) = build_pool_with_fail_flags(2);
+
+    flags[1].store(true, Ordering::SeqCst);
+
+    let result = pool.invalidate_component_all("MyComponent").await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn invalidate_component_all_succeeds_when_all_runtimes_ok() {
+    let (pool, _flags) = build_pool_with_fail_flags(2);
+
+    let result = pool.invalidate_component_all("MyComponent").await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn broadcast_load_and_evaluate_module_reports_evaluate_failures() {
+    let (pool, flags) = build_pool_with_fail_flags(2);
+    flags[1].store(true, Ordering::SeqCst);
+
+    let result = pool.broadcast_load_and_evaluate_module("MyComponent").await;
+    assert!(result.is_err());
+    let msg = match result {
+        Ok(()) => String::new(),
+        Err(e) => e.to_string(),
+    };
+
+    assert!(msg.contains("runtime[1].evaluate_module"), "got: {msg}");
+    assert!(!msg.contains("runtime[1].load_es_module"), "got: {msg}");
+}
+
+#[tokio::test]
+async fn pool_size_one_behaves_like_single_runtime() -> Result<(), RariError> {
+    let (pool, counters) = build_pool_with_counters(1);
+
+    for _ in 0..5 {
+        pool.execute_script("test".into(), "1+1".into()).await?;
+    }
+
+    assert_eq!(counters[0].load(Ordering::SeqCst), 5);
+    Ok(())
+}
+
+#[test]
+fn pick_returns_none_when_all_unhealthy() {
+    let (pool, _) = build_pool_with_counters(2);
+    pool.mark_unhealthy(0);
+    pool.mark_unhealthy(1);
+    assert!(pool.pick().is_none());
+}
+
+#[tokio::test]
+async fn execute_script_returns_pool_unavailable_when_all_unhealthy() {
+    let (pool, counters) = build_pool_with_counters(2);
+    pool.mark_unhealthy(0);
+    pool.mark_unhealthy(1);
+
+    let result = pool.execute_script("x.js".into(), "1".into()).await;
+    assert!(result.is_err());
+    let msg = match result {
+        Ok(_) => String::new(),
+        Err(e) => e.to_string(),
+    };
+    assert!(msg.contains("No healthy JS runtime available in pool"), "got: {msg}");
+
+    assert_eq!(counters[0].load(Ordering::SeqCst), 0);
+    assert_eq!(counters[1].load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn execute_script_batch_emits_pool_unavailable_for_each_script_when_all_unhealthy()
+-> Result<(), RariError> {
+    let (pool, _counters) = build_pool_with_counters(2);
+    pool.mark_unhealthy(0);
+    pool.mark_unhealthy(1);
+
+    let scripts = vec![
+        ("a".to_string(), "1".to_string()),
+        ("b".to_string(), "2".to_string()),
+        ("c".to_string(), "3".to_string()),
+    ];
+    let expected_len = scripts.len();
+    let mut rx = pool.execute_script_batch(scripts).await;
+
+    let mut errors: Vec<(usize, String)> = Vec::new();
+    for _ in 0..expected_len {
+        match rx.recv().await {
+            Some((idx, Err(e))) => errors.push((idx, e.to_string())),
+            Some((idx, Ok(_))) => {
+                return Err(RariError::js_runtime(format!("expected error at idx {idx}, got Ok")));
+            }
+            None => {
+                return Err(RariError::js_runtime(format!(
+                    "channel closed before receiving all {expected_len} errors"
+                )));
+            }
+        }
+    }
+    assert_eq!(rx.recv().await, None, "receiver should be closed after N errors");
+
+    assert_eq!(errors.len(), expected_len);
+    let mut indices: Vec<usize> = errors.iter().map(|(i, _)| *i).collect();
+    indices.sort_unstable();
+    assert_eq!(indices, vec![0, 1, 2]);
+    for (_, msg) in &errors {
+        assert!(msg.contains("No healthy JS runtime available in pool"), "got: {msg}");
+    }
+    Ok(())
+}
+
+#[test]
+fn pick_runtime_returns_error_when_all_unhealthy() {
+    let (pool, _) = build_pool_with_counters(2);
+    pool.mark_unhealthy(0);
+    pool.mark_unhealthy(1);
+    assert!(pool.pick_runtime().is_err());
+}
+
+#[tokio::test]
+async fn pooled_runtime_is_sticky_across_calls() -> Result<(), RariError> {
+    let (pool, _counters) = build_pool_with_counters(3);
+    let handle = pool.pick_runtime()?;
+    let expected_idx = handle.idx();
+    let expected_runtime = Arc::clone(handle.runtime());
+
+    for i in 0..3 {
+        if i != expected_idx {
+            pool.mark_unhealthy(i);
+        }
+    }
+
+    assert!(Arc::ptr_eq(handle.runtime(), &expected_runtime));
+    assert_eq!(handle.idx(), expected_idx);
+
+    pool.mark_unhealthy(expected_idx);
+
+    assert!(Arc::ptr_eq(handle.runtime(), &expected_runtime));
+    assert_eq!(handle.idx(), expected_idx);
+    Ok(())
+}
+
+#[tokio::test]
+async fn pooled_runtime_routes_through_self_runtime_after_pool_changes() -> Result<(), RariError> {
+    let (pool, counters) = build_pool_with_counters(3);
+    let handle = pool.pick_runtime()?;
+    let picked_idx = handle.idx();
+
+    pool.mark_unhealthy(0);
+    pool.mark_unhealthy(2);
+
+    handle.execute_script("s.js".into(), "x".into()).await?;
+    handle.execute_script("s.js".into(), "y".into()).await?;
+
+    assert_eq!(counters[picked_idx].load(Ordering::SeqCst), 2);
+    assert_eq!(counters[(picked_idx + 1) % 3].load(Ordering::SeqCst), 0);
+    Ok(())
+}
+
+struct RequestContextRuntime {
+    last_seen: Arc<std::sync::Mutex<Option<Arc<RequestContext>>>>,
+    fail_cleanup: Arc<AtomicBool>,
+}
+
+impl JsRuntimeInterface for RequestContextRuntime {
+    fn execute_script(
+        &self,
+        _script_name: String,
+        _script_code: String,
+    ) -> Pin<Box<dyn Future<Output = Result<JsonValue, RariError>> + Send>> {
+        Box::pin(async move { Ok(json!({"ok": true})) })
+    }
+
+    fn execute_script_batch(
+        &self,
+        _scripts: Vec<(String, String)>,
+    ) -> Pin<
+        Box<
+            dyn Future<Output = mpsc::UnboundedReceiver<(usize, Result<JsonValue, RariError>)>>
+                + Send,
+        >,
+    > {
+        let (_tx, rx) = mpsc::unbounded_channel();
+        Box::pin(async move { rx })
+    }
+
+    fn execute_function(
+        &self,
+        _function_name: &str,
+        _args: Vec<JsonValue>,
+    ) -> Pin<Box<dyn Future<Output = Result<JsonValue, RariError>> + Send + 'static>> {
+        Box::pin(async move { Ok(json!(null)) })
+    }
+
+    fn add_module_to_loader(
+        &self,
+        _specifier: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn load_es_module(
+        &self,
+        _specifier: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<deno_core::ModuleId, RariError>> + Send>> {
+        Box::pin(async move { Ok(0) })
+    }
+
+    fn evaluate_module(
+        &self,
+        _module_id: deno_core::ModuleId,
+    ) -> Pin<Box<dyn Future<Output = Result<JsonValue, RariError>> + Send>> {
+        Box::pin(async move { Ok(json!(null)) })
+    }
+
+    fn get_module_namespace(
+        &self,
+        _module_id: deno_core::ModuleId,
+    ) -> Pin<Box<dyn Future<Output = Result<JsonValue, RariError>> + Send>> {
+        Box::pin(async move { Ok(json!(null)) })
+    }
+
+    fn add_module_to_loader_only(
+        &self,
+        _specifier: &str,
+        _code: String,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn clear_module_loader_caches(
+        &self,
+        _component_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn set_request_context(
+        &self,
+        request_context: Arc<RequestContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        let last_seen = Arc::clone(&self.last_seen);
+        Box::pin(async move {
+            let mut guard = last_seen
+                .lock()
+                .map_err(|_| RariError::js_runtime("request context mutex poisoned".to_string()))?;
+            *guard = Some(Arc::clone(&request_context));
+            Ok(())
+        })
+    }
+
+    fn clear_request_context(&self) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn clear_request_context_if_matches(
+        &self,
+        expected_context: Arc<RequestContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        let last_seen = Arc::clone(&self.last_seen);
+        let fail_cleanup = Arc::clone(&self.fail_cleanup);
+        Box::pin(async move {
+            if fail_cleanup.load(Ordering::Acquire) {
+                return Err(RariError::js_runtime("forced cleanup failure".to_string()));
+            }
+            let mut guard = last_seen
+                .lock()
+                .map_err(|_| RariError::js_runtime("request context mutex poisoned".to_string()))?;
+            if let Some(current) = guard.as_ref() {
+                if Arc::ptr_eq(current, &expected_context) {
+                    *guard = None;
+                    return Ok(());
+                }
+                return Err(RariError::js_runtime("request context mismatch on clear".to_string()));
+            }
+            Err(RariError::js_runtime("no request context to clear".to_string()))
+        })
+    }
+}
+
+type LastSeenSlot = Arc<std::sync::Mutex<Option<Arc<RequestContext>>>>;
+
+fn build_pool_with_distinct_request_context_runtimes(
+    size: usize,
+) -> (Arc<JsRuntimePool>, Vec<LastSeenSlot>) {
+    let last_seens: Vec<LastSeenSlot> =
+        (0..size).map(|_| Arc::new(std::sync::Mutex::new(None))).collect();
+    let runtimes: Vec<Arc<dyn JsRuntimeInterface>> = last_seens
+        .iter()
+        .map(|ls| {
+            Arc::new(RequestContextRuntime {
+                last_seen: Arc::clone(ls),
+                fail_cleanup: Arc::new(AtomicBool::new(false)),
+            }) as Arc<dyn JsRuntimeInterface>
+        })
+        .collect();
+    let healthy = runtimes.iter().map(|_| AtomicBool::new(true)).collect();
+    let pool = Arc::new(JsRuntimePool {
+        runtimes,
+        pick_strategy: Arc::new(RoundRobinStrategy),
+        next_index: AtomicUsize::new(0),
+        healthy,
+        setup_mode: AtomicBool::new(false),
+    });
+    (pool, last_seens)
+}
+
+#[tokio::test]
+async fn pooled_runtime_set_and_clear_request_context_round_trip() -> Result<(), RariError> {
+    let (pool, last_seens) = build_pool_with_distinct_request_context_runtimes(2);
+
+    let handle = pool.pick_runtime()?;
+    let picked_idx = handle.idx();
+    let ctx = Arc::new(RequestContext::new("/test".to_string()));
+
+    handle.set_request_context(Arc::clone(&ctx)).await?;
+    assert!(
+        last_seens[picked_idx].lock().map(|guard| guard.is_some()).unwrap_or(false),
+        "set_request_context must touch the picked runtime, not another slot"
+    );
+    for (i, ls) in last_seens.iter().enumerate() {
+        if i != picked_idx {
+            assert!(
+                ls.lock().map(|guard| guard.is_none()).unwrap_or(true),
+                "non-picked runtime {i} must not be touched"
+            );
+        }
+    }
+
+    handle.clear_request_context_if_matches(Arc::clone(&ctx)).await?;
+    assert!(
+        last_seens[picked_idx].lock().map(|guard| guard.is_none()).unwrap_or(false),
+        "clear must touch the same runtime that was set"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn load_and_evaluate_module_returns_ok_on_healthy_pool() -> Result<(), RariError> {
+    let (pool, _counters) = build_pool_with_counters(2);
+    let result = pool.load_and_evaluate_module("m.js").await;
+    assert!(result.is_ok(), "load_and_evaluate_module should succeed on healthy pool");
+    let (module_id, _) = result?;
+    assert_eq!(module_id, 0, "fake CountingRuntime returns Ok(0) for load_es_module");
+    Ok(())
+}
+
+#[tokio::test]
+async fn load_and_evaluate_module_returns_pool_unavailable_when_all_unhealthy() {
+    let (pool, _counters) = build_pool_with_counters(2);
+    pool.mark_unhealthy(0);
+    pool.mark_unhealthy(1);
+
+    let result = pool.load_and_evaluate_module("m.js").await;
+    assert!(result.is_err());
+    let msg = match result {
+        Ok(_) => String::new(),
+        Err(e) => e.to_string(),
+    };
+    assert!(msg.contains("No healthy JS runtime available in pool"), "got: {msg}");
+}
+
+#[tokio::test]
+async fn with_request_context_runs_op_and_cleans_up() {
+    let (pool, last_seens) = build_pool_with_distinct_request_context_runtimes(2);
+
+    let ctx = Arc::new(RequestContext::new("/with_req_ctx".to_string()));
+    let ctx_for_op = Arc::clone(&ctx);
+
+    let observed_during_op = Arc::new(std::sync::Mutex::new(false));
+
+    let observed_inside = Arc::clone(&observed_during_op);
+    let result = pool
+        .with_request_context(Arc::clone(&ctx), move |runtime| {
+            let observed = observed_inside;
+            let ctx_for_op = ctx_for_op;
+            async move {
+                let _ = runtime.execute_script("noop".into(), "1".into()).await?;
+                let mut observed = observed
+                    .lock()
+                    .map_err(|_| RariError::js_runtime("observed mutex poisoned".to_string()))?;
+                *observed = true;
+                drop(observed);
+                let _ = ctx_for_op;
+                Ok::<_, RariError>(())
+            }
+        })
+        .await;
+
+    assert!(result.is_ok());
+    assert!(
+        observed_during_op.lock().map(|guard| *guard).unwrap_or(false),
+        "op must have executed on a runtime"
+    );
+    let touched: Vec<usize> = last_seens
+        .iter()
+        .enumerate()
+        .filter_map(|(i, ls)| {
+            if ls.lock().map(|guard| guard.is_some()).unwrap_or(false) { Some(i) } else { None }
+        })
+        .collect();
+    assert_eq!(
+        touched.len(),
+        0,
+        "no runtime should retain ctx after with_request_context returns; touched: {touched:?}"
+    );
+}
+
+#[tokio::test]
+async fn with_request_context_cleans_up_even_when_op_errors() {
+    let (pool, last_seens) = build_pool_with_distinct_request_context_runtimes(1);
+
+    let ctx = Arc::new(RequestContext::new("/error_path".to_string()));
+
+    let result = pool
+        .with_request_context(Arc::clone(&ctx), |_runtime| async {
+            Err::<(), _>(RariError::js_runtime("op failed".to_string()))
+        })
+        .await;
+
+    assert!(result.is_err());
+    assert!(
+        last_seens[0].lock().map(|guard| guard.is_none()).unwrap_or(false),
+        "ctx must be cleared even when op returns Err"
+    );
+}
+
+#[tokio::test]
+async fn with_request_context_returns_op_value_when_cleanup_fails() -> Result<(), RariError> {
+    let fail_flag = Arc::new(AtomicBool::new(true));
+    let last_seen = Arc::new(std::sync::Mutex::new(None));
+    let runtime: Arc<dyn JsRuntimeInterface> = Arc::new(RequestContextRuntime {
+        last_seen: Arc::clone(&last_seen),
+        fail_cleanup: Arc::clone(&fail_flag),
+    });
+    let runtimes: Vec<Arc<dyn JsRuntimeInterface>> = vec![Arc::clone(&runtime)];
+    let healthy = runtimes.iter().map(|_| AtomicBool::new(true)).collect();
+    let pool = Arc::new(JsRuntimePool {
+        runtimes,
+        pick_strategy: Arc::new(RoundRobinStrategy),
+        next_index: AtomicUsize::new(0),
+        healthy,
+        setup_mode: AtomicBool::new(false),
+    });
+
+    let ctx = Arc::new(RequestContext::new("/cleanup_fails".to_string()));
+
+    let value =
+        pool.with_request_context(Arc::clone(&ctx), |_runtime| async { Ok(42_i32) }).await?;
+    assert_eq!(value, 42);
+    Ok(())
+}
+
+#[tokio::test]
+async fn setup_mode_error_message_uses_executed_not_total() {
+    let (pool, flags) = build_pool_with_fail_flags(4);
+    pool.mark_unhealthy(1);
+    pool.mark_unhealthy(3);
+    pool.set_setup_mode(true);
+    flags[2].store(true, Ordering::SeqCst);
+
+    let result = pool.execute_script("setup.js".into(), "init".into()).await;
+    let msg = match result {
+        Ok(_) => String::new(),
+        Err(e) => e.to_string(),
+    };
+    assert!(
+        msg.contains("1 of 2 runtimes"),
+        "error must report failed/attempted (1 of 2), got: {msg}"
+    );
+    assert!(!msg.contains("1 of 4 runtimes"), "error must not use total pool size, got: {msg}");
+}
+
+#[tokio::test]
+async fn invalidate_component_all_error_uses_executed_not_total() {
+    let (pool, flags) = build_pool_with_fail_flags(4);
+    pool.mark_unhealthy(0);
+    pool.mark_unhealthy(3);
+    flags[2].store(true, Ordering::SeqCst);
+
+    let result = pool.invalidate_component_all("MyComponent").await;
+    let msg = match result {
+        Ok(()) => String::new(),
+        Err(e) => e.to_string(),
+    };
+    assert!(
+        msg.contains("1 of 2 runtimes"),
+        "error must report failed/attempted (1 of 2), got: {msg}"
+    );
+}

--- a/tools/prepare-binaries/src/use_cache_addon.rs
+++ b/tools/prepare-binaries/src/use_cache_addon.rs
@@ -16,6 +16,34 @@ fn addon_napi_output_path(target_info: &Target, project_root: &Path) -> PathBuf 
     project_root.join(ADDON_BUILD_DIR).join(format!("rari-use-cache.{}.node", target_info.platform))
 }
 
+fn find_addon_artifact(target_info: &Target, project_root: &Path) -> Option<PathBuf> {
+    let dir = project_root.join(ADDON_BUILD_DIR);
+    let exact = addon_napi_output_path(target_info, project_root);
+    if exact.exists() {
+        return Some(exact);
+    }
+    for abi in ["msvc", "gnu", "musl"] {
+        let with_abi = dir.join(format!("rari-use-cache.{}-{abi}.node", target_info.platform));
+        if with_abi.exists() {
+            return Some(with_abi);
+        }
+    }
+    if let Ok(entries) = fs::read_dir(&dir) {
+        let prefix = format!("rari-use-cache.{}.", target_info.platform);
+        let mut matches: Vec<PathBuf> = entries
+            .flatten()
+            .map(|entry| (entry.file_name().to_string_lossy().to_string(), entry.path()))
+            .filter(|(name, _)| name.starts_with(&prefix) && name.ends_with(".node"))
+            .map(|(_, path)| path)
+            .collect();
+        if !matches.is_empty() {
+            matches.sort();
+            return matches.into_iter().next();
+        }
+    }
+    None
+}
+
 fn addon_stable_output_path(target_info: &Target, project_root: &Path) -> PathBuf {
     project_root.join(ADDON_BUILD_DIR).join(target_info.platform).join(ADDON_OUTPUT_FILE)
 }
@@ -114,11 +142,13 @@ pub async fn build_addon(
         return Ok(false);
     }
 
-    let src = addon_napi_output_path(target_info, project_root);
-    if !src.exists() {
-        log_error(&format!("expected addon artifact not found: {}", src.display()));
+    let Some(src) = find_addon_artifact(target_info, project_root) else {
+        log_error(&format!(
+            "expected addon artifact not found: {}",
+            addon_napi_output_path(target_info, project_root).display()
+        ));
         return Ok(false);
-    }
+    };
 
     let stable = addon_stable_output_path(target_info, project_root);
     if let Some(parent) = stable.parent() {


### PR DESCRIPTION
- Introduced `JsRuntimePool` to manage a pool of JavaScript runtimes.
- Added `PooledRuntime` to handle individual runtime interactions.
- Implemented round-robin strategy for runtime selection.
- Enhanced error handling for runtime availability.
- Created tests to validate runtime distribution and error scenarios.

## Pull Request Description

### Summary

Adds `JsRuntimePool`, an opt-in pool of independent V8 isolates behind a single rari process, so CPU-heavy SSR/RSC workloads can use multiple cores without k8s/PM2/systemd. Default pool size is 1 (binary-compatible with the previous single-runtime behaviour); `RARI_JS_POOL_SIZE > 1` enables it.

The pool is delivered as a self-contained module in this PR — `JsRuntimePool` is **dormant**: `factory/mod.rs` declares `pub mod pool;` but no production caller wires the pool into `JsExecutionRuntime` yet. That wiring lives in the follow-up `feat/js-runtime-pool-wiring` PR.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔧 Code refactoring (no functional changes)
- [x] 🧪 Test improvements

### Related Issues

- Relates to #223 (HMR invalidation must surface errors instead of silently continuing).
- Relates to issue around multi-core SSR distribution (no upstream issue id known).

### Motivation and Context

A single `RariRuntime` (V8 isolate) is the throughput ceiling for one rari process. With CPU-bound SSR/RSC workloads, requests serialize behind the isolate. Spinning multiple isolates per process lets a single `node` use multiple cores without paying the cold-start / IPC cost of forking the whole process.

A pool also has subtle pitfalls this PR addresses up-front:

- **Sticky runtime for stateful multi-step sequences.** `load_es_module` → `evaluate_module` returns a `ModuleId` that only makes sense on the same isolate; the same is true for `set_request_context` → ... → `clear_request_context_if_matches`. Naïve per-call `pick()` can split these across runtimes. This PR adds `PooledRuntime` (a sticky handle) so callers can pin a runtime for a sequence.
- **All-unhealthy pool must fail loudly.** Earlier drafts silently routed to slot 0 when every slot was marked unhealthy, masking real failures. `pick()` now returns `Option<usize>` and callers surface a clear `No healthy JS runtime available in pool` error.
- **HMR / setup-time broadcast.** Initial setup and HMR invalidation must reach every isolate, not just the picked one. `setup_mode` plus the `broadcast_*` methods handle this; `invalidate_component_all` aggregates errors instead of swallowing them.

## Changes Made

### Code Changes

- **New module `runtime::factory::pool`** (6 files):
  - `pool/mod.rs` — `JsRuntimePool` struct, `Debug` impl, constructors (`new`, `with_strategy`), getters (`size`, `runtime_at`), health API (`mark_unhealthy`, `mark_healthy`, `is_healthy`, `healthy_count`, `all_healthy_indices`), setup-mode API, and `pick_runtime()` returning a sticky `PooledRuntime`. Declares `mod strategy; mod interface; mod broadcast; mod handle;` and re-exports `PooledRuntime`, `PickStrategy`, `RoundRobinStrategy`.
  - `pool/strategy.rs` — `PickStrategy` trait (returns `Option<usize>`) and `RoundRobinStrategy` impl (round-robin via `AtomicUsize`, returns `None` when healthy set is empty).
  - `pool/interface.rs` — `impl JsRuntimeInterface for JsRuntimePool`. `execute_script`, `add_module_to_loader_only`, and `clear_module_loader_caches` branch on `setup_mode` to broadcast across every runtime; other methods pick one runtime via `Arc::clone(&self.runtimes[self.pick()?])` and return a clear pool-unavailable error if no runtime is healthy.
  - `pool/broadcast.rs` — `invalidate_component_all`, `load_component_code_all`, and `broadcast_*` methods on `JsRuntimePool`, plus free helpers `sanitize`, `build_invalidate_script`, and `dispatch_load_component` (ESM detection + module load + evaluate + `~rsc` registration script). All aggregate per-runtime errors and surface them as a single `RariError::js_runtime` so a partial failure is not silently swallowed.
  - `pool/handle.rs` — `PooledRuntime` sticky handle with forward methods (`execute_script`, `execute_function`, `add_module_to_loader_only`, `clear_module_loader_caches`, `load_es_module`, `evaluate_module`, `get_module_namespace`, `set_request_context`, `clear_request_context`, `clear_request_context_if_matches`). Implementations are generated by the local `forward_to_runtime!` macro so adding a new forwarded method is a one-line change.
  - `pool/tests.rs` — 18 unit tests (see Testing).
- **`factory/mod.rs`** — adds `pub mod pool;`. This is the only edit to a previously-existing file in this PR.

### API Changes

New public API (inside `runtime::factory::pool`):

- `JsRuntimePool::new(pool_size, env_vars) -> Result<Arc<JsRuntimePool>, RariError>` and `JsRuntimePool::with_strategy(...)` for custom pick strategies.
- `JsRuntimePool::pick_runtime() -> Result<PooledRuntime, RariError>` — sticky handle for multi-step sequences.
- `PooledRuntime` — see `pool/handle.rs`. `idx()`, `runtime()`, and the forwarded methods.
- `PickStrategy` trait + `RoundRobinStrategy` (re-exported from `pool::mod`).

**Breaking changes to API introduced by this PR:**

- `JsRuntimePool::pick()` now returns `Option<usize>` (was `usize`). Callers must handle the `None` case.
- `PickStrategy::pick(&self, healthy_indices, next)` now returns `Option<usize>` (was `usize`). External implementors of `PickStrategy` will need to be updated.

Both changes are scoped to types declared inside `runtime::factory::pool`, which is **new in this PR**. There is no production caller of either method yet (the wiring is in the follow-up PR), so the breakage is contained.

### Configuration Changes

None in this PR. The wiring PR will introduce `RuntimeConfig::js_pool_size` and `RARI_JS_POOL_SIZE` env var.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed
- [ ] Performance benchmarks run
- [ ] Cross-platform testing completed

### Test Results

```bash
$ cargo test -p rari --lib runtime::factory::pool
running 18 tests
test runtime::factory::pool::tests::healthy_count_tracks_marks ... ok
test runtime::factory::pool::tests::pick_returns_none_when_all_unhealthy ... ok
test runtime::factory::pool::tests::pick_runtime_returns_error_when_all_unhealthy ... ok
test runtime::factory::pool::tests::pool_size_zero_is_rejected ... ok
test runtime::factory::pool::tests::execute_script_returns_pool_unavailable_when_all_unhealthy ... ok
test runtime::factory::pool::tests::execute_script_batch_emits_pool_unavailable_for_each_script_when_all_unhealthy ... ok
test runtime::factory::pool::tests::pooled_runtime_is_sticky_across_calls ... ok
test runtime::factory::pool::tests::pooled_runtime_routes_through_self_runtime_after_pool_changes ... ok
test runtime::factory::pool::tests::pooled_runtime_set_and_clear_request_context_round_trip ... ok
test runtime::factory::pool::tests::round_robin_distributes_across_runtimes ... ok
test runtime::factory::pool::tests::pool_size_one_picks_always_index_zero ... ok
test runtime::factory::pool::tests::pool_size_one_behaves_like_single_runtime ... ok
test runtime::factory::pool::tests::mark_unhealthy_changes_round_robin_distribution ... ok
test runtime::factory::pool::tests::mark_healthy_restores_round_robin ... ok
test runtime::factory::pool::tests::setup_mode_broadcasts_to_all_runtimes ... ok
test runtime::factory::pool::tests::setup_mode_aggregates_errors ... ok
test runtime::factory::pool::tests::invalidate_component_all_succeeds_when_all_runtimes_ok ... ok
test runtime::factory::pool::tests::invalidate_component_all_returns_error_when_some_runtime_fails ... ok

test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 540 filtered out
```

```bash
$ cargo fmt -p rari -- --check
(clean)

$ cargo check -p rari --lib --tests
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.08s
    warning: num-bigint-dig v0.8.2 (third-party, not this PR)
```

### Manual Testing Steps

Not applicable in this PR. `JsRuntimePool` is dormant until the wiring PR threads it through `JsExecutionRuntime` and `RuntimeConfig`. Until then, end-to-end behaviour is identical to the previous single-runtime path (pool size 1).

1. (Wiring PR, future) Set `RARI_JS_POOL_SIZE=4`, boot rari, confirm `RuntimeConfig::js_pool_size == 4` and `JsExecutionRuntime` holds an `Arc<JsRuntimePool>`.
2. (Wiring PR, future) Hit a steady-state SSR endpoint, verify `counters` on each isolate advance roughly evenly via round-robin.
3. (Wiring PR, future) Manually `mark_unhealthy(2)` on three slots, confirm next request returns `No healthy JS runtime available in pool` instead of silently succeeding on slot 0.

## Performance Impact

### Performance Considerations

- [ ] No performance impact expected
- [x] Performance improvement (provide metrics)
- [ ] Potential performance impact (explain and justify)
- [ ] Performance regression (explain mitigation)

When `RARI_JS_POOL_SIZE > 1`, CPU-heavy SSR/RSC workloads scale roughly linearly with the pool size up to physical core count (each isolate holds its own V8 heap, no shared state between them). The default size is 1, so existing single-tenant deployments see no change.

No benchmarks are included in this PR — pool selection is the responsibility of the wiring PR, which is also where end-to-end benchmarks will live.

### Benchmarks

Not applicable in this PR (see Manual Testing above).

## Breaking Changes

### Breaking Changes Details

- `JsRuntimePool::pick()`: `usize` → `Option<usize>`.
- `PickStrategy::pick(...)`: `usize` → `Option<usize>`.

Both types are new to this PR. There is no in-tree caller outside the pool module itself, so the surface is contained. External implementors of `PickStrategy` (if any) will need to be updated to return `Option<usize>` and use `None` for an empty healthy set.

### Migration Guide

For external `PickStrategy` implementors:

```rust
// Before
impl PickStrategy for MyStrategy {
    fn pick(&self, healthy_indices: &[usize], next: &AtomicUsize) -> usize {
        healthy_indices[0] // or any fallback
    }
}

// After
impl PickStrategy for MyStrategy {
    fn pick(&self, healthy_indices: &[usize], next: &AtomicUsize) -> Option<usize> {
        if healthy_indices.is_empty() {
            None
        } else {
            Some(healthy_indices[0])
        }
    }
}
```

For callers of `JsRuntimePool::pick()`:

```rust
// Before
let idx = pool.pick();
let runtime = &pool.runtimes[idx];

// After
match pool.pick() {
    Some(idx) => { let runtime = &pool.runtimes[idx]; ... }
    None => return Err(RariError::js_runtime("No healthy JS runtime available in pool".into())),
}
```

Prefer `JsRuntimePool::pick_runtime()` over direct `pick()` — it returns a `PooledRuntime` sticky handle and is the right primitive for any multi-step sequence.

## Documentation

### Documentation Updates

- [x] API documentation updated (rustdoc on `PooledRuntime`, `JsRuntimePool::pick_runtime`, `JsRuntimePool::pick`).
- [ ] Code comments added/updated — author avoids `//`-comments per project convention; rustdoc carries the API explanation.
- [ ] No documentation changes needed

### Documentation Links

Rustdoc is rendered by `cargo doc -p rari --open` after this PR merges.

## Checklist

### General

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings (third-party `num-bigint-dig` warning pre-existed)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Rust-specific

- [x] Code compiles without warnings (`cargo check -p rari --lib --tests`)
- [x] All tests pass (`cargo test -p rari --lib runtime::factory::pool` — 18/18)
- [x] Code is properly formatted (`cargo fmt -p rari -- --check`)
- [ ] Clippy checks pass — not run in this session; will be checked in CI
- [x] Public APIs are documented with doc comments
- [x] No unsafe code introduced

### Build & Release

- [x] Build process works correctly (`cargo check` clean)
- [ ] Version numbers updated (if applicable) — N/A
- [ ] Changelog updated (if applicable) — deferred to release notes

### Security

- [x] No sensitive information exposed in code or commits
- [x] Dependencies are up to date and secure (no new deps in this PR)
- [x] Input validation implemented where needed (`pool_size == 0` is rejected by `JsRuntimePool::new`)

## Additional Context

### Related Work

- **Follow-up PR:** `feat/js-runtime-pool-wiring` (separate). Threads `JsRuntimePool` through `JsExecutionRuntime`, `RuntimeConfig`, `RARI_JS_POOL_SIZE`, and the streaming pin. Also migrates `api_routes.rs:442` and `rsc/rendering/layout/core.rs:604` to use `JsRuntimePool::pick_runtime()` instead of the per-call `JsRuntimeInterface` path, closing the multi-runtime-hop gap for `add_module_to_loader_only` → `load_es_module` → `evaluate_module` and for `set_request_context` → ... → `clear_request_context_if_matches`.

### Future Work

- Custom `PickStrategy` impls (e.g. least-loaded, jittered) — exposed via `JsRuntimePool::with_strategy` but no shipped strategy beyond round-robin.
- Per-runtime restart coordination — `mark_unhealthy`/`mark_healthy` API is in place; restart policy is intentionally out of scope.
- Real `JsExecutionRuntime` integration tests using two real V8 isolates (covered by the wiring PR's e2e tests).

### Notes for Reviewers

- The pool module is **dormant** in this PR. `factory/mod.rs` declares `pub mod pool;`, but `JsExecutionRuntime` and the rest of the production code path still construct a single `RariRuntime`. Behaviour in production is identical to the previous single-runtime path (pool size 1, round-robin degrades to slot 0).
- `factory/mod.rs` change is intentionally one line (`pub mod pool;`) so the wiring PR can branch off cleanly without re-touching the module declaration.
- The `PickStrategy::pick -> Option<usize>` signature change is the only public-API-level breakage. There are no in-tree callers outside the module, so the blast radius is contained to external crate authors (none today).
- The forward macro in `pool/handle.rs` is local to that file (`macro_rules!` not `pub`). Adding a new forwarded method is a single line in the macro invocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pooled JavaScript runtime with health tracking, round-robin selection, and request-context-aware execution.
  * Added pool-wide broadcast utilities to load/evaluate modules and invalidate/clear cached component state across all runtimes.
* **Bug Fixes**
  * Improved failure handling when no healthy runtime is available, including consistent error messaging and per-item batch reporting.
  * Added more robust native addon artifact discovery during binary preparation.
* **Tests / Chores**
  * Expanded pool test coverage and updated Windows-specific assertions/behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->