### PR TITLE
refactor: streamline clippy allow attributes and update string formatting

### DIFF
--- a/crates/rari-rsc/src/components.rs
+++ b/crates/rari-rsc/src/components.rs
@@ -454,27 +454,7 @@ impl Default for ComponentRegistry {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use smallvec::smallvec;
 

--- a/crates/rari-rsc/src/flight/escape.rs
+++ b/crates/rari-rsc/src/flight/escape.rs
@@ -109,27 +109,6 @@ pub fn unescape_rsc_value(value: &Value) -> Value {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
 mod tests {
     use serde_json::json;
 
@@ -176,7 +155,7 @@ mod tests {
         for case in test_cases {
             let escaped = escape_rsc_string(case);
             let unescaped = unescape_rsc_string(&escaped);
-            assert_eq!(unescaped, case, "Roundtrip failed for: {}", case);
+            assert_eq!(unescaped, case, "Roundtrip failed for: {case}");
         }
     }
 

--- a/crates/rari-rsc/src/flight/parser.rs
+++ b/crates/rari-rsc/src/flight/parser.rs
@@ -291,27 +291,7 @@ impl RscFlightParser {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::panic)]
 mod tests {
     use super::*;
 
@@ -746,15 +726,15 @@ mod tests {
         ];
 
         for (marker, description) in markers {
-            let rsc = format!(r#"0:"{}""#, marker);
+            let rsc = format!(r#"0:"{marker}""#);
             let mut parser = RscFlightParser::new(&rsc);
-            assert!(parser.parse().is_ok(), "Failed to parse {}", description);
+            assert!(parser.parse().is_ok(), "Failed to parse {description}");
 
             let elements = parser.elements();
             if let Some(RscElement::Reference(ref_str)) = elements.get(&0) {
-                assert_eq!(ref_str, marker, "Marker mismatch for {}", description);
+                assert_eq!(ref_str, marker, "Marker mismatch for {description}");
             } else {
-                panic!("Expected Reference element for {}", description);
+                panic!("Expected Reference element for {description}");
             }
         }
     }
@@ -808,15 +788,15 @@ mod tests {
         ];
 
         for (marker, description) in markers {
-            let rsc = format!(r#"0:"{}""#, marker);
+            let rsc = format!(r#"0:"{marker}""#);
             let mut parser = RscFlightParser::new(&rsc);
-            assert!(parser.parse().is_ok(), "Failed to parse {}: {}", marker, description);
+            assert!(parser.parse().is_ok(), "Failed to parse {marker}: {description}");
 
             let elements = parser.elements();
             if let Some(RscElement::Reference(ref_str)) = elements.get(&0) {
-                assert_eq!(ref_str, marker, "Marker mismatch for {}: {}", marker, description);
+                assert_eq!(ref_str, marker, "Marker mismatch for {marker}: {description}");
             } else {
-                panic!("Expected Reference element for {}: {}", marker, description);
+                panic!("Expected Reference element for {marker}: {description}");
             }
         }
     }

--- a/crates/rari-rsc/src/flight/serializer.rs
+++ b/crates/rari-rsc/src/flight/serializer.rs
@@ -1451,27 +1451,6 @@ impl SerializedReactElement {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
 mod tests {
     use super::*;
     use crate::types::ReactElement as LoadingReactElement;

--- a/crates/rari-rsc/src/types.rs
+++ b/crates/rari-rsc/src/types.rs
@@ -404,27 +404,7 @@ impl RSCRenderResult {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::panic, clippy::unwrap_used)]
 mod tests {
     use serde_json::json;
 

--- a/crates/rari-rsc/src/utils.rs
+++ b/crates/rari-rsc/src/utils.rs
@@ -48,33 +48,12 @@ pub fn hash_string(s: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_extract_dependencies() {
-        let code = r#"
+        let code = r"
         import React from 'react';
         import { useState } from 'react';
         import Button from './Button';
@@ -83,7 +62,7 @@ mod tests {
         export default function Component() {
             return <div>Test</div>;
         }
-        "#;
+        ";
 
         let dependencies = extract_dependencies(code);
         assert_eq!(dependencies.len(), 2);

--- a/crates/rari/src/rendering/base/mod.rs
+++ b/crates/rari/src/rendering/base/mod.rs
@@ -11,27 +11,7 @@ pub use sanitizer::sanitize_component_output;
 pub use types::{ResourceLimits, ResourceMetrics, ResourceTracker};
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use std::sync::Arc;
 
@@ -85,14 +65,14 @@ mod tests {
 
         renderer.initialize().await.expect("Failed to initialize renderer");
 
-        let register_component_js = r#"
+        let register_component_js = r"
         globalThis.MyJsxComponent = function(props) {
             return React.createElement('h1', null, 'Hello ' + (props.name || 'JSX World') + '!');
         };
 
         globalThis.Component_a83fd0f5d95fb38e = globalThis.MyJsxComponent;
         true
-        "#;
+        ";
 
         {
             let mut registry = renderer.component_registry.lock();
@@ -111,7 +91,7 @@ mod tests {
         assert!(renderer.initialized);
 
         let output = render_result.expect("Rendering should succeed");
-        assert!(output.contains("<"), "Output should contain some HTML content");
+        assert!(output.contains('<'), "Output should contain some HTML content");
     }
 
     #[tokio::test]

--- a/crates/rari/src/rendering/base/sanitizer.rs
+++ b/crates/rari/src/rendering/base/sanitizer.rs
@@ -21,27 +21,6 @@ pub fn sanitize_component_output(html: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
 mod tests {
     use super::*;
 
@@ -67,7 +46,7 @@ mod tests {
 
     #[test]
     fn test_sanitize_preserves_normal_content() {
-        let html = r#"<div><h1>Title</h1><p>Paragraph</p></div>"#;
+        let html = r"<div><h1>Title</h1><p>Paragraph</p></div>";
         let result = sanitize_component_output(html);
         assert_eq!(result, html);
     }

--- a/crates/rari/src/rendering/layout/core.rs
+++ b/crates/rari/src/rendering/layout/core.rs
@@ -1284,27 +1284,7 @@ impl LayoutRenderer {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::server::cache::handler::NoOpCacheHandler;

--- a/crates/rari/src/rendering/layout/mod.rs
+++ b/crates/rari/src/rendering/layout/mod.rs
@@ -11,27 +11,7 @@ pub use types::*;
 pub use utils::create_layout_context;
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::unwrap_used)]
 mod tests {
     use std::sync::Arc;
 

--- a/crates/rari/src/rendering/layout/route_composer.rs
+++ b/crates/rari/src/rendering/layout/route_composer.rs
@@ -254,27 +254,7 @@ impl RouteComposer {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -430,7 +410,7 @@ mod tests {
 
     fn template_info(file_path: &str) -> TemplateInfo {
         TemplateInfo {
-            component_id: format!("template:{}", file_path),
+            component_id: format!("template:{file_path}"),
             client_component_id: format!("src/app/{}", file_path.trim_end_matches(".tsx")),
             file_path: file_path.to_string(),
         }

--- a/crates/rari/src/rendering/static.rs
+++ b/crates/rari/src/rendering/static.rs
@@ -2217,27 +2217,7 @@ impl Default for RscToHtmlConverter {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::panic, clippy::unwrap_used, clippy::clone_on_ref_ptr)]
 mod tests {
     use super::*;
     use crate::server::config::Mode;
@@ -2906,7 +2886,7 @@ mod tests {
             assert!(props.contains_key("fallback"));
             assert!(props.contains_key("children"));
             assert!(props.contains_key("~boundaryId"));
-            assert_eq!(props.get("~boundaryId").unwrap().as_str().unwrap(), "suspense_123");
+            assert_eq!(props["~boundaryId"].as_str().unwrap(), "suspense_123");
         } else {
             panic!("Expected Component element");
         }
@@ -2986,9 +2966,9 @@ mod tests {
         let renderer = Arc::new(RscHtmlRenderer::new(runtime));
         let mut converter = RscToHtmlConverter::new(renderer);
 
-        converter.row_cache.insert(1, r#"<div>Outer Loading</div>"#.to_string());
-        converter.row_cache.insert(2, r#"<div>Inner Loading</div>"#.to_string());
-        converter.row_cache.insert(3, r#"<div>Inner Content</div>"#.to_string());
+        converter.row_cache.insert(1, r"<div>Outer Loading</div>".to_string());
+        converter.row_cache.insert(2, r"<div>Inner Loading</div>".to_string());
+        converter.row_cache.insert(3, r"<div>Inner Content</div>".to_string());
 
         let inner_suspense = serde_json::json!([
             "$",
@@ -3057,7 +3037,7 @@ mod tests {
         let renderer = Arc::new(RscHtmlRenderer::new(runtime));
         let mut converter = RscToHtmlConverter::new(renderer);
 
-        converter.row_cache.insert(1, r#"<div>Loading</div>"#.to_string());
+        converter.row_cache.insert(1, r"<div>Loading</div>".to_string());
 
         let suspense_element = serde_json::json!([
             "$",
@@ -3498,16 +3478,12 @@ b:["$","span",null,{"children":"Content from row 11 (hex b)"}]
 
         let html = renderer.render_rsc_to_html_string(&rows).await.unwrap();
 
-        assert!(html.contains("color:red"), "color should be in style: {}", html);
-        assert!(html.contains("padding:10px"), "padding should be in style: {}", html);
+        assert!(html.contains("color:red"), "color should be in style: {html}");
+        assert!(html.contains("padding:10px"), "padding should be in style: {html}");
 
-        assert!(
-            !html.contains("display:null"),
-            "display:null should not appear in style: {}",
-            html
-        );
-        assert!(!html.contains("margin:null"), "margin:null should not appear in style: {}", html);
-        assert!(!html.contains("null"), "The word 'null' should not appear in output: {}", html);
+        assert!(!html.contains("display:null"), "display:null should not appear in style: {html}");
+        assert!(!html.contains("margin:null"), "margin:null should not appear in style: {html}");
+        assert!(!html.contains("null"), "The word 'null' should not appear in output: {html}");
     }
 
     #[tokio::test]
@@ -3521,9 +3497,9 @@ b:["$","span",null,{"children":"Content from row 11 (hex b)"}]
 
         let html = renderer.render_rsc_to_html_string(&rows).await.unwrap();
 
-        assert!(!html.contains("null"), "Should not contain 'null' string: {}", html);
+        assert!(!html.contains("null"), "Should not contain 'null' string: {html}");
 
-        assert!(html.contains("class=\"test\""), "Should have class attribute: {}", html);
+        assert!(html.contains("class=\"test\""), "Should have class attribute: {html}");
     }
 
     #[tokio::test]
@@ -3555,7 +3531,7 @@ b:["$","span",null,{"children":"Content from row 11 (hex b)"}]
         let invalid_angle = serde_json::json!(["$", "div>script", null, {}]);
         let result = converter.rsc_element_to_html(&invalid_angle).await;
         if let Ok(html) = result {
-            panic!("Tag with angle bracket should be rejected, but got: {:?}", html);
+            panic!("Tag with angle bracket should be rejected, but got: {html:?}");
         }
         assert!(result.is_err(), "Tag with angle bracket should be rejected");
 
@@ -3608,7 +3584,7 @@ b:["$","span",null,{"children":"Content from row 11 (hex b)"}]
             let element = serde_json::json!(["$", malicious_tag, null, {}]);
             let result = converter.rsc_element_to_html(&element).await;
 
-            assert!(result.is_err(), "Malicious tag '{}' should be rejected", malicious_tag);
+            assert!(result.is_err(), "Malicious tag '{malicious_tag}' should be rejected");
         }
     }
 
@@ -3623,10 +3599,10 @@ b:["$","span",null,{"children":"Content from row 11 (hex b)"}]
 
         let html = renderer.render_rsc_to_html_string(&rows).await.unwrap();
 
-        assert!(html.contains("width:100px"), "Width should have px suffix: {}", html);
-        assert!(html.contains("height:200px"), "Height should have px suffix: {}", html);
-        assert!(html.contains("margin:10px"), "Margin should have px suffix: {}", html);
-        assert!(html.contains("padding:20px"), "Padding should have px suffix: {}", html);
+        assert!(html.contains("width:100px"), "Width should have px suffix: {html}");
+        assert!(html.contains("height:200px"), "Height should have px suffix: {html}");
+        assert!(html.contains("margin:10px"), "Margin should have px suffix: {html}");
+        assert!(html.contains("padding:20px"), "Padding should have px suffix: {html}");
     }
 
     #[tokio::test]
@@ -3639,14 +3615,10 @@ b:["$","span",null,{"children":"Content from row 11 (hex b)"}]
 
         let html = renderer.render_rsc_to_html_string(&rows).await.unwrap();
 
-        assert!(html.contains("opacity:0.5"), "Opacity should not have px suffix: {}", html);
-        assert!(html.contains("z-index:10"), "z-index should not have px suffix: {}", html);
-        assert!(
-            html.contains("line-height:1.5"),
-            "line-height should not have px suffix: {}",
-            html
-        );
-        assert!(html.contains("flex-grow:2"), "flex-grow should not have px suffix: {}", html);
+        assert!(html.contains("opacity:0.5"), "Opacity should not have px suffix: {html}");
+        assert!(html.contains("z-index:10"), "z-index should not have px suffix: {html}");
+        assert!(html.contains("line-height:1.5"), "line-height should not have px suffix: {html}");
+        assert!(html.contains("flex-grow:2"), "flex-grow should not have px suffix: {html}");
     }
 
     #[tokio::test]
@@ -3659,10 +3631,10 @@ b:["$","span",null,{"children":"Content from row 11 (hex b)"}]
 
         let html = renderer.render_rsc_to_html_string(&rows).await.unwrap();
 
-        assert!(html.contains("width:50%"), "String width should be preserved: {}", html);
-        assert!(html.contains("height:100px"), "Numeric height should have px: {}", html);
-        assert!(html.contains("opacity:0.8"), "Opacity should not have px: {}", html);
-        assert!(html.contains("color:red"), "Color string should be preserved: {}", html);
+        assert!(html.contains("width:50%"), "String width should be preserved: {html}");
+        assert!(html.contains("height:100px"), "Numeric height should have px: {html}");
+        assert!(html.contains("opacity:0.8"), "Opacity should not have px: {html}");
+        assert!(html.contains("color:red"), "Color string should be preserved: {html}");
     }
 
     #[tokio::test]
@@ -3677,20 +3649,17 @@ b:["$","span",null,{"children":"Content from row 11 (hex b)"}]
 
         assert!(
             html.contains("font-size:16px"),
-            "fontSize should become font-size with px: {}",
-            html
+            "fontSize should become font-size with px: {html}"
         );
         assert!(
             html.contains("margin-top:10px"),
-            "marginTop should become margin-top with px: {}",
-            html
+            "marginTop should become margin-top with px: {html}"
         );
         assert!(
             html.contains("padding-left:5px"),
-            "paddingLeft should become padding-left with px: {}",
-            html
+            "paddingLeft should become padding-left with px: {html}"
         );
-        assert!(html.contains("z-index:100"), "zIndex should become z-index without px: {}", html);
+        assert!(html.contains("z-index:100"), "zIndex should become z-index without px: {html}");
     }
 
     #[tokio::test]
@@ -3704,9 +3673,9 @@ b:["$","span",null,{"children":"Content from row 11 (hex b)"}]
 
         let html = renderer.render_rsc_to_html_string(&rows).await.unwrap();
 
-        assert!(html.contains("width:100.5px"), "Float width should have px: {}", html);
-        assert!(html.contains("opacity:0.75"), "Float opacity should not have px: {}", html);
-        assert!(html.contains("line-height:1.2"), "Float line-height should not have px: {}", html);
+        assert!(html.contains("width:100.5px"), "Float width should have px: {html}");
+        assert!(html.contains("opacity:0.75"), "Float opacity should not have px: {html}");
+        assert!(html.contains("line-height:1.2"), "Float line-height should not have px: {html}");
     }
 
     #[tokio::test]
@@ -3719,20 +3688,12 @@ b:["$","span",null,{"children":"Content from row 11 (hex b)"}]
 
         let html = renderer.render_rsc_to_html_string(&rows).await.unwrap();
 
-        assert!(html.contains(" checked"), "checked=true should render as presence-only: {}", html);
-        assert!(!html.contains("checked=\"true\""), "checked should not have =\"true\": {}", html);
-        assert!(
-            html.contains(" disabled"),
-            "disabled=true should render as presence-only: {}",
-            html
-        );
-        assert!(
-            !html.contains("disabled=\"true\""),
-            "disabled should not have =\"true\": {}",
-            html
-        );
+        assert!(html.contains(" checked"), "checked=true should render as presence-only: {html}");
+        assert!(!html.contains("checked=\"true\""), "checked should not have =\"true\": {html}");
+        assert!(html.contains(" disabled"), "disabled=true should render as presence-only: {html}");
+        assert!(!html.contains("disabled=\"true\""), "disabled should not have =\"true\": {html}");
 
-        assert!(!html.contains("required"), "required=false should be omitted: {}", html);
+        assert!(!html.contains("required"), "required=false should be omitted: {html}");
     }
 
     #[tokio::test]
@@ -3748,18 +3709,15 @@ b:["$","span",null,{"children":"Content from row 11 (hex b)"}]
 
         assert!(
             html.contains("aria-hidden=\"true\""),
-            "aria-hidden=true should render as \"true\": {}",
-            html
+            "aria-hidden=true should render as \"true\": {html}"
         );
         assert!(
             html.contains("aria-expanded=\"false\""),
-            "aria-expanded=false should render as \"false\": {}",
-            html
+            "aria-expanded=false should render as \"false\": {html}"
         );
         assert!(
             html.contains("aria-checked=\"true\""),
-            "aria-checked=true should render as \"true\": {}",
-            html
+            "aria-checked=true should render as \"true\": {html}"
         );
     }
 
@@ -3776,18 +3734,15 @@ b:["$","span",null,{"children":"Content from row 11 (hex b)"}]
 
         assert!(
             html.contains("contentEditable=\"true\""),
-            "contentEditable=true should render as \"true\": {}",
-            html
+            "contentEditable=true should render as \"true\": {html}"
         );
         assert!(
             html.contains("draggable=\"false\""),
-            "draggable=false should render as \"false\": {}",
-            html
+            "draggable=false should render as \"false\": {html}"
         );
         assert!(
             html.contains("spellcheck=\"true\""),
-            "spellcheck=true should render as \"true\": {}",
-            html
+            "spellcheck=true should render as \"true\": {html}"
         );
     }
 
@@ -3802,18 +3757,16 @@ b:["$","span",null,{"children":"Content from row 11 (hex b)"}]
 
         let html = renderer.render_rsc_to_html_string(&rows).await.unwrap();
 
-        assert!(html.contains(" disabled"), "disabled=true should be presence-only: {}", html);
-        assert!(!html.contains(" disabled="), "disabled should not have a value: {}", html);
+        assert!(html.contains(" disabled"), "disabled=true should be presence-only: {html}");
+        assert!(!html.contains(" disabled="), "disabled should not have a value: {html}");
 
         assert!(
             html.contains("aria-disabled=\"true\""),
-            "aria-disabled=true should render as \"true\": {}",
-            html
+            "aria-disabled=true should render as \"true\": {html}"
         );
         assert!(
             html.contains("aria-pressed=\"false\""),
-            "aria-pressed=false should render as \"false\": {}",
-            html
+            "aria-pressed=false should render as \"false\": {html}"
         );
     }
 
@@ -3838,19 +3791,17 @@ b:["$","span",null,{"children":"Content from row 11 (hex b)"}]
 
         let html = converter.rsc_element_to_html(&element).await.unwrap();
 
-        assert!(html.contains(" checked"), "checked=true should be presence-only: {}", html);
-        assert!(!html.contains(" checked="), "checked should not have a value: {}", html);
-        assert!(!html.contains(" disabled"), "disabled=false should be omitted: {}", html);
+        assert!(html.contains(" checked"), "checked=true should be presence-only: {html}");
+        assert!(!html.contains(" checked="), "checked should not have a value: {html}");
+        assert!(!html.contains(" disabled"), "disabled=false should be omitted: {html}");
 
         assert!(
             html.contains("aria-checked=\"true\""),
-            "aria-checked=true should render as \"true\": {}",
-            html
+            "aria-checked=true should render as \"true\": {html}"
         );
         assert!(
             html.contains("aria-disabled=\"false\""),
-            "aria-disabled=false should render as \"false\": {}",
-            html
+            "aria-disabled=false should render as \"false\": {html}"
         );
     }
 
@@ -3864,16 +3815,15 @@ b:["$","span",null,{"children":"Content from row 11 (hex b)"}]
 
         let html = renderer.render_rsc_to_html_string(&rows).await.unwrap();
 
-        assert!(html.contains(" hidden"), "hidden should be presence-only: {}", html);
-        assert!(html.contains(" readonly"), "readonly should be presence-only: {}", html);
-        assert!(html.contains(" required"), "required should be presence-only: {}", html);
-        assert!(html.contains(" autofocus"), "autofocus should be presence-only: {}", html);
-        assert!(html.contains(" multiple"), "multiple should be presence-only: {}", html);
+        assert!(html.contains(" hidden"), "hidden should be presence-only: {html}");
+        assert!(html.contains(" readonly"), "readonly should be presence-only: {html}");
+        assert!(html.contains(" required"), "required should be presence-only: {html}");
+        assert!(html.contains(" autofocus"), "autofocus should be presence-only: {html}");
+        assert!(html.contains(" multiple"), "multiple should be presence-only: {html}");
 
         assert!(
             !html.contains("=\"true\""),
-            "HTML boolean attributes should not have =\"true\": {}",
-            html
+            "HTML boolean attributes should not have =\"true\": {html}"
         );
     }
 
@@ -3889,7 +3839,7 @@ b:["$","span",null,{"children":"Content from row 11 (hex b)"}]
         let rows = renderer.parse_rsc_flight_protocol(rsc_data).unwrap();
         let html = renderer.render_rsc_to_html_string(&rows).await.unwrap();
 
-        assert!(html.contains("Row 10"), "Should render content from row 10 (hex 'a'): {}", html);
-        assert!(html.contains("Row 31"), "Should render content from row 31 (hex '1f'): {}", html);
+        assert!(html.contains("Row 10"), "Should render content from row 10 (hex 'a'): {html}");
+        assert!(html.contains("Row 31"), "Should render content from row 31 (hex '1f'): {html}");
     }
 }

--- a/crates/rari/src/runtime/module_loader/cache.rs
+++ b/crates/rari/src/runtime/module_loader/cache.rs
@@ -119,27 +119,7 @@ impl ModuleCaching {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::unwrap_used, clippy::clone_on_ref_ptr)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/runtime/module_loader/resolver.rs
+++ b/crates/rari/src/runtime/module_loader/resolver.rs
@@ -72,27 +72,6 @@ impl Default for ModuleResolver {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/runtime/module_loader/transpiler.rs
+++ b/crates/rari/src/runtime/module_loader/transpiler.rs
@@ -21,27 +21,6 @@ pub fn get_module_type(_specifier: &str) -> &'static str {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/runtime/ops.rs
+++ b/crates/rari/src/runtime/ops.rs
@@ -654,27 +654,6 @@ pub fn op_cache_set(
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
 mod tests {
     use tokio::sync::mpsc;
 

--- a/crates/rari/src/server/cache/handler.rs
+++ b/crates/rari/src/server/cache/handler.rs
@@ -470,27 +470,7 @@ impl CacheHandlerRegistry {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use std::{sync::Arc, time::Duration};
 

--- a/crates/rari/src/server/cache/response.rs
+++ b/crates/rari/src/server/cache/response.rs
@@ -540,24 +540,9 @@ mod header_map_serde {
 #[cfg(test)]
 #[allow(
     clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
     clippy::expect_used,
     clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
+    clippy::clone_on_ref_ptr
 )]
 mod tests {
     use std::{sync::Arc, time::Duration};
@@ -624,7 +609,7 @@ mod tests {
         let etag = ResponseCache::generate_etag(content);
 
         assert!(etag.starts_with("W/\""));
-        assert!(etag.ends_with("\""));
+        assert!(etag.ends_with('"'));
 
         let etag2 = ResponseCache::generate_etag(content);
         assert_eq!(etag, etag2);
@@ -757,7 +742,7 @@ mod tests {
         let cache = ResponseCache::new(config);
 
         for i in 0..10 {
-            cache.set(format!("key{}", i), create_test_response(&format!("body{}", i), 60)).await;
+            cache.set(format!("key{i}"), create_test_response(&format!("body{i}"), 60)).await;
         }
 
         assert_eq!(cache.get_metrics().total_entries, 10);
@@ -775,7 +760,7 @@ mod tests {
         let cache = ResponseCache::new(config);
 
         for i in 0..8 {
-            cache.set(format!("key{}", i), create_test_response(&format!("body{}", i), 60)).await;
+            cache.set(format!("key{i}"), create_test_response(&format!("body{i}"), 60)).await;
         }
 
         assert!(!cache.should_clear_on_memory_pressure());
@@ -818,7 +803,7 @@ mod tests {
         let config = CacheConfig::from_env(true);
         assert!(config.enabled);
         assert_eq!(config.max_entries, 1000);
-        assert_eq!(config.default_ttl, 31536000);
+        assert_eq!(config.default_ttl, 31_536_000);
 
         let config = CacheConfig::from_env(false);
         assert!(!config.enabled);

--- a/crates/rari/src/server/compression/stream.rs
+++ b/crates/rari/src/server/compression/stream.rs
@@ -254,27 +254,7 @@ impl GzipCompressor {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::unwrap_used)]
 mod tests {
     use futures::stream;
 

--- a/crates/rari/src/server/config.rs
+++ b/crates/rari/src/server/config.rs
@@ -880,27 +880,7 @@ pub enum ConfigError {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::unwrap_used)]
 mod tests {
     use std::{fs::File, io::Write, process};
 
@@ -1059,7 +1039,7 @@ mod tests {
             config.caching.routes.contains_key("/valid"),
             "Valid cache-control route should be accepted"
         );
-        assert_eq!(config.caching.routes.get("/valid").unwrap(), "public, max-age=3600");
+        assert_eq!(&config.caching.routes["/valid"], "public, max-age=3600");
 
         assert!(
             !config.caching.routes.contains_key("/invalid-newline"),

--- a/crates/rari/src/server/core/types/request.rs
+++ b/crates/rari/src/server/core/types/request.rs
@@ -29,27 +29,6 @@ impl RequestTypeDetector {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
 mod tests {
     use axum::http::{HeaderMap, HeaderValue};
 
@@ -126,7 +105,7 @@ mod tests {
     #[test]
     fn test_render_mode_debug() {
         let mode = RenderMode::Ssr;
-        let debug_str = format!("{:?}", mode);
+        let debug_str = format!("{mode:?}");
         assert!(debug_str.contains("Ssr"));
     }
 }

--- a/crates/rari/src/server/core/utils/http.rs
+++ b/crates/rari/src/server/core/utils/http.rs
@@ -246,27 +246,7 @@ pub fn add_api_security_headers(headers: &mut HeaderMap) {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/server/core/utils/path_validation.rs
+++ b/crates/rari/src/server/core/utils/path_validation.rs
@@ -111,34 +111,14 @@ pub fn validate_component_path(file_path: &str) -> Result<(), RariError> {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use std::{env, fs};
 
     use super::*;
 
     fn test_temp_dir(name: &str) -> PathBuf {
-        env::temp_dir().join(format!("rari-test-path-validation-{}", name))
+        env::temp_dir().join(format!("rari-test-path-validation-{name}"))
     }
 
     #[test]

--- a/crates/rari/src/server/handlers/actions.rs
+++ b/crates/rari/src/server/handlers/actions.rs
@@ -925,27 +925,7 @@ pub fn build_set_cookie_header(cookie: &PendingCookie) -> Result<String, String>
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::unwrap_used, clippy::float_cmp, clippy::approx_constant)]
 mod tests {
     use serde_json::json;
 
@@ -1083,13 +1063,13 @@ mod tests {
         assert_eq!(sanitized.len(), 5);
         assert_eq!(sanitized[0].as_str().unwrap(), "string value");
         assert_eq!(sanitized[1].as_i64().unwrap(), 42);
-        assert_eq!(sanitized[2].as_bool().unwrap(), true);
+        assert!(sanitized[2].as_bool().unwrap());
         assert!(sanitized[3].is_null());
 
         let obj = sanitized[4].as_object().unwrap();
         assert_eq!(obj.get("name").unwrap().as_str().unwrap(), "test");
         assert_eq!(obj.get("count").unwrap().as_i64().unwrap(), 10);
-        assert_eq!(obj.get("active").unwrap().as_bool().unwrap(), true);
+        assert!(obj.get("active").unwrap().as_bool().unwrap());
         assert_eq!(obj.get("tags").unwrap().as_array().unwrap().len(), 3);
     }
 
@@ -1198,14 +1178,14 @@ mod tests {
 
         let mut valid_obj = serde_json::Map::new();
         for i in 0..5 {
-            valid_obj.insert(format!("key{}", i), json!(i));
+            valid_obj.insert(format!("key{i}"), json!(i));
         }
         let valid = vec![json!(valid_obj)];
         assert!(validate_and_sanitize_args(&valid, &config).is_ok());
 
         let mut invalid_obj = serde_json::Map::new();
         for i in 0..6 {
-            invalid_obj.insert(format!("key{}", i), json!(i));
+            invalid_obj.insert(format!("key{i}"), json!(i));
         }
         let invalid = vec![json!(invalid_obj)];
         let result = validate_and_sanitize_args(&invalid, &config);
@@ -1330,8 +1310,8 @@ mod tests {
         let result = validate_and_sanitize_args(&args, &config).unwrap();
 
         assert!(result[0].is_null());
-        assert_eq!(result[1].as_bool().unwrap(), true);
-        assert_eq!(result[2].as_bool().unwrap(), false);
+        assert!(result[1].as_bool().unwrap());
+        assert!(!result[2].as_bool().unwrap());
         assert_eq!(result[3].as_i64().unwrap(), 42);
         assert_eq!(result[4].as_i64().unwrap(), -123);
         assert_eq!(result[5].as_f64().unwrap(), 3.14);
@@ -1393,7 +1373,7 @@ mod tests {
                 }
             },
             "action": "update",
-            "timestamp": 1733756400
+            "timestamp": 1_733_756_400
         })];
 
         let result = validate_and_sanitize_args(&args, &config);
@@ -1681,8 +1661,7 @@ mod tests {
         let err_msg = result.unwrap_err().to_string();
         assert!(
             err_msg.contains("Maximum array nesting exceeded") || err_msg.contains("12000 > 10000"),
-            "Expected array nesting error, got: {}",
-            err_msg
+            "Expected array nesting error, got: {err_msg}"
         );
     }
 
@@ -1703,8 +1682,7 @@ mod tests {
         let err_msg = result.unwrap_err().to_string();
         assert!(
             err_msg.contains("Maximum array nesting exceeded"),
-            "Expected cumulative limit error, got: {}",
-            err_msg
+            "Expected cumulative limit error, got: {err_msg}"
         );
     }
 

--- a/crates/rari/src/server/image/cache.rs
+++ b/crates/rari/src/server/image/cache.rs
@@ -176,27 +176,7 @@ impl ImageCache {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use std::env::temp_dir;
 
@@ -204,7 +184,7 @@ mod tests {
     use crate::server::cache::{MemoryConfig, handler::MemoryCacheHandler};
 
     fn test_project_path(test_name: &str) -> PathBuf {
-        temp_dir().join(format!("rari-test-image-cache-{}", test_name))
+        temp_dir().join(format!("rari-test-image-cache-{test_name}"))
     }
 
     fn fresh_cache(test_name: &str, max_memory_size: usize) -> ImageCache {

--- a/crates/rari/src/server/middleware/request_context.rs
+++ b/crates/rari/src/server/middleware/request_context.rs
@@ -307,27 +307,6 @@ impl RequestContext {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/server/og/cache.rs
+++ b/crates/rari/src/server/og/cache.rs
@@ -158,27 +158,7 @@ impl OgImageCache {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use std::env::temp_dir;
 
@@ -186,7 +166,7 @@ mod tests {
     use crate::server::cache::handler::MemoryCacheHandler;
 
     fn test_project_path(test_name: &str) -> PathBuf {
-        temp_dir().join(format!("rari-test-og-cache-{}", test_name))
+        temp_dir().join(format!("rari-test-og-cache-{test_name}"))
     }
 
     fn fresh_cache(test_name: &str, memory_capacity: usize) -> OgImageCache {

--- a/crates/rari/src/server/og/generator.rs
+++ b/crates/rari/src/server/og/generator.rs
@@ -405,27 +405,7 @@ impl OgImageGenerator {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::unwrap_used)]
 mod tests {
     use std::env;
 
@@ -595,7 +575,7 @@ mod tests {
         let generator = OgImageGenerator::new(runtime, test_dir);
 
         let result = generator.load_manifest(manifest_path.to_str().unwrap()).await;
-        assert!(result.is_ok(), "load_manifest should succeed: {:?}", result);
+        assert!(result.is_ok(), "load_manifest should succeed: {result:?}");
 
         let found = generator.find_og_image_for_route("/").await;
         assert!(found.is_some());

--- a/crates/rari/src/server/og/layout/style/gradient.rs
+++ b/crates/rari/src/server/og/layout/style/gradient.rs
@@ -361,27 +361,7 @@ pub struct GradientParams {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::unwrap_used, clippy::float_cmp)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/server/og/rendering/svg.rs
+++ b/crates/rari/src/server/og/rendering/svg.rs
@@ -270,27 +270,6 @@ fn escape_xml(s: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/server/og/resources/fonts.rs
+++ b/crates/rari/src/server/og/resources/fonts.rs
@@ -124,27 +124,7 @@ impl FontContext {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::expect_used, clippy::print_stdout)]
 mod tests {
     use parley::PositionedLayoutItem::GlyphRun;
     use swash::scale::StrikeWith::BestFit;
@@ -166,7 +146,7 @@ mod tests {
         use parley::{LayoutContext, TextStyle};
 
         let ctx = FontContext::new();
-        let mut font_ctx = ctx.inner.clone();
+        let mut font_ctx = ctx.inner;
         let mut layout_cx: LayoutContext<[u8; 4]> = LayoutContext::new();
 
         let root_style = TextStyle { font_size: 32.0, ..Default::default() };
@@ -188,7 +168,7 @@ mod tests {
             }
         }
 
-        println!("Line count: {}, Glyph count: {}", line_count, glyph_count);
+        println!("Line count: {line_count}, Glyph count: {glyph_count}");
         assert!(glyph_count > 0, "Should have glyphs");
     }
 
@@ -198,7 +178,7 @@ mod tests {
         use swash::{FontRef, scale::ScaleContext};
 
         let ctx = FontContext::new();
-        let mut font_ctx = ctx.inner.clone();
+        let mut font_ctx = ctx.inner;
         let mut layout_cx: LayoutContext<[u8; 4]> = LayoutContext::new();
 
         let root_style = TextStyle { font_size: 32.0, ..Default::default() };

--- a/crates/rari/src/server/rendering/metadata.rs
+++ b/crates/rari/src/server/rendering/metadata.rs
@@ -101,27 +101,7 @@ pub fn finalize_metadata(metadata: &mut Value) {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::unwrap_used)]
 mod tests {
     use serde_json::json;
 

--- a/crates/rari/src/server/rendering/metadata_injection.rs
+++ b/crates/rari/src/server/rendering/metadata_injection.rs
@@ -541,27 +541,7 @@ pub fn inject_metadata(
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::expect_used)]
 mod tests {
     use rustc_hash::FxHashMap;
 
@@ -607,13 +587,13 @@ mod tests {
 
     #[test]
     fn test_inject_open_graph() {
-        let html = r#"<!DOCTYPE html>
+        let html = r"<!DOCTYPE html>
 <html>
 <head>
     <title>Test</title>
 </head>
 <body></body>
-</html>"#;
+</html>";
 
         let metadata = PageMetadata {
             title: Some("Test".to_string()),
@@ -670,13 +650,13 @@ mod tests {
 
     #[test]
     fn test_inject_twitter_metadata() {
-        let html = r#"<!DOCTYPE html>
+        let html = r"<!DOCTYPE html>
 <html>
 <head>
     <title>Test</title>
 </head>
 <body></body>
-</html>"#;
+</html>";
 
         let metadata = PageMetadata {
             title: Some("Test".to_string()),
@@ -717,13 +697,13 @@ mod tests {
 
     #[test]
     fn test_inject_robots() {
-        let html = r#"<!DOCTYPE html>
+        let html = r"<!DOCTYPE html>
 <html>
 <head>
     <title>Test</title>
 </head>
 <body></body>
-</html>"#;
+</html>";
 
         let metadata = PageMetadata {
             title: Some("Test".to_string()),
@@ -752,13 +732,13 @@ mod tests {
 
     #[test]
     fn test_escape_html() {
-        let html = r#"<!DOCTYPE html>
+        let html = r"<!DOCTYPE html>
 <html>
 <head>
     <title>Test</title>
 </head>
 <body></body>
-</html>"#;
+</html>";
 
         let metadata = PageMetadata {
             title: Some("Test & <script>alert('xss')</script>".to_string()),
@@ -779,20 +759,18 @@ mod tests {
         let result = inject_metadata(html, &metadata, None);
 
         assert!(result.contains("Test &amp; &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;"));
-        assert!(
-            result.contains(r#"Description with &quot;quotes&quot; and &#39;apostrophes&#39;"#)
-        );
+        assert!(result.contains(r"Description with &quot;quotes&quot; and &#39;apostrophes&#39;"));
     }
 
     #[test]
     fn test_inject_default_meta_tags() {
-        let html = r#"<!DOCTYPE html>
+        let html = r"<!DOCTYPE html>
 <html>
 <head>
     <title>Test</title>
 </head>
 <body></body>
-</html>"#;
+</html>";
 
         let metadata = PageMetadata {
             title: Some("Test".to_string()),
@@ -859,19 +837,19 @@ mod tests {
 
         let result = inject_metadata(html, &metadata, None);
 
-        assert_eq!(result.matches(r#"<meta charset"#).count(), 1);
+        assert_eq!(result.matches(r"<meta charset").count(), 1);
         assert_eq!(result.matches(r#"<meta name="viewport""#).count(), 1);
     }
 
     #[test]
     fn test_custom_viewport_overrides_default() {
-        let html = r#"<!DOCTYPE html>
+        let html = r"<!DOCTYPE html>
 <html>
 <head>
     <title>Test</title>
 </head>
 <body></body>
-</html>"#;
+</html>";
 
         let metadata = PageMetadata {
             title: Some("Test".to_string()),
@@ -901,13 +879,13 @@ mod tests {
 
     #[test]
     fn test_no_injection_into_header_tag() {
-        let html = r#"<!DOCTYPE html>
+        let html = r"<!DOCTYPE html>
 <html>
 <header>
     <title>This is not a head tag</title>
 </header>
 <body></body>
-</html>"#;
+</html>";
 
         let metadata = PageMetadata {
             title: Some("Test".to_string()),
@@ -934,13 +912,13 @@ mod tests {
 
     #[test]
     fn test_inject_alternates_rss_feed() {
-        let html = r#"<!DOCTYPE html>
+        let html = r"<!DOCTYPE html>
 <html>
 <head>
     <title>Test</title>
 </head>
 <body></body>
-</html>"#;
+</html>";
 
         let mut types = FxHashMap::default();
         types.insert("application/rss+xml".to_string(), "https://example.com/feed.xml".to_string());
@@ -974,13 +952,13 @@ mod tests {
 
     #[test]
     fn test_inject_alternates_languages() {
-        let html = r#"<!DOCTYPE html>
+        let html = r"<!DOCTYPE html>
 <html>
 <head>
     <title>Test</title>
 </head>
 <body></body>
-</html>"#;
+</html>";
 
         let mut languages = FxHashMap::default();
         languages.insert("en".to_string(), "https://example.com/en".to_string());
@@ -1023,13 +1001,13 @@ mod tests {
 
     #[test]
     fn test_no_duplicate_canonical_when_both_set() {
-        let html = r#"<!DOCTYPE html>
+        let html = r"<!DOCTYPE html>
 <html>
 <head>
     <title>Test</title>
 </head>
 <body></body>
-</html>"#;
+</html>";
 
         let metadata = PageMetadata {
             title: Some("Test".to_string()),

--- a/crates/rari/src/server/rendering/streaming_response.rs
+++ b/crates/rari/src/server/rendering/streaming_response.rs
@@ -77,27 +77,7 @@ impl IntoResponse for StreamingHtmlResponse {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::unwrap_used)]
 mod tests {
     use async_stream::stream;
     use axum::body::to_bytes;

--- a/crates/rari/src/server/routing/api_routes.rs
+++ b/crates/rari/src/server/routing/api_routes.rs
@@ -635,27 +635,7 @@ impl ApiRouteHandler {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::unwrap_used)]
 mod tests {
     use axum::http::HeaderValue;
 

--- a/crates/rari/src/server/routing/app_router.rs
+++ b/crates/rari/src/server/routing/app_router.rs
@@ -658,27 +658,7 @@ impl AppRouter {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/server/routing/types.rs
+++ b/crates/rari/src/server/routing/types.rs
@@ -58,27 +58,7 @@ impl ParamValue {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
+#[allow(clippy::allow_attributes, clippy::unwrap_used)]
 mod tests {
     use rustc_hash::FxHashMap;
 
@@ -108,7 +88,7 @@ mod tests {
         let json = serde_json::to_value(&map).unwrap();
         assert!(json.is_object());
         assert_eq!(json.get("slug").and_then(|v| v.as_str()), Some("hello"));
-        assert_eq!(json.get("path").and_then(|v| v.as_array()).map(|a| a.len()), Some(2));
+        assert_eq!(json.get("path").and_then(|v| v.as_array()).map(Vec::len), Some(2));
     }
 
     #[test]

--- a/crates/rari/src/server/vite.rs
+++ b/crates/rari/src/server/vite.rs
@@ -395,27 +395,6 @@ pub async fn check_vite_server_health() -> Result<(), RariError> {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::unreadable_literal,
-    clippy::needless_raw_string_hashes,
-    clippy::panic,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::print_stdout,
-    clippy::float_cmp,
-    clippy::bool_assert_comparison,
-    clippy::redundant_clone,
-    clippy::redundant_closure_for_method_calls,
-    clippy::single_char_pattern,
-    clippy::approx_constant,
-    clippy::uninlined_format_args,
-    clippy::module_inception,
-    clippy::return_self_not_must_use,
-    clippy::disallowed_methods,
-    clippy::clone_on_ref_ptr,
-    clippy::get_unwrap
-)]
 mod tests {
     use super::*;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Cleaned up test code formatting and assertions across multiple areas.
  * Updated several tests to use clearer Rust string interpolation and more consistent assertion styles.

* **Chores**
  * Reduced or removed broad Clippy lint suppressions in test modules.
  * Made minor formatting and literal-style updates without changing product behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->