### PR TITLE
refactor: convert instance methods to static methods across runtime and rendering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,9 @@
 [workspace]
 members = [
   "crates/*",
-  "tools/prepare-binaries",
-  "tools/release",
-  "tools/snapshot",
+  "tools/*",
 ]
+exclude = [ "tools/bundle-react-esm" ]
 resolver = "2"
 
 [workspace.package]
@@ -91,6 +90,9 @@ redundant_clone = "warn"
 redundant_pub_crate = "warn"
 significant_drop_in_scrutinee = "warn"
 unused_peekable = "warn"
+
+[workspace.lints.rust]
+linker_messages = "allow"
 
 [workspace.dependencies]
 anyhow = "1.0.103"

--- a/crates/rari-error/src/lib.rs
+++ b/crates/rari-error/src/lib.rs
@@ -652,8 +652,7 @@ impl From<DataError> for RariError {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::disallowed_methods)]
-    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::disallowed_methods, clippy::unwrap_used)]
     use super::*;
 
     #[test]

--- a/crates/rari-rsc/src/components.rs
+++ b/crates/rari-rsc/src/components.rs
@@ -399,7 +399,7 @@ impl ComponentRegistry {
             return Some(component.source.clone());
         }
 
-        let further_normalized_id = self.normalize_component_id(normalized_id.as_ref());
+        let further_normalized_id = Self::normalize_component_id(normalized_id.as_ref());
         if let Some(component) = self.components.get(&further_normalized_id) {
             return Some(component.source.clone());
         }
@@ -428,7 +428,7 @@ impl ComponentRegistry {
         }
     }
 
-    fn normalize_component_id(&self, id: &str) -> String {
+    fn normalize_component_id(id: &str) -> String {
         let mut clean_id = id;
         let is_relative = id.starts_with("./") || id.starts_with("../");
 
@@ -588,12 +588,13 @@ mod tests {
 
     #[test]
     fn test_normalize_component_id() {
-        let registry = ComponentRegistry::new();
-
-        assert_eq!(registry.normalize_component_id("./component.tsx"), "component");
-        assert_eq!(registry.normalize_component_id("../utils/helper.js"), "helper");
-        assert_eq!(registry.normalize_component_id("Button"), "Button");
-        assert_eq!(registry.normalize_component_id("components/Button.jsx"), "components/Button");
+        assert_eq!(ComponentRegistry::normalize_component_id("./component.tsx"), "component");
+        assert_eq!(ComponentRegistry::normalize_component_id("../utils/helper.js"), "helper");
+        assert_eq!(ComponentRegistry::normalize_component_id("Button"), "Button");
+        assert_eq!(
+            ComponentRegistry::normalize_component_id("components/Button.jsx"),
+            "components/Button"
+        );
     }
 
     #[test]

--- a/crates/rari-rsc/src/flight/parser.rs
+++ b/crates/rari-rsc/src/flight/parser.rs
@@ -158,20 +158,15 @@ impl RscFlightParser {
         let key = arr[2].as_str();
 
         let props_value = &arr[3];
-        if tag == "Suspense" || tag == "react.suspense" {
-            let props = if let Value::Object(obj) = props_value {
-                obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
-            } else {
-                FxHashMap::default()
-            };
-            return Self::parse_suspense_element(key, props);
-        }
-
         let props = if let Value::Object(obj) = props_value {
             obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
         } else {
             FxHashMap::default()
         };
+
+        if tag == "Suspense" || tag == "react.suspense" {
+            return Self::parse_suspense_element(key, props);
+        }
 
         if tag == "Promise" || tag == "react.promise" {
             return Self::parse_promise_element(&props);

--- a/crates/rari-rsc/src/flight/parser.rs
+++ b/crates/rari-rsc/src/flight/parser.rs
@@ -47,14 +47,14 @@ impl RscFlightParser {
                 continue;
             }
 
-            let (row_id, element) = self.parse_line(line)?;
+            let (row_id, element) = Self::parse_line(line)?;
             self.elements.insert(row_id, element);
         }
 
         Ok(())
     }
 
-    fn parse_line(&self, line: &str) -> Result<(u32, RscElement), RariError> {
+    fn parse_line(line: &str) -> Result<(u32, RscElement), RariError> {
         let colon_pos = line.find(':').ok_or_else(|| {
             RariError::internal(format!("Invalid RSC line format: missing colon in '{line}'"))
         })?;
@@ -72,12 +72,12 @@ impl RscFlightParser {
         let json_value: Value = serde_json::from_str(data_str)
             .map_err(|e| RariError::internal(format!("Invalid JSON in RSC line: {e}")))?;
 
-        let element = self.parse_json_element(&json_value)?;
+        let element = Self::parse_json_element(&json_value)?;
 
         Ok((row_id, element))
     }
 
-    fn parse_json_element(&self, value: &Value) -> Result<RscElement, RariError> {
+    fn parse_json_element(value: &Value) -> Result<RscElement, RariError> {
         match value {
             Value::String(s) => {
                 if let Some(stripped) = s.strip_prefix('$') {
@@ -127,7 +127,7 @@ impl RscFlightParser {
                 if let Some(Value::String(marker)) = arr.first()
                     && marker == "$"
                 {
-                    return self.parse_react_element(arr);
+                    return Self::parse_react_element(arr);
                 }
 
                 Ok(RscElement::Text(serde_json::to_string(value).unwrap_or_default()))
@@ -142,7 +142,7 @@ impl RscFlightParser {
         }
     }
 
-    fn parse_react_element(&self, arr: &[Value]) -> Result<RscElement, RariError> {
+    fn parse_react_element(arr: &[Value]) -> Result<RscElement, RariError> {
         if arr.len() < 4 {
             return Err(RariError::internal(format!(
                 "Invalid React element: expected 4 elements, got {}",
@@ -155,7 +155,7 @@ impl RscFlightParser {
             .ok_or_else(|| RariError::internal("React element tag must be a string".to_string()))?
             .to_string();
 
-        let key = arr[2].as_str().map(ToString::to_string);
+        let key = arr[2].as_str();
 
         let props_value = &arr[3];
         let props = if let Value::Object(obj) = props_value {
@@ -165,20 +165,19 @@ impl RscFlightParser {
         };
 
         if tag == "Suspense" || tag == "react.suspense" {
-            return self.parse_suspense_element(key, props);
+            return Self::parse_suspense_element(key, &props);
         }
 
         if tag == "Promise" || tag == "react.promise" {
-            return self.parse_promise_element(props);
+            return Self::parse_promise_element(&props);
         }
 
-        Ok(RscElement::Component { tag, key, props })
+        Ok(RscElement::Component { tag, key: key.map(ToString::to_string), props })
     }
 
     fn parse_suspense_element(
-        &self,
-        key: Option<String>,
-        props: FxHashMap<String, Value>,
+        key: Option<&str>,
+        props: &FxHashMap<String, Value>,
     ) -> Result<RscElement, RariError> {
         let fallback_ref = if let Some(fallback_value) = props.get("fallback") {
             match fallback_value {
@@ -210,16 +209,13 @@ impl RscFlightParser {
             .get("~boundaryId")
             .and_then(|v| v.as_str())
             .map(ToString::to_string)
-            .or_else(|| key.clone())
+            .or_else(|| key.map(ToString::to_string))
             .unwrap_or_else(|| format!("boundary_{}", Uuid::new_v4()));
 
-        Ok(RscElement::Suspense { fallback_ref, children_ref, boundary_id, props })
+        Ok(RscElement::Suspense { fallback_ref, children_ref, boundary_id, props: props.clone() })
     }
 
-    fn parse_promise_element(
-        &self,
-        props: FxHashMap<String, Value>,
-    ) -> Result<RscElement, RariError> {
+    fn parse_promise_element(props: &FxHashMap<String, Value>) -> Result<RscElement, RariError> {
         let promise_id = props
             .get("id")
             .and_then(|v| v.as_str())

--- a/crates/rari-rsc/src/flight/parser.rs
+++ b/crates/rari-rsc/src/flight/parser.rs
@@ -158,15 +158,20 @@ impl RscFlightParser {
         let key = arr[2].as_str();
 
         let props_value = &arr[3];
+        if tag == "Suspense" || tag == "react.suspense" {
+            let props = if let Value::Object(obj) = props_value {
+                obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+            } else {
+                FxHashMap::default()
+            };
+            return Self::parse_suspense_element(key, props);
+        }
+
         let props = if let Value::Object(obj) = props_value {
             obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
         } else {
             FxHashMap::default()
         };
-
-        if tag == "Suspense" || tag == "react.suspense" {
-            return Self::parse_suspense_element(key, &props);
-        }
 
         if tag == "Promise" || tag == "react.promise" {
             return Self::parse_promise_element(&props);
@@ -177,7 +182,7 @@ impl RscFlightParser {
 
     fn parse_suspense_element(
         key: Option<&str>,
-        props: &FxHashMap<String, Value>,
+        props: FxHashMap<String, Value>,
     ) -> Result<RscElement, RariError> {
         let fallback_ref = if let Some(fallback_value) = props.get("fallback") {
             match fallback_value {
@@ -212,7 +217,7 @@ impl RscFlightParser {
             .or_else(|| key.map(ToString::to_string))
             .unwrap_or_else(|| format!("boundary_{}", Uuid::new_v4()));
 
-        Ok(RscElement::Suspense { fallback_ref, children_ref, boundary_id, props: props.clone() })
+        Ok(RscElement::Suspense { fallback_ref, children_ref, boundary_id, props })
     }
 
     fn parse_promise_element(props: &FxHashMap<String, Value>) -> Result<RscElement, RariError> {

--- a/crates/rari-rsc/src/lib.rs
+++ b/crates/rari-rsc/src/lib.rs
@@ -1,6 +1,4 @@
 #![expect(clippy::missing_errors_doc)]
-#![expect(clippy::unused_self)]
-#![expect(clippy::needless_pass_by_value)]
 
 pub mod components;
 pub mod core;

--- a/crates/rari-use-cache/src/closure.rs
+++ b/crates/rari-use-cache/src/closure.rs
@@ -334,8 +334,7 @@ fn collect_pat_idents(pattern: &Pat, idents: &mut FxHashSet<Id>) {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::default_trait_access)]
-    #![allow(clippy::expect_used)]
+    #![allow(clippy::default_trait_access, clippy::expect_used)]
     use deno_ast::swc::{
         ast::{
             AssignPatProp, BindingIdent, Class, ClassDecl, ClassExpr, Decl, DefaultDecl,

--- a/crates/rari/src/lib.rs
+++ b/crates/rari/src/lib.rs
@@ -1,19 +1,7 @@
-#![expect(clippy::missing_errors_doc)]
-#![expect(clippy::cast_precision_loss)]
-#![expect(clippy::cast_possible_truncation)]
-#![expect(clippy::cast_sign_loss)]
-#![expect(clippy::cast_possible_wrap)]
-#![expect(clippy::unused_self)]
-#![expect(clippy::manual_let_else)]
-#![expect(clippy::too_many_lines)]
-#![expect(clippy::needless_pass_by_value)]
-#![expect(clippy::items_after_statements)]
-#![expect(clippy::unused_async)]
-#![expect(clippy::needless_pass_by_ref_mut)]
-
 pub mod rendering;
 pub mod runtime;
 pub mod server;
+pub mod utils;
 pub use ::async_trait;
 pub use rari_rsc::{
     RSCRenderDebug, RSCRenderResult, RSCTree, ReactElement, RscElement, RscFlightParser,

--- a/crates/rari/src/lib.rs
+++ b/crates/rari/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod rendering;
 pub mod runtime;
 pub mod server;
-pub mod utils;
+mod utils;
 pub use ::async_trait;
 pub use rari_rsc::{
     RSCRenderDebug, RSCRenderResult, RSCTree, ReactElement, RscElement, RscFlightParser,

--- a/crates/rari/src/rendering/base/constants.rs
+++ b/crates/rari/src/rendering/base/constants.rs
@@ -1,6 +1,8 @@
 use std::time::Duration;
 
 pub const MEMORY_PRESSURE_THRESHOLD: f64 = 0.8;
+pub const MEMORY_PRESSURE_RENDER_THRESHOLD_NUM: usize = 8;
+pub const MEMORY_PRESSURE_RENDER_THRESHOLD_DEN: usize = 10;
 pub const CACHE_CLEANUP_INTERVAL: Duration = Duration::from_millis(10);
 
 pub const MAX_RETRIES: u64 = 3;

--- a/crates/rari/src/rendering/base/loader.rs
+++ b/crates/rari/src/rendering/base/loader.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::too_many_lines)]
+
 use cow_utils::CowUtils;
 
 #[non_exhaustive]
@@ -67,7 +69,7 @@ impl RscJsLoader {
         create_js_wrapper(&setup_code)
     }
 
-    pub fn create_stub_via_js_function(component_id: &str, stub_type: StubType) -> String {
+    pub fn create_stub_via_js_function(component_id: &str, stub_type: &StubType) -> String {
         let function_name = match stub_type {
             StubType::Component => "createComponentStub",
             StubType::Loader => "createLoaderStub",

--- a/crates/rari/src/rendering/base/loader.rs
+++ b/crates/rari/src/rendering/base/loader.rs
@@ -1,5 +1,3 @@
-#![expect(clippy::too_many_lines)]
-
 use cow_utils::CowUtils;
 
 #[non_exhaustive]
@@ -103,6 +101,7 @@ impl RscJsLoader {
         )
     }
 
+    #[expect(clippy::too_many_lines)]
     pub fn create_module_operation_script(
         component_id: &str,
         operation: RscModuleOperation,

--- a/crates/rari/src/rendering/base/renderer.rs
+++ b/crates/rari/src/rendering/base/renderer.rs
@@ -1,6 +1,3 @@
-#![allow(clippy::unused_async_trait_impl)]
-#![expect(clippy::too_many_lines)]
-
 use std::{
     env,
     fmt::Write,
@@ -27,6 +24,7 @@ use tracing::error;
 use super::{
     constants::{
         BATCH_ERROR_COLLECTION, CACHE_CLEANUP_INTERVAL, EXTENSION_CHECKS,
+        MEMORY_PRESSURE_RENDER_THRESHOLD_DEN, MEMORY_PRESSURE_RENDER_THRESHOLD_NUM,
         SERVER_ACTION_INVOCATION_SCRIPT, SERVER_FUNCTION_RESOLVER, V8_CACHE_CLEAR_SCRIPT,
         module_registration_script, resolve_server_functions_for_component,
     },
@@ -95,7 +93,9 @@ impl RscRenderer {
         let current_renders = metrics.active_renders;
         let max_renders = self.resource_limits.max_concurrent_renders;
 
-        current_renders * 10 > max_renders * 8 || metrics.memory_pressure_events > 0
+        current_renders * MEMORY_PRESSURE_RENDER_THRESHOLD_DEN
+            > max_renders * MEMORY_PRESSURE_RENDER_THRESHOLD_NUM
+            || metrics.memory_pressure_events > 0
     }
 
     pub fn force_cleanup(&self) -> impl Future<Output = Result<(), RariError>> {
@@ -870,6 +870,7 @@ globalThis['~errors'].batch.push({{
         self.internal_render_to_string(component_id, props).await
     }
 
+    #[expect(clippy::too_many_lines)]
     async fn internal_render_to_string(
         &self,
         component_id: &str,
@@ -1117,6 +1118,7 @@ globalThis['~errors'].batch.push({{
         self.ensure_component_loaded_with_force(component_id, false).await
     }
 
+    #[expect(clippy::too_many_lines)]
     pub async fn ensure_component_loaded_with_force(
         &self,
         component_id: &str,

--- a/crates/rari/src/rendering/base/renderer.rs
+++ b/crates/rari/src/rendering/base/renderer.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unused_async_trait_impl)]
+#![expect(clippy::too_many_lines)]
 
 use std::{
     env,
@@ -26,8 +27,8 @@ use tracing::error;
 use super::{
     constants::{
         BATCH_ERROR_COLLECTION, CACHE_CLEANUP_INTERVAL, EXTENSION_CHECKS,
-        MEMORY_PRESSURE_THRESHOLD, SERVER_ACTION_INVOCATION_SCRIPT, SERVER_FUNCTION_RESOLVER,
-        V8_CACHE_CLEAR_SCRIPT, module_registration_script, resolve_server_functions_for_component,
+        SERVER_ACTION_INVOCATION_SCRIPT, SERVER_FUNCTION_RESOLVER, V8_CACHE_CLEAR_SCRIPT,
+        module_registration_script, resolve_server_functions_for_component,
     },
     types::{ResourceLimits, ResourceMetrics, ResourceTracker},
     utils::transform_imports_for_hmr,
@@ -36,6 +37,7 @@ use crate::{
     rendering::base::loader::{RscJsLoader, RscModuleOperation},
     runtime::JsExecutionRuntime,
     server::middleware::request_context::RequestContext,
+    utils::cast,
 };
 
 pub struct RscRenderer {
@@ -93,8 +95,7 @@ impl RscRenderer {
         let current_renders = metrics.active_renders;
         let max_renders = self.resource_limits.max_concurrent_renders;
 
-        current_renders as f64 / max_renders as f64 > MEMORY_PRESSURE_THRESHOLD
-            || metrics.memory_pressure_events > 0
+        current_renders * 10 > max_renders * 8 || metrics.memory_pressure_events > 0
     }
 
     pub fn force_cleanup(&self) -> impl Future<Output = Result<(), RariError>> {
@@ -154,7 +155,7 @@ impl RscRenderer {
         }
     }
 
-    fn create_batch_script_section(&self, index: usize, name: &str, script: &str) -> String {
+    fn create_batch_script_section(index: usize, name: &str, script: &str) -> String {
         format!(
             r#"
             // === Batch Script {}: {} ===
@@ -190,7 +191,7 @@ globalThis['~errors'].batch.push({{
         let batch_sections: Vec<String> = scripts
             .iter()
             .enumerate()
-            .map(|(i, (name, script))| self.create_batch_script_section(i, name, script))
+            .map(|(i, (name, script))| Self::create_batch_script_section(i, name, script))
             .collect();
 
         let combined_script = batch_sections.join("\n");
@@ -200,14 +201,10 @@ globalThis['~errors'].batch.push({{
         let batch_name = format!("batch_execution_{}", scripts.len());
         let result = self.execute_script_with_timeout(batch_name, final_script).await?;
 
-        self.handle_batch_script_result(result, scripts.len())
+        Self::handle_batch_script_result(result, scripts.len())
     }
 
-    fn handle_batch_script_result(
-        &self,
-        result: Value,
-        _script_count: usize,
-    ) -> Result<Value, RariError> {
+    fn handle_batch_script_result(result: Value, _script_count: usize) -> Result<Value, RariError> {
         if let Some(success) = result.get("success").and_then(serde_json::Value::as_bool)
             && !success
             && let Some(errors) = result.get("errors").and_then(|e| e.as_array())
@@ -418,7 +415,7 @@ globalThis['~errors'].batch.push({{
         has_jsx || has_client_directive || (has_react_import && has_component_export)
     }
 
-    async fn register_dependency_if_needed(&mut self, dep: String) -> Result<(), RariError> {
+    async fn register_dependency_if_needed(&self, dep: String) -> Result<(), RariError> {
         let mut stack: Vec<String> = vec![dep];
         let mut visited: FxHashSet<String> = FxHashSet::default();
 
@@ -510,7 +507,7 @@ globalThis['~errors'].batch.push({{
     }
 
     async fn register_component_without_loading(
-        &mut self,
+        &self,
         component_id: &str,
         component_code: &str,
     ) -> Result<(), RariError> {
@@ -557,7 +554,7 @@ globalThis['~errors'].batch.push({{
         Ok(())
     }
 
-    async fn load_all_components(&mut self) -> Result<(), RariError> {
+    async fn load_all_components(&self) -> Result<(), RariError> {
         let components_to_load = {
             let registry = self.component_registry.lock();
             registry.get_unloaded_components_in_order()
@@ -614,7 +611,7 @@ globalThis['~errors'].batch.push({{
             match self.runtime.execute_script(format!("load_{component_id}.js"), load_script).await
             {
                 Ok(_) => {
-                    let verify_script = self.create_component_verification_script(component_id);
+                    let verify_script = Self::create_component_verification_script(component_id);
                     self.execute_verification_script(component_id, verify_script).await?;
 
                     let mut registry = self.component_registry.lock();
@@ -631,7 +628,7 @@ globalThis['~errors'].batch.push({{
         Ok(())
     }
 
-    fn create_component_verification_script(&self, component_id: &str) -> String {
+    fn create_component_verification_script(component_id: &str) -> String {
         let hashed_component_id = format!("Component_{}", hash_string(component_id));
         RscJsLoader::create_component_verification_script(component_id, &hashed_component_id)
     }
@@ -754,7 +751,7 @@ globalThis['~errors'].batch.push({{
     }
 
     async fn internal_render_to_rsc(
-        &mut self,
+        &self,
         component_id: &str,
         props: Option<&str>,
     ) -> Result<String, RariError> {
@@ -765,7 +762,7 @@ globalThis['~errors'].batch.push({{
         }
 
         if self.is_client_reference(component_id).await {
-            return self.handle_client_reference(component_id, props).await;
+            return Self::handle_client_reference(component_id, props).await;
         }
 
         if !self.component_exists(component_id) {
@@ -808,13 +805,12 @@ globalThis['~errors'].batch.push({{
         let render_duration = render_start.elapsed();
         self.resource_tracker.record_render_completion(render_duration);
 
-        self.process_rsc_extraction_result(component_id, extraction_result)
+        Self::process_rsc_extraction_result(component_id, &extraction_result)
     }
 
     fn process_rsc_extraction_result(
-        &self,
         component_id: &str,
-        extraction_result: Value,
+        extraction_result: &Value,
     ) -> Result<String, RariError> {
         let parsed_result: Value = if let Some(obj) = extraction_result.as_object() {
             Value::Object(obj.clone())
@@ -857,7 +853,7 @@ globalThis['~errors'].batch.push({{
     }
 
     async fn internal_render_to_rsc_with_context(
-        &mut self,
+        &self,
         component_id: &str,
         props: Option<&str>,
         _request_context: Option<Arc<RequestContext>>,
@@ -866,7 +862,7 @@ globalThis['~errors'].batch.push({{
     }
 
     async fn internal_render_to_string_with_context(
-        &mut self,
+        &self,
         component_id: &str,
         props: Option<&str>,
         _request_context: Option<Arc<RequestContext>>,
@@ -875,7 +871,7 @@ globalThis['~errors'].batch.push({{
     }
 
     async fn internal_render_to_string(
-        &mut self,
+        &self,
         component_id: &str,
         props: Option<&str>,
     ) -> Result<String, RariError> {
@@ -888,7 +884,7 @@ globalThis['~errors'].batch.push({{
         }
 
         if self.is_client_reference(component_id).await {
-            return self.handle_client_reference(component_id, props).await;
+            return Self::handle_client_reference(component_id, props).await;
         }
 
         let is_app_router_component = component_id.starts_with("app/");
@@ -972,13 +968,13 @@ globalThis['~errors'].batch.push({{
                 let mut html =
                     value.get("html").and_then(|h| h.as_str()).unwrap_or_default().to_string();
 
-                html = self.sanitize_html_output(&html, component_id);
+                html = Self::sanitize_html_output(&html, component_id);
 
                 let render_duration = render_start.elapsed();
 
                 self.resource_tracker
                     .total_render_time_ms
-                    .fetch_add(render_duration.as_millis() as u64, Ordering::Relaxed);
+                    .fetch_add(cast::duration_millis_u64(render_duration), Ordering::Relaxed);
 
                 if html == "<div></div>" || html.trim() == "" || html == "<div/>" {
                     return Ok(format!(
@@ -1013,7 +1009,6 @@ globalThis['~errors'].batch.push({{
     }
 
     fn handle_client_reference(
-        &mut self,
         component_id: &str,
         _props: Option<&str>,
     ) -> impl Future<Output = Result<String, RariError>> {
@@ -1022,7 +1017,7 @@ globalThis['~errors'].batch.push({{
         )))
     }
 
-    fn sanitize_html_output(&self, html: &str, component_id: &str) -> String {
+    fn sanitize_html_output(html: &str, component_id: &str) -> String {
         let mut sanitized_html = html.to_string();
 
         let sanitization_rules =
@@ -1323,7 +1318,7 @@ globalThis['~rsc'].functions['{component_id}'] = {component_id};
             .execute_script(format!("post_register_{component_id}.js"), post_register_script)
             .await?;
 
-        let verify_script = self.create_component_verification_script(component_id);
+        let verify_script = Self::create_component_verification_script(component_id);
         self.execute_verification_script(component_id, verify_script).await?;
         {
             let mut registry = self.component_registry.lock();

--- a/crates/rari/src/rendering/base/renderer.rs
+++ b/crates/rari/src/rendering/base/renderer.rs
@@ -326,7 +326,7 @@ globalThis['~errors'].batch.push({{
     }
 
     pub async fn register_component(
-        &mut self,
+        &self,
         component_id: &str,
         component_code: &str,
     ) -> Result<(), RariError> {
@@ -709,7 +709,7 @@ globalThis['~errors'].batch.push({{
     }
 
     pub async fn render_to_rsc_format(
-        &mut self,
+        &self,
         component_id: &str,
         props: Option<&str>,
     ) -> Result<String, RariError> {
@@ -717,7 +717,7 @@ globalThis['~errors'].batch.push({{
     }
 
     pub async fn render_to_rsc_format_with_context(
-        &mut self,
+        &self,
         component_id: &str,
         props: Option<&str>,
         request_context: Option<Arc<RequestContext>>,
@@ -730,7 +730,7 @@ globalThis['~errors'].batch.push({{
     }
 
     pub async fn render_to_string(
-        &mut self,
+        &self,
         component_id: &str,
         props: Option<&str>,
     ) -> Result<String, RariError> {
@@ -738,7 +738,7 @@ globalThis['~errors'].batch.push({{
     }
 
     pub async fn render_to_string_with_context(
-        &mut self,
+        &self,
         component_id: &str,
         props: Option<&str>,
         request_context: Option<Arc<RequestContext>>,

--- a/crates/rari/src/rendering/base/sanitizer.rs
+++ b/crates/rari/src/rendering/base/sanitizer.rs
@@ -2,18 +2,19 @@ use std::sync::OnceLock;
 
 use regex::Regex;
 
+static PRE_JSON_REGEX: OnceLock<Regex> = OnceLock::new();
+static ID_JSON_REGEX: OnceLock<Regex> = OnceLock::new();
+
 pub fn sanitize_component_output(html: &str) -> String {
     if html.is_empty() {
         return String::new();
     }
 
-    static PRE_JSON_REGEX: OnceLock<Regex> = OnceLock::new();
     #[expect(clippy::expect_used, reason = "Infallible operation with valid inputs")]
     let pre_json_regex = PRE_JSON_REGEX
         .get_or_init(|| Regex::new(r"<pre>\\?\{.*?\\?\}</pre>").expect("Valid regex pattern"));
     let result = pre_json_regex.replace_all(html, "");
 
-    static ID_JSON_REGEX: OnceLock<Regex> = OnceLock::new();
     #[expect(clippy::expect_used, reason = "Infallible operation with valid inputs")]
     let id_json_regex = ID_JSON_REGEX
         .get_or_init(|| Regex::new(r#"\\?\{"id":.*?\\?\}"#).expect("Valid regex pattern"));

--- a/crates/rari/src/rendering/base/types.rs
+++ b/crates/rari/src/rendering/base/types.rs
@@ -7,6 +7,7 @@ use super::constants::{
     DEFAULT_MAX_CACHE_SIZE, DEFAULT_MAX_CONCURRENT_RENDERS, DEFAULT_MAX_MEMORY_PER_COMPONENT_MB,
     DEFAULT_MAX_RENDER_TIME_MS, DEFAULT_MAX_SCRIPT_EXECUTION_TIME_MS,
 };
+use crate::utils::{cast, float};
 
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -67,7 +68,7 @@ impl ResourceTracker {
             active_renders: self.active_renders.load(Ordering::Relaxed),
             total_renders,
             average_render_time_ms: if total_renders > 0 {
-                total_time as f64 / total_renders as f64
+                float::u64_ratio(total_time, total_renders)
             } else {
                 0.0
             },
@@ -75,7 +76,7 @@ impl ResourceTracker {
                 let hits = self.cache_hits.load(Ordering::Relaxed);
                 let misses = self.cache_misses.load(Ordering::Relaxed);
                 let total = hits + misses;
-                if total > 0 { hits as f64 / total as f64 } else { 0.0 }
+                if total > 0 { float::u64_ratio(hits, total) } else { 0.0 }
             },
             timeout_errors: self.timeout_errors.load(Ordering::Relaxed),
             memory_pressure_events: self.memory_pressure_events.load(Ordering::Relaxed),
@@ -92,7 +93,7 @@ impl ResourceTracker {
 
     pub fn record_render_completion(&self, duration: Duration) {
         self.total_renders.fetch_add(1, Ordering::Relaxed);
-        self.total_render_time_ms.fetch_add(duration.as_millis() as u64, Ordering::Relaxed);
+        self.total_render_time_ms.fetch_add(cast::duration_millis_u64(duration), Ordering::Relaxed);
     }
 
     pub fn record_cache_hit(&self) {

--- a/crates/rari/src/rendering/base/utils.rs
+++ b/crates/rari/src/rendering/base/utils.rs
@@ -1,31 +1,31 @@
+#![expect(clippy::too_many_lines)]
+
 use std::fmt::Write;
 
 use regex::Regex;
 
 pub fn transform_imports_for_hmr(source: &str) -> String {
-    let react_named_imports_regex =
-        match Regex::new(r"import\s+React,?\s*\{\s*([^}]+)\s*\}\s+from\s+['\x22]react['\x22]") {
-            Ok(regex) => regex,
-            Err(_) => return source.to_string(),
-        };
+    let Ok(react_named_imports_regex) =
+        Regex::new(r"import\s+React,?\s*\{\s*([^}]+)\s*\}\s+from\s+['\x22]react['\x22]")
+    else {
+        return source.to_string();
+    };
 
-    let react_default_import_regex =
-        match Regex::new(r"import\s+React\s+from\s+['\x22]react['\x22]") {
-            Ok(regex) => regex,
-            Err(_) => return source.to_string(),
-        };
+    let Ok(react_default_import_regex) = Regex::new(r"import\s+React\s+from\s+['\x22]react['\x22]")
+    else {
+        return source.to_string();
+    };
 
-    let named_imports_regex =
-        match Regex::new(r"import\s+\{\s*([^}]+)\s*\}\s+from\s+['\x22]([^'\x22]+)['\x22]") {
-            Ok(regex) => regex,
-            Err(_) => return source.to_string(),
-        };
+    let Ok(named_imports_regex) =
+        Regex::new(r"import\s+\{\s*([^}]+)\s*\}\s+from\s+['\x22]([^'\x22]+)['\x22]")
+    else {
+        return source.to_string();
+    };
 
-    let default_import_regex =
-        match Regex::new(r"import\s+(\w+)\s+from\s+['\x22]([^'\x22]+)['\x22]") {
-            Ok(regex) => regex,
-            Err(_) => return source.to_string(),
-        };
+    let Ok(default_import_regex) = Regex::new(r"import\s+(\w+)\s+from\s+['\x22]([^'\x22]+)['\x22]")
+    else {
+        return source.to_string();
+    };
 
     let mut result = String::new();
     let lines: Vec<&str> = source.lines().collect();

--- a/crates/rari/src/rendering/base/utils.rs
+++ b/crates/rari/src/rendering/base/utils.rs
@@ -1,9 +1,8 @@
-#![expect(clippy::too_many_lines)]
-
 use std::fmt::Write;
 
 use regex::Regex;
 
+#[expect(clippy::too_many_lines)]
 pub fn transform_imports_for_hmr(source: &str) -> String {
     let Ok(react_named_imports_regex) =
         Regex::new(r"import\s+React,?\s*\{\s*([^}]+)\s*\}\s+from\s+['\x22]react['\x22]")

--- a/crates/rari/src/rendering/layout/core.rs
+++ b/crates/rari/src/rendering/layout/core.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::too_many_lines)]
+
 use std::{
     env,
     path::{Path, PathBuf},
@@ -74,6 +76,28 @@ const FIZZ_CHUNK_PUMP_HELPER: &str = r"
                         }
 ";
 
+fn convert_route_path_to_dist_path(path: &str) -> String {
+    let (base, ext) =
+        if let Some(pos) = path.rfind('.') { (&path[..pos], &path[pos..]) } else { (path, "") };
+
+    let converted_base = base
+        .chars()
+        .map(|c| if c.is_alphanumeric() || c == '/' || c == '-' || c == '_' { c } else { '_' })
+        .collect::<String>();
+
+    format!("{converted_base}{ext}")
+}
+
+fn component_dist_path(base_path: &Path, file_path: &str, component_id: Option<&str>) -> PathBuf {
+    if let Some(component_id) = component_id {
+        return base_path.join(format!("{component_id}.js"));
+    }
+
+    let js_filename = file_path.cow_replace(".tsx", ".js").cow_replace(".ts", ".js").into_owned();
+    let dist_filename = convert_route_path_to_dist_path(&js_filename);
+    base_path.join("app").join(&dist_filename)
+}
+
 pub struct LayoutHtmlCache {
     handler: Arc<dyn CacheHandler>,
     default_ttl_secs: u64,
@@ -88,7 +112,7 @@ impl Default for LayoutHtmlCache {
 impl LayoutHtmlCache {
     pub fn new() -> Self {
         Self::with_ttl(
-            Arc::new(MemoryCacheHandler::with_config(MemoryConfig {
+            Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
                 max_entries: 5000,
                 default_ttl: 3600,
             })),
@@ -183,50 +207,13 @@ impl LayoutRenderer {
         let page_props = utils::create_page_props(route_match, context)?;
         let page_props_json = serde_json::to_string(&page_props)?;
 
-        fn component_dist_path(
-            base_path: &Path,
-            file_path: &str,
-            component_id: Option<&str>,
-        ) -> PathBuf {
-            if let Some(component_id) = component_id {
-                return base_path.join(format!("{component_id}.js"));
-            }
-
-            fn convert_route_path_to_dist_path(path: &str) -> String {
-                let (base, ext) = if let Some(pos) = path.rfind('.') {
-                    (&path[..pos], &path[pos..])
-                } else {
-                    (path, "")
-                };
-
-                let converted_base = base
-                    .chars()
-                    .map(|c| {
-                        if c.is_alphanumeric() || c == '/' || c == '-' || c == '_' {
-                            c
-                        } else {
-                            '_'
-                        }
-                    })
-                    .collect::<String>();
-
-                format!("{converted_base}{ext}")
-            }
-
-            let js_filename =
-                file_path.cow_replace(".tsx", ".js").cow_replace(".ts", ".js").into_owned();
-            let dist_filename = convert_route_path_to_dist_path(&js_filename);
-            base_path.join("app").join(&dist_filename)
-        }
-
         let dist_server_path = env::current_dir()
             .ok()
             .map(|p| p.join("dist/server"))
             .and_then(|p| p.canonicalize().ok());
 
-        let base_path = match dist_server_path {
-            Some(path) => path,
-            None => return Ok(false),
+        let Some(base_path) = dist_server_path else {
+            return Ok(false);
         };
 
         let page_file_path = component_dist_path(

--- a/crates/rari/src/rendering/layout/core.rs
+++ b/crates/rari/src/rendering/layout/core.rs
@@ -1,10 +1,4 @@
-#![expect(clippy::too_many_lines)]
-
-use std::{
-    env,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{env, sync::Arc};
 
 use base64::{Engine, engine::general_purpose::STANDARD};
 use cow_utils::CowUtils;
@@ -75,28 +69,6 @@ const FIZZ_CHUNK_PUMP_HELPER: &str = r"
                             }
                         }
 ";
-
-fn convert_route_path_to_dist_path(path: &str) -> String {
-    let (base, ext) =
-        if let Some(pos) = path.rfind('.') { (&path[..pos], &path[pos..]) } else { (path, "") };
-
-    let converted_base = base
-        .chars()
-        .map(|c| if c.is_alphanumeric() || c == '/' || c == '-' || c == '_' { c } else { '_' })
-        .collect::<String>();
-
-    format!("{converted_base}{ext}")
-}
-
-fn component_dist_path(base_path: &Path, file_path: &str, component_id: Option<&str>) -> PathBuf {
-    if let Some(component_id) = component_id {
-        return base_path.join(format!("{component_id}.js"));
-    }
-
-    let js_filename = file_path.cow_replace(".tsx", ".js").cow_replace(".ts", ".js").into_owned();
-    let dist_filename = convert_route_path_to_dist_path(&js_filename);
-    base_path.join("app").join(&dist_filename)
-}
 
 pub struct LayoutHtmlCache {
     handler: Arc<dyn CacheHandler>,
@@ -216,7 +188,7 @@ impl LayoutRenderer {
             return Ok(false);
         };
 
-        let page_file_path = component_dist_path(
+        let page_file_path = utils::component_dist_path(
             &base_path,
             &route_match.route.file_path,
             route_match.route.component_id.as_deref(),
@@ -364,6 +336,7 @@ impl LayoutRenderer {
         self.render_route(route_match, context, request_context).await
     }
 
+    #[expect(clippy::too_many_lines)]
     pub async fn render_route_with_streaming(
         &self,
         route_match: &AppRouteMatch,
@@ -1049,6 +1022,7 @@ impl LayoutRenderer {
         Ok(RscStream::new(rx))
     }
 
+    #[expect(clippy::too_many_lines)]
     pub fn build_composition_script(
         &self,
         route_match: &AppRouteMatch,

--- a/crates/rari/src/rendering/layout/core.rs
+++ b/crates/rari/src/rendering/layout/core.rs
@@ -1193,7 +1193,7 @@ impl LayoutRenderer {
     ) -> Result<String, RariError> {
         let component_id = utils::get_component_id(loading_path);
 
-        let mut renderer = self.renderer.lock().await;
+        let renderer = self.renderer.lock().await;
         renderer.render_to_string(&component_id, None).await
     }
 
@@ -1215,7 +1215,7 @@ impl LayoutRenderer {
         let props_json = serde_json::to_string(&props)
             .map_err(|e| RariError::internal(format!("Failed to serialize error props: {e}")))?;
 
-        let mut renderer = self.renderer.lock().await;
+        let renderer = self.renderer.lock().await;
         renderer.render_to_string(&component_id, Some(&props_json)).await
     }
 
@@ -1226,7 +1226,7 @@ impl LayoutRenderer {
     ) -> Result<String, RariError> {
         let component_id = utils::get_component_id(not_found_path);
 
-        let mut renderer = self.renderer.lock().await;
+        let renderer = self.renderer.lock().await;
         renderer.render_to_string(&component_id, None).await
     }
 

--- a/crates/rari/src/rendering/layout/mod.rs
+++ b/crates/rari/src/rendering/layout/mod.rs
@@ -8,6 +8,7 @@ pub use core::{LayoutHtmlCache, LayoutRenderer};
 
 pub use route_composer::{LayoutInfo, RouteComposer};
 pub use types::*;
+pub(crate) use utils::component_dist_path;
 pub use utils::create_layout_context;
 
 #[cfg(test)]

--- a/crates/rari/src/rendering/layout/utils.rs
+++ b/crates/rari/src/rendering/layout/utils.rs
@@ -1,9 +1,7 @@
-#![allow(clippy::string_add, clippy::implicit_hasher)]
-
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use cow_utils::CowUtils;
@@ -73,6 +71,32 @@ pub fn create_client_component_id(file_path: &str) -> String {
         .to_string()
 }
 
+pub fn convert_route_path_to_dist_path(path: &str) -> String {
+    let (base, ext) =
+        if let Some(pos) = path.rfind('.') { (&path[..pos], &path[pos..]) } else { (path, "") };
+
+    let converted_base = base
+        .chars()
+        .map(|c| if c.is_alphanumeric() || c == '/' || c == '-' || c == '_' { c } else { '_' })
+        .collect::<String>();
+
+    format!("{converted_base}{ext}")
+}
+
+pub fn component_dist_path(
+    base_path: &Path,
+    file_path: &str,
+    component_id: Option<&str>,
+) -> PathBuf {
+    if let Some(component_id) = component_id {
+        return base_path.join(format!("{component_id}.js"));
+    }
+
+    let js_filename = file_path.cow_replace(".tsx", ".js").cow_replace(".ts", ".js").into_owned();
+    let dist_filename = convert_route_path_to_dist_path(&js_filename);
+    base_path.join("app").join(&dist_filename)
+}
+
 pub fn get_component_id(file_path: &str) -> String {
     let path = Path::new(file_path);
     let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("Unknown");
@@ -80,7 +104,11 @@ pub fn get_component_id(file_path: &str) -> String {
     let mut chars = stem.chars();
     match chars.next() {
         None => String::new(),
-        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        Some(first) => {
+            let mut result = first.to_uppercase().collect::<String>();
+            result.push_str(chars.as_str());
+            result
+        }
     }
 }
 
@@ -107,6 +135,10 @@ pub fn create_page_props(
     Ok(result)
 }
 
+#[expect(
+    clippy::implicit_hasher,
+    reason = "FxHashMap is the specific hasher needed for LayoutRenderContext"
+)]
 pub fn create_layout_context(
     params: FxHashMap<String, ParamValue>,
     search_params: FxHashMap<String, Vec<String>>,

--- a/crates/rari/src/rendering/mod.rs
+++ b/crates/rari/src/rendering/mod.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::missing_errors_doc)]
+
 pub mod base;
 pub mod layout;
 pub mod r#static;

--- a/crates/rari/src/rendering/static.rs
+++ b/crates/rari/src/rendering/static.rs
@@ -1,6 +1,3 @@
-#![allow(clippy::format_collect, clippy::unused_async_trait_impl)]
-#![expect(clippy::too_many_lines)]
-
 use std::{
     fmt::Write,
     future::Future,
@@ -115,6 +112,7 @@ pub fn test_is_valid_attribute_name(name: &str) -> bool {
     is_valid_attribute_name(name)
 }
 
+#[expect(clippy::too_many_lines)]
 fn serialize_style_object(style_obj: &serde_json::Map<String, serde_json::Value>) -> String {
     const UNITLESS_PROPERTIES: &[&str] = &[
         "animation-iteration-count",
@@ -1046,6 +1044,7 @@ impl RscHtmlRenderer {
         })
     }
 
+    #[expect(clippy::too_many_lines)]
     fn render_component_to_html<'a>(
         &'a self,
         tag: &'a str,
@@ -1351,6 +1350,7 @@ impl RscToHtmlConverter {
         self.boundary_id_generator.next()
     }
 
+    #[expect(clippy::too_many_lines)]
     pub async fn convert_chunk(&mut self, chunk: RscStreamChunk) -> Result<Vec<u8>, RariError> {
         let chunk_type_str = format!("{:?}", chunk.chunk_type);
 
@@ -1593,8 +1593,11 @@ impl RscToHtmlConverter {
 
         rows_with_ids.sort_by_key(|(id, _)| if *id == 0 { u32::MAX - 1 } else { *id });
 
-        let mut rsc_payload =
-            rows_with_ids.iter().map(|(_, row)| format!("{row}\n")).collect::<String>();
+        let mut rsc_payload = String::new();
+        for (_, row) in &rows_with_ids {
+            rsc_payload.push_str(row);
+            rsc_payload.push('\n');
+        }
 
         let has_row_0 = rows_with_ids.iter().any(|(id, _)| *id == 0);
 
@@ -1700,6 +1703,7 @@ if (typeof window !== 'undefined') {{
         Ok(html.into_bytes())
     }
 
+    #[expect(clippy::too_many_lines)]
     fn rsc_element_to_html<'a>(
         &'a self,
         element: &'a serde_json::Value,

--- a/crates/rari/src/rendering/static.rs
+++ b/crates/rari/src/rendering/static.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::format_collect, clippy::unused_async_trait_impl)]
+#![expect(clippy::too_many_lines)]
 
 use std::{
     fmt::Write,
@@ -32,6 +33,8 @@ const SELF_CLOSING_TAGS: &[&str] = &[
     "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source",
     "track", "wbr",
 ];
+
+const PAYLOAD_SIZE_LIMIT: usize = 50000;
 
 pub fn escape_html(text: &str) -> String {
     text.cow_replace('&', "&amp;")
@@ -354,14 +357,14 @@ impl RscHtmlRenderer {
         let template = match self.read_template_file(is_dev_mode).await {
             Ok(content) => {
                 if is_dev_mode {
-                    self.inject_vite_client_if_needed(&content)
+                    Self::inject_vite_client_if_needed(&content)
                 } else {
                     content
                 }
             }
             Err(e) => {
                 if is_dev_mode {
-                    self.generate_dev_template_fallback()
+                    Self::generate_dev_template_fallback()
                 } else {
                     return Err(e);
                 }
@@ -376,7 +379,7 @@ impl RscHtmlRenderer {
         Ok(template)
     }
 
-    fn inject_vite_client_if_needed(&self, html: &str) -> String {
+    fn inject_vite_client_if_needed(html: &str) -> String {
         if html.contains("/@vite/client") || html.contains("@vite/client") {
             return html.to_string();
         }
@@ -412,7 +415,7 @@ impl RscHtmlRenderer {
         )
     }
 
-    fn generate_dev_template_fallback(&self) -> String {
+    fn generate_dev_template_fallback() -> String {
         r#"<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -545,7 +548,7 @@ impl RscHtmlRenderer {
                 continue;
             }
 
-            let row = self.parse_rsc_line(line)?;
+            let row = Self::parse_rsc_line(line)?;
             rows.push(row);
         }
 
@@ -574,7 +577,7 @@ impl RscHtmlRenderer {
         }
     }
 
-    fn parse_rsc_line(&self, line: &str) -> Result<RscRow, RariError> {
+    fn parse_rsc_line(line: &str) -> Result<RscRow, RariError> {
         let colon_pos = line.find(':').ok_or_else(|| {
             RariError::internal(format!("Invalid RSC line format: missing colon in '{line}'"))
         })?;
@@ -605,12 +608,12 @@ impl RscHtmlRenderer {
         let json_value: Value = serde_json::from_str(data_str)
             .map_err(|e| RariError::internal(format!("Invalid JSON in RSC line: {e}")))?;
 
-        let data = self.parse_rsc_element(&json_value)?;
+        let data = Self::parse_rsc_element(&json_value)?;
 
         Ok(RscRow { id, data })
     }
 
-    fn parse_rsc_element(&self, value: &Value) -> Result<RscElement, RariError> {
+    fn parse_rsc_element(value: &Value) -> Result<RscElement, RariError> {
         match value {
             Value::String(s) => {
                 if let Some(stripped) = s.strip_prefix('$') {
@@ -632,12 +635,12 @@ impl RscHtmlRenderer {
                 if let Some(Value::String(marker)) = arr.first()
                     && marker == "$"
                 {
-                    return self.parse_react_element(arr);
+                    return Self::parse_react_element(arr);
                 }
 
                 let mut children = Vec::new();
                 for item in arr {
-                    children.push(self.parse_rsc_element(item)?);
+                    children.push(Self::parse_rsc_element(item)?);
                 }
 
                 Ok(RscElement::Fragment { children })
@@ -653,7 +656,7 @@ impl RscHtmlRenderer {
         }
     }
 
-    fn parse_react_element(&self, arr: &[Value]) -> Result<RscElement, RariError> {
+    fn parse_react_element(arr: &[Value]) -> Result<RscElement, RariError> {
         if arr.len() < 4 {
             return Err(RariError::internal(format!(
                 "Invalid React element: expected 4 elements, got {}",
@@ -1154,8 +1157,7 @@ impl RscHtmlRenderer {
                 }
             }
 
-            const SELF_CLOSING: &[&str] = SELF_CLOSING_TAGS;
-            if SELF_CLOSING.contains(&tag) {
+            if SELF_CLOSING_TAGS.contains(&tag) {
                 html.push_str(" />");
                 return Ok(html);
             }
@@ -1467,37 +1469,9 @@ impl RscToHtmlConverter {
                     self.rsc_flight_protocol.push(placeholder_row.trim().to_string());
                 }
 
-                let fallback_html = self.generate_fallback_error_html();
-
-                match self.generate_error_replacement(&chunk).await {
-                    Ok(error_html) => {
-                        html.extend(error_html);
-                        Ok(html)
-                    }
-                    Err(e) => {
-                        error!("Error generating error replacement: {}", e);
-                        if let Some(ref boundary_id) = chunk.boundary_id {
-                            let react_boundary_id = {
-                                let map = self.rari_to_react_boundary_map.lock();
-                                map.get(boundary_id).cloned()
-                            };
-                            if let Some(react_id) = react_boundary_id {
-                                let content_id = format!("E:{}", react_id.trim_start_matches("B:"));
-                                let cleanup = format!(
-                                    r#"<div hidden id="{}">{}</div><script>$RC=window.$RC||function(b,c){{var t=document.getElementById(b);var s=document.getElementById(c);if(t&&s){{var p=t.parentNode;var f=document.createDocumentFragment();Array.from(s.childNodes).forEach(function(n){{f.appendChild(n)}});var d=t.nextSibling;while(d&&!(d.nodeType===8&&d.data==='/$')){{var next=d.nextSibling;d.remove();d=next;}}if(d)d.remove();p.insertBefore(f,t.nextSibling);t.remove();s.remove();}}}};$RC("{}","{}")</script>"#,
-                                    content_id,
-                                    String::from_utf8_lossy(&fallback_html),
-                                    react_id,
-                                    content_id
-                                );
-                                html.extend(cleanup.into_bytes());
-                                return Ok(html);
-                            }
-                        }
-                        html.extend(fallback_html);
-                        Ok(html)
-                    }
-                }
+                let error_html = self.generate_error_replacement(&chunk);
+                html.extend(error_html);
+                Ok(html)
             }
 
             RscChunkType::StreamComplete => {
@@ -1525,7 +1499,7 @@ impl RscToHtmlConverter {
         result
     }
 
-    fn generate_fallback_error_html(&self) -> Vec<u8> {
+    fn generate_fallback_error_html() -> Vec<u8> {
         r#"<div style="color: red; border: 1px solid red; padding: 10px; margin: 10px 0;">
             An error occurred while loading content.
         </div>"#
@@ -1711,8 +1685,6 @@ if (typeof window !== 'undefined') {{
         {
             return Ok(Vec::new());
         }
-
-        const PAYLOAD_SIZE_LIMIT: usize = 50000;
 
         if json_str.starts_with("[[") || json_str.len() > PAYLOAD_SIZE_LIMIT {
             return Ok(Vec::new());
@@ -2059,8 +2031,7 @@ if (typeof window !== 'undefined') {{
             }
         }
 
-        const SELF_CLOSING: &[&str] = SELF_CLOSING_TAGS;
-        if SELF_CLOSING.contains(&tag) {
+        if SELF_CLOSING_TAGS.contains(&tag) {
             html.push_str(" />");
             return Ok(html);
         }
@@ -2159,15 +2130,12 @@ if (typeof window !== 'undefined') {{
         Ok(output.into_bytes())
     }
 
-    async fn generate_error_replacement(
-        &self,
-        chunk: &RscStreamChunk,
-    ) -> Result<Vec<u8>, RariError> {
+    fn generate_error_replacement(&self, chunk: &RscStreamChunk) -> Vec<u8> {
         let rsc_line = String::from_utf8_lossy(&chunk.data);
         let parts: Vec<&str> = rsc_line.trim().splitn(2, ':').collect();
 
         if parts.len() != 2 {
-            return Ok(self.generate_fallback_error_html());
+            return Self::generate_fallback_error_html();
         }
 
         let json_part = parts[1].strip_prefix('E').unwrap_or(parts[1]);
@@ -2176,7 +2144,7 @@ if (typeof window !== 'undefined') {{
             Ok(data) => data,
             Err(e) => {
                 error!("Failed to parse error data from stream, using fallback: {}", e);
-                return Ok(self.generate_fallback_error_html());
+                return Self::generate_fallback_error_html();
             }
         };
 
@@ -2201,9 +2169,9 @@ if (typeof window !== 'undefined') {{
                 r#"<div hidden id="{content_id}">{error_html}</div><script>$RC=window.$RC||function(b,c){{const t=document.getElementById(b);const s=document.getElementById(c);if(t&&s){{const p=t.parentNode;Array.from(s.childNodes).forEach(n=>p.insertBefore(n,t));t.remove();s.remove();}}}};$RC("{react_boundary_id}","{content_id}");</script>"#
             );
 
-            Ok(error_update.into_bytes())
+            error_update.into_bytes()
         } else {
-            Ok(self.generate_fallback_error_html())
+            Self::generate_fallback_error_html()
         }
     }
 }
@@ -2272,10 +2240,7 @@ mod tests {
 
     #[test]
     fn test_parse_rsc_line_missing_colon() {
-        let runtime = Arc::new(JsExecutionRuntime::new(None));
-        let renderer = RscHtmlRenderer::new(runtime);
-
-        let result = renderer.parse_rsc_line("0invalid");
+        let result = RscHtmlRenderer::parse_rsc_line("0invalid");
         assert!(result.is_err());
         let err_msg = format!("{:?}", result.unwrap_err());
         assert!(err_msg.contains("missing colon"));
@@ -2283,10 +2248,7 @@ mod tests {
 
     #[test]
     fn test_parse_rsc_line_invalid_row_id() {
-        let runtime = Arc::new(JsExecutionRuntime::new(None));
-        let renderer = RscHtmlRenderer::new(runtime);
-
-        let result = renderer.parse_rsc_line("xyz:{}");
+        let result = RscHtmlRenderer::parse_rsc_line("xyz:{}");
         assert!(result.is_err());
         let err_msg = format!("{:?}", result.unwrap_err());
         assert!(err_msg.contains("Invalid row ID"));
@@ -2294,10 +2256,7 @@ mod tests {
 
     #[test]
     fn test_parse_rsc_line_invalid_json() {
-        let runtime = Arc::new(JsExecutionRuntime::new(None));
-        let renderer = RscHtmlRenderer::new(runtime);
-
-        let result = renderer.parse_rsc_line("0:{invalid json}");
+        let result = RscHtmlRenderer::parse_rsc_line("0:{invalid json}");
         assert!(result.is_err());
         let err_msg = format!("{:?}", result.unwrap_err());
         assert!(err_msg.contains("Invalid JSON"));
@@ -2305,12 +2264,9 @@ mod tests {
 
     #[test]
     fn test_parse_react_element_invalid_structure() {
-        let runtime = Arc::new(JsExecutionRuntime::new(None));
-        let renderer = RscHtmlRenderer::new(runtime);
-
         let arr = vec![Value::String("$".to_string()), Value::String("div".to_string())];
 
-        let result = renderer.parse_react_element(&arr);
+        let result = RscHtmlRenderer::parse_react_element(&arr);
         assert!(result.is_err());
         let err_msg = format!("{:?}", result.unwrap_err());
         assert!(err_msg.contains("expected 4 elements"));
@@ -2318,9 +2274,6 @@ mod tests {
 
     #[test]
     fn test_parse_react_element_non_string_tag() {
-        let runtime = Arc::new(JsExecutionRuntime::new(None));
-        let renderer = RscHtmlRenderer::new(runtime);
-
         let arr = vec![
             Value::String("$".to_string()),
             Value::Number(123.into()),
@@ -2328,7 +2281,7 @@ mod tests {
             Value::Object(serde_json::Map::new()),
         ];
 
-        let result = renderer.parse_react_element(&arr);
+        let result = RscHtmlRenderer::parse_react_element(&arr);
         assert!(result.is_err());
         let err_msg = format!("{:?}", result.unwrap_err());
         assert!(err_msg.contains("tag must be a string"));
@@ -2336,11 +2289,8 @@ mod tests {
 
     #[test]
     fn test_parse_rsc_element_text() {
-        let runtime = Arc::new(JsExecutionRuntime::new(None));
-        let renderer = RscHtmlRenderer::new(runtime);
-
         let value = Value::String("Hello World".to_string());
-        let result = renderer.parse_rsc_element(&value);
+        let result = RscHtmlRenderer::parse_rsc_element(&value);
         assert!(result.is_ok());
 
         if let RscElement::Text(text) = result.unwrap() {
@@ -2352,11 +2302,8 @@ mod tests {
 
     #[test]
     fn test_parse_rsc_element_reference() {
-        let runtime = Arc::new(JsExecutionRuntime::new(None));
-        let renderer = RscHtmlRenderer::new(runtime);
-
         let value = Value::String("$L1".to_string());
-        let result = renderer.parse_rsc_element(&value);
+        let result = RscHtmlRenderer::parse_rsc_element(&value);
         assert!(result.is_ok());
 
         if let RscElement::Reference(ref_str) = result.unwrap() {
@@ -2396,9 +2343,6 @@ mod tests {
 
     #[test]
     fn test_parse_rsc_element_component() {
-        let runtime = Arc::new(JsExecutionRuntime::new(None));
-        let renderer = RscHtmlRenderer::new(runtime);
-
         let mut props = serde_json::Map::new();
         props.insert("children".to_string(), Value::String("Hello".to_string()));
 
@@ -2409,7 +2353,7 @@ mod tests {
             Value::Object(props),
         ]);
 
-        let result = renderer.parse_rsc_element(&value);
+        let result = RscHtmlRenderer::parse_rsc_element(&value);
         assert!(result.is_ok());
 
         if let RscElement::Component { tag, key, props } = result.unwrap() {
@@ -2423,11 +2367,8 @@ mod tests {
 
     #[test]
     fn test_parse_rsc_element_empty_array() {
-        let runtime = Arc::new(JsExecutionRuntime::new(None));
-        let renderer = RscHtmlRenderer::new(runtime);
-
         let value = Value::Array(vec![]);
-        let result = renderer.parse_rsc_element(&value);
+        let result = RscHtmlRenderer::parse_rsc_element(&value);
         assert!(result.is_err());
         let err_msg = format!("{:?}", result.unwrap_err());
         assert!(err_msg.contains("Empty array"));
@@ -2611,10 +2552,7 @@ mod tests {
 
     #[test]
     fn test_generate_dev_template_fallback() {
-        let runtime = Arc::new(JsExecutionRuntime::new(None));
-        let renderer = RscHtmlRenderer::new(runtime);
-
-        let template = renderer.generate_dev_template_fallback();
+        let template = RscHtmlRenderer::generate_dev_template_fallback();
 
         assert!(template.contains("<!DOCTYPE html>"));
         assert!(template.contains(r#"<div id="root"></div>"#));
@@ -2862,9 +2800,6 @@ mod tests {
 
     #[test]
     fn test_parse_suspense_boundary() {
-        let runtime = Arc::new(JsExecutionRuntime::new(None));
-        let renderer = RscHtmlRenderer::new(runtime);
-
         let mut props = serde_json::Map::new();
         props.insert("fallback".to_string(), Value::String("$L1".to_string()));
         props.insert("children".to_string(), Value::String("$L2".to_string()));
@@ -2877,7 +2812,7 @@ mod tests {
             Value::Object(props),
         ]);
 
-        let result = renderer.parse_rsc_element(&value);
+        let result = RscHtmlRenderer::parse_rsc_element(&value);
         assert!(result.is_ok());
 
         if let RscElement::Component { tag, key, props } = result.unwrap() {

--- a/crates/rari/src/runtime/ext/io/tty_unix.rs
+++ b/crates/rari/src/runtime/ext/io/tty_unix.rs
@@ -9,10 +9,12 @@ use std::{
     mem,
     os::fd::RawFd,
     rc::Rc,
+    sync::OnceLock,
 };
 
 use deno_core::{OpState, ResourceId, error::ResourceError, op2};
 use deno_error::{JsErrorBox, JsErrorClass, builtin_classes::GENERIC_ERROR};
+use libc::{atexit, tcgetattr, tcsetattr, termios as LibcTermios};
 use nix::sys::termios;
 use rustc_hash::FxHashMap;
 use rustyline::{
@@ -88,8 +90,34 @@ impl From<Error> for TtyError {
     }
 }
 
+static ORIG_TERMIOS: OnceLock<Option<LibcTermios>> = OnceLock::new();
+
+extern "C" fn reset_stdio() {
+    // SAFETY: Reset the stdio state.
+    unsafe {
+        if let Some(Some(termios)) = ORIG_TERMIOS.get() {
+            tcsetattr(libc::STDIN_FILENO, 0, termios);
+        }
+    }
+}
+
+fn prepare_stdio() {
+    // SAFETY: Save current state of stdio and restore it when we exit.
+    unsafe {
+        ORIG_TERMIOS.get_or_init(|| {
+            let mut termios = mem::zeroed::<LibcTermios>();
+            if tcgetattr(libc::STDIN_FILENO, &raw mut termios) == 0 {
+                atexit(reset_stdio);
+                Some(termios)
+            } else {
+                None
+            }
+        });
+    }
+}
+
 #[op2(fast)]
-fn op_set_raw(state: &mut OpState, rid: u32, is_raw: bool, cbreak: bool) -> Result<(), TtyError> {
+fn op_set_raw(state: &OpState, rid: u32, is_raw: bool, cbreak: bool) -> Result<(), TtyError> {
     let handle_or_fd = state.resource_table.get_fd(rid)?;
 
     // From https://github.com/kkawakam/rustyline/blob/master/src/tty/windows.rs
@@ -97,38 +125,6 @@ fn op_set_raw(state: &mut OpState, rid: u32, is_raw: bool, cbreak: bool) -> Resu
     // and https://github.com/crossterm-rs/crossterm/blob/e35d4d2c1cc4c919e36d242e014af75f6127ab50/src/terminal/sys/windows.rs
     // Copyright (c) 2015 Katsu Kawakami & Rustyline authors. MIT license.
     // Copyright (c) 2019 Timon. MIT license.
-
-    fn prepare_stdio() {
-        // SAFETY: Save current state of stdio and restore it when we exit.
-        unsafe {
-            use std::sync::OnceLock;
-
-            use libc::{atexit, tcgetattr, tcsetattr, termios};
-
-            // Only save original state once.
-            static ORIG_TERMIOS: OnceLock<Option<termios>> = OnceLock::new();
-            ORIG_TERMIOS.get_or_init(|| {
-                let mut termios = mem::zeroed::<termios>();
-                if tcgetattr(libc::STDIN_FILENO, &raw mut termios) == 0 {
-                    extern "C" fn reset_stdio() {
-                        // SAFETY: Reset the stdio state.
-                        unsafe {
-                            if let Some(Some(termios)) = ORIG_TERMIOS.get() {
-                                tcsetattr(libc::STDIN_FILENO, 0, termios)
-                            } else {
-                                -1
-                            }
-                        };
-                    }
-
-                    atexit(reset_stdio);
-                    return Some(termios);
-                }
-
-                None
-            });
-        }
-    }
 
     prepare_stdio();
     let tty_mode_store = state.borrow::<TtyModeStore>().clone();
@@ -179,12 +175,8 @@ fn op_set_raw(state: &mut OpState, rid: u32, is_raw: bool, cbreak: bool) -> Resu
 }
 
 #[op2(fast)]
-fn op_console_size(state: &mut OpState, #[buffer] result: &mut [u32]) -> Result<(), TtyError> {
-    fn check_console_size(
-        state: &mut OpState,
-        result: &mut [u32],
-        rid: u32,
-    ) -> Result<(), TtyError> {
+fn op_console_size(state: &OpState, #[buffer] result: &mut [u32]) -> Result<(), TtyError> {
+    fn check_console_size(state: &OpState, result: &mut [u32], rid: u32) -> Result<(), TtyError> {
         let fd = state.resource_table.get_fd(rid)?;
         let size = console_size_from_fd(fd)?;
         result[0] = size.cols;

--- a/crates/rari/src/runtime/ext/rari/cache/redis_cache.rs
+++ b/crates/rari/src/runtime/ext/rari/cache/redis_cache.rs
@@ -94,7 +94,7 @@ fn js_error(error: &impl Display) -> JsErrorBox {
     JsErrorBox::generic(error.to_string())
 }
 
-fn get_redis_state(state: Rc<RefCell<OpState>>) -> Result<Arc<RedisCacheState>, RedisCacheError> {
+fn get_redis_state(state: &Rc<RefCell<OpState>>) -> Result<Arc<RedisCacheState>, RedisCacheError> {
     state
         .borrow()
         .try_borrow::<Arc<RedisCacheState>>()
@@ -108,7 +108,7 @@ pub async fn op_cache_remote_get(
     state: Rc<RefCell<OpState>>,
     #[string] key: String,
 ) -> Result<Option<String>, JsErrorBox> {
-    let mut connection = get_redis_state(state)
+    let mut connection = get_redis_state(&state)
         .map_err(|e| js_error(&e))?
         .connection()
         .await
@@ -127,7 +127,7 @@ pub async fn op_cache_remote_set(
     #[string] value: String,
     #[smi] ttl_ms: u32,
 ) -> Result<(), JsErrorBox> {
-    let redis_state = get_redis_state(state).map_err(|e| js_error(&e))?;
+    let redis_state = get_redis_state(&state).map_err(|e| js_error(&e))?;
     let mut connection = redis_state.connection().await.map_err(|e| js_error(&e))?;
     let ttl_secs = if ttl_ms == 0 { redis_state.default_ttl_secs } else { ttl_ms_to_secs(ttl_ms) };
     time::timeout(REDIS_TIMEOUT, connection.set_ex::<_, _, ()>(&key, value.into_bytes(), ttl_secs))

--- a/crates/rari/src/runtime/ext/web/options.rs
+++ b/crates/rari/src/runtime/ext/web/options.rs
@@ -66,7 +66,7 @@ fn fix_accept_encoding_for_deno(
 }
 
 impl WebOptions {
-    pub fn whitelist_certificate_for(&mut self, domain_or_ip: impl ToString) {
+    pub fn whitelist_certificate_for(&mut self, domain_or_ip: &impl ToString) {
         if let Some(ref mut domains) = self.unsafely_ignore_certificate_errors {
             domains.push(domain_or_ip.to_string());
         } else {

--- a/crates/rari/src/runtime/ext/web/permissions.rs
+++ b/crates/rari/src/runtime/ext/web/permissions.rs
@@ -14,7 +14,7 @@ pub use deno_permissions::PermissionDeniedError;
 use parking_lot::RwLock;
 use rustc_hash::FxHashSet;
 
-fn to_io_err(err: PermissionDeniedError) -> Error {
+fn to_io_err(err: &PermissionDeniedError) -> Error {
     Error::new(PermissionDenied, err.to_string())
 }
 

--- a/crates/rari/src/runtime/factory/executor.rs
+++ b/crates/rari/src/runtime/factory/executor.rs
@@ -177,8 +177,9 @@ async fn execute_as_script(
     promise_timeout_ms: u64,
 ) -> Result<Value, RariError> {
     let transpiled_code = if script_name.ends_with(".ts") || script_name.ends_with(".tsx") {
+        let module_name = deno_core::ModuleName::from(script_name.to_string());
         match transpile::maybe_transpile_source(
-            deno_core::ModuleName::from(script_name.to_string()),
+            &module_name,
             deno_core::ModuleCodeString::from(script_code.to_string()),
         ) {
             Ok((code, _source_map)) => Some(code.to_string()),
@@ -231,12 +232,9 @@ async fn handle_promise_result(
         let local_v8_val = deno_core::v8::Local::new(scope, &global_v8_val);
         let context = scope.get_current_context();
         let global = context.global(scope);
-        let key = match v8::String::new(scope, "__temp_promise_ref__") {
-            Some(key) => key,
-            None => {
-                error!("Failed to create V8 string for __temp_promise_ref__");
-                return Err(RariError::internal("Failed to create V8 string".to_string()));
-            }
+        let Some(key) = v8::String::new(scope, "__temp_promise_ref__") else {
+            error!("Failed to create V8 string for __temp_promise_ref__");
+            return Err(RariError::internal("Failed to create V8 string".to_string()));
         };
         global.set(scope, key.into(), local_v8_val);
         Ok::<(), RariError>(())

--- a/crates/rari/src/runtime/factory/mod.rs
+++ b/crates/rari/src/runtime/factory/mod.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::implicit_hasher)]
-
 mod create_params;
 mod executor;
 mod interface;
@@ -17,6 +15,10 @@ pub fn create_runtime() -> Arc<RariRuntime> {
     Arc::new(RariRuntime::new(None))
 }
 
+#[expect(
+    clippy::implicit_hasher,
+    reason = "FxHashMap is the specific hasher needed for runtime env vars"
+)]
 pub fn create_runtime_with_env(env_vars: FxHashMap<String, String>) -> Arc<RariRuntime> {
     Arc::new(RariRuntime::new(Some(env_vars)))
 }

--- a/crates/rari/src/runtime/factory/runtime.rs
+++ b/crates/rari/src/runtime/factory/runtime.rs
@@ -124,17 +124,14 @@ impl RariRuntime {
 
             runtime.block_on(async {
                 loop {
-                    let (mut js_runtime, module_loader) =
-                        match build_js_runtime(env_vars.clone()) {
-                            Ok(rt) => rt,
-                            Err(_) => {
-                                time::sleep(Duration::from_millis(
-                                    RUNTIME_RESTART_DELAY_MS,
-                                ))
-                                .await;
-                                continue;
-                            }
-                        };
+                    let Ok((mut js_runtime, module_loader)) = build_js_runtime(env_vars.clone())
+                    else {
+                        time::sleep(Duration::from_millis(
+                            RUNTIME_RESTART_DELAY_MS,
+                        ))
+                        .await;
+                        continue;
+                    };
 
                     let mut continue_processing = true;
                     let mut pending_batches: Vec<PendingBatch> = Vec::new();
@@ -408,8 +405,7 @@ async fn handle_js_request(
                 })
                 .collect();
 
-            if let Some(pending_batch) =
-                setup_concurrent_batch(js_runtime, batch, batch_id_counter).await
+            if let Some(pending_batch) = setup_concurrent_batch(js_runtime, batch, batch_id_counter)
             {
                 pending_batches.push(pending_batch);
             }
@@ -499,7 +495,7 @@ async fn handle_js_request(
     Ok(())
 }
 
-async fn setup_concurrent_batch(
+fn setup_concurrent_batch(
     js_runtime: &mut deno_core::JsRuntime,
     batch: Vec<ScriptBatchItem>,
     batch_id_counter: &mut u64,

--- a/crates/rari/src/runtime/factory/utils/v8.rs
+++ b/crates/rari/src/runtime/factory/utils/v8.rs
@@ -141,7 +141,7 @@ fn deserialize_composition_result<'s>(
                 return Ok(metadata);
             }
 
-            extract_composition_result_manually(scope, value, err)
+            extract_composition_result_manually(scope, value, &err)
         }
         Err(_panic) => {
             tracing::error!(
@@ -161,7 +161,7 @@ fn deserialize_composition_result<'s>(
 fn extract_composition_result_manually<'s>(
     scope: &mut v8::PinScope<'s, '_>,
     value: v8::Local<'s, v8::Value>,
-    original_error: serde_v8::Error,
+    original_error: &serde_v8::Error,
 ) -> Result<Value, RariError> {
     let try_json_stringify =
         |scope: &mut v8::PinScope, value: v8::Local<v8::Value>| -> Option<Value> {

--- a/crates/rari/src/runtime/mod.rs
+++ b/crates/rari/src/runtime/mod.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::missing_errors_doc, clippy::too_many_lines)]
+
 use std::{
     future::Future,
     sync::{Arc, OnceLock},

--- a/crates/rari/src/runtime/module_loader/cache.rs
+++ b/crates/rari/src/runtime/module_loader/cache.rs
@@ -42,7 +42,7 @@ impl ModuleCaching {
         Self::with_handler(
             cache_size,
             ttl_secs,
-            Arc::new(MemoryCacheHandler::with_config(MemoryConfig {
+            Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
                 max_entries: cache_size.max(1),
                 default_ttl: ttl_secs,
             })),
@@ -63,9 +63,8 @@ impl ModuleCaching {
     }
 
     pub async fn get(&self, key: &str) -> Option<Value> {
-        let bytes = match self.handler.get(key).await {
-            Ok(Some(b)) => b,
-            Ok(None) | Err(_) => return None,
+        let Ok(Some(bytes)) = self.handler.get(key).await else {
+            return None;
         };
         match serde_json::from_slice(&bytes) {
             Ok(v) => Some(v),

--- a/crates/rari/src/runtime/module_loader/core.rs
+++ b/crates/rari/src/runtime/module_loader/core.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::self_only_used_in_recursion)]
-
 use std::{
     borrow::Cow,
     env, fs,
@@ -491,13 +489,13 @@ export default {{}};
                     let package_name = &package_specifier[..actual_slash_pos];
                     let subpath = &package_specifier[actual_slash_pos..];
 
-                    return self.resolve_subpath_export_from_dir(package_name, subpath, start_dir);
+                    return Self::resolve_subpath_export_from_dir(package_name, subpath, start_dir);
                 }
             } else {
                 let package_name = &package_specifier[..slash_pos];
                 let subpath = &package_specifier[slash_pos..];
 
-                return self.resolve_subpath_export_from_dir(package_name, subpath, start_dir);
+                return Self::resolve_subpath_export_from_dir(package_name, subpath, start_dir);
             }
         }
 
@@ -1118,7 +1116,6 @@ export {{ __exportProxy__ as __cjsExports__, __keys__ }};
     }
 
     fn resolve_subpath_export_from_dir(
-        &self,
         package_name: &str,
         subpath: &str,
         start_dir: &Path,
@@ -1134,14 +1131,13 @@ export {{ __exportProxy__ as __cjsExports__, __keys__ }};
         let package_info = Self::parse_package_json(&package_json_content).ok()?;
 
         if let Some(exports) = &package_info.exports {
-            return self.resolve_subpath_from_exports(exports, subpath, &package_dir);
+            return Self::resolve_subpath_from_exports(exports, subpath, &package_dir);
         }
 
         None
     }
 
     fn resolve_subpath_from_exports(
-        &self,
         exports: &serde_json::Value,
         subpath: &str,
         package_dir: &Path,
@@ -1156,7 +1152,7 @@ export {{ __exportProxy__ as __cjsExports__, __keys__ }};
 
             for variant in &subpath_variants {
                 if let Some(export_value) = exports_obj.get(variant)
-                    && let Some(result) = self.resolve_export_value(export_value, package_dir)
+                    && let Some(result) = Self::resolve_export_value(export_value, package_dir)
                 {
                     return Some(result);
                 }
@@ -1166,7 +1162,7 @@ export {{ __exportProxy__ as __cjsExports__, __keys__ }};
         None
     }
 
-    fn resolve_subpath_import(&self, specifier: &str, referrer: &str) -> Option<String> {
+    fn resolve_subpath_import(specifier: &str, referrer: &str) -> Option<String> {
         let clean_referrer = if referrer.starts_with(FILE_PROTOCOL) {
             file_url_to_path(referrer)
                 .map(|p| p.to_string_lossy().to_string())
@@ -1188,7 +1184,7 @@ export {{ __exportProxy__ as __cjsExports__, __keys__ }};
                     && let Ok(json) = serde_json::from_str::<serde_json::Value>(&content)
                     && let Some(imports) = json.get("imports").and_then(|v| v.as_object())
                     && let Some(import_value) = imports.get(specifier)
-                    && let Some(resolved) = self.resolve_import_value(import_value, &current_dir)
+                    && let Some(resolved) = Self::resolve_import_value(import_value, &current_dir)
                 {
                     return Some(resolved);
                 }
@@ -1203,11 +1199,7 @@ export {{ __exportProxy__ as __cjsExports__, __keys__ }};
         None
     }
 
-    fn resolve_import_value(
-        &self,
-        value: &serde_json::Value,
-        package_dir: &Path,
-    ) -> Option<String> {
+    fn resolve_import_value(value: &serde_json::Value, package_dir: &Path) -> Option<String> {
         match value {
             serde_json::Value::String(path_str) => {
                 let clean_path = path_str.trim_start_matches("./");
@@ -1220,7 +1212,7 @@ export {{ __exportProxy__ as __cjsExports__, __keys__ }};
                 let conditions = ["node", "import", "module", "default"];
                 for condition in &conditions {
                     if let Some(nested_value) = obj.get(*condition)
-                        && let Some(result) = self.resolve_import_value(nested_value, package_dir)
+                        && let Some(result) = Self::resolve_import_value(nested_value, package_dir)
                     {
                         return Some(result);
                     }
@@ -1232,7 +1224,6 @@ export {{ __exportProxy__ as __cjsExports__, __keys__ }};
     }
 
     fn resolve_export_value(
-        &self,
         export_value: &serde_json::Value,
         package_dir: &Path,
     ) -> Option<String> {
@@ -1248,7 +1239,7 @@ export {{ __exportProxy__ as __cjsExports__, __keys__ }};
                 let conditions = ["import", "module", "default"];
                 for condition in &conditions {
                     if let Some(nested_value) = obj.get(*condition)
-                        && let Some(result) = self.resolve_export_value(nested_value, package_dir)
+                        && let Some(result) = Self::resolve_export_value(nested_value, package_dir)
                     {
                         return Some(result);
                     }
@@ -1450,7 +1441,7 @@ impl ModuleLoader for RariModuleLoader {
         }
 
         if specifier.starts_with('#')
-            && let Some(resolved) = self.resolve_subpath_import(specifier, referrer)
+            && let Some(resolved) = Self::resolve_subpath_import(specifier, referrer)
         {
             return self.resolve(&resolved, referrer, kind);
         }

--- a/crates/rari/src/runtime/module_loader/core.rs
+++ b/crates/rari/src/runtime/module_loader/core.rs
@@ -88,6 +88,30 @@ fn file_url_to_path(url: &str) -> Option<PathBuf> {
     })
 }
 
+fn append_extension_only(path: &str) -> (String, &str) {
+    let (base_path, suffix) = if let Some(query_pos) = path.find('?') {
+        (&path[..query_pos], &path[query_pos..])
+    } else if let Some(hash_pos) = path.find('#') {
+        (&path[..hash_pos], &path[hash_pos..])
+    } else {
+        (path, "")
+    };
+
+    let base_with_ext = if base_path.ends_with(".ts")
+        || base_path.ends_with(".js")
+        || base_path.ends_with(".tsx")
+        || base_path.ends_with(".jsx")
+        || base_path.ends_with(".mjs")
+        || base_path.ends_with(".cjs")
+    {
+        base_path.to_string()
+    } else {
+        format!("{base_path}.ts")
+    };
+
+    (base_with_ext, suffix)
+}
+
 #[derive(Debug)]
 pub struct RariModuleLoader {
     storage: ModuleStorage,
@@ -98,15 +122,15 @@ pub struct RariModuleLoader {
 
 impl RariModuleLoader {
     pub fn new() -> Self {
-        Self::with_config(RuntimeConfig::default())
+        Self::with_config(&RuntimeConfig::default())
     }
 
-    pub fn with_config(config: RuntimeConfig) -> Self {
+    pub fn with_config(config: &RuntimeConfig) -> Self {
         Self::with_config_and_registry(config, &CacheHandlerRegistry::default_with_memory())
     }
 
     pub fn with_config_and_registry(
-        config: RuntimeConfig,
+        config: &RuntimeConfig,
         registry: &CacheHandlerRegistry,
     ) -> Self {
         let layer = CacheLayerConfig {
@@ -125,7 +149,7 @@ impl RariModuleLoader {
     }
 
     pub async fn add_module(&self, specifier: &str, original_path: &str, code: String) {
-        self.add_module_internal(specifier, original_path, code.clone());
+        self.add_module_internal(specifier, original_path, &code);
 
         if specifier.contains(RARI_INTERNAL_PATH) {
             if let Err(e) =
@@ -136,7 +160,7 @@ impl RariModuleLoader {
         }
     }
 
-    fn add_module_internal(&self, specifier: &str, original_path: &str, code: String) {
+    fn add_module_internal(&self, specifier: &str, original_path: &str, code: &str) {
         let is_update = self.storage.contains_module_code(specifier);
         let specifier_owned = specifier.to_string();
 
@@ -154,20 +178,20 @@ impl RariModuleLoader {
             let current_version = self.storage.get_version(&version_key).unwrap_or(0) + 1;
             let versioned_specifier = format!("{specifier}{VERSION_QUERY_PARAM}{current_version}");
 
-            self.storage.set_module_code(specifier_owned.clone(), code.clone());
-            self.storage.set_module_code(versioned_specifier.clone(), code.clone());
+            self.storage.set_module_code(specifier_owned.clone(), code.to_string());
+            self.storage.set_module_code(versioned_specifier.clone(), code.to_string());
 
             self.storage.set_module_meta(format!("registered_{specifier_owned}"), true);
             self.storage.set_module_meta(format!("registered_{versioned_specifier}"), true);
             self.storage.set_module_meta(format!("hmr_{specifier_owned}"), true);
             self.storage.set_version(version_key, current_version);
         } else {
-            self.storage.set_module_code(specifier_owned.clone(), code.clone());
+            self.storage.set_module_code(specifier_owned.clone(), code.to_string());
             self.storage.set_module_meta(format!("registered_{specifier_owned}"), true);
             self.storage.set_version(version_key, 1);
         }
 
-        let dependencies = self.register_dependencies(original_path, &code);
+        let dependencies = Self::register_dependencies(original_path, code);
 
         if !dependencies.is_empty() {
             for dep in &dependencies {
@@ -201,7 +225,7 @@ export default {{}};
         }
     }
 
-    fn register_dependencies(&self, _original_path: &str, code: &str) -> DependencyList {
+    fn register_dependencies(_original_path: &str, code: &str) -> DependencyList {
         extract_dependencies(code)
     }
 
@@ -290,7 +314,7 @@ export default {{}};
     pub fn as_extension_transpiler(self: &Rc<Self>) -> Rc<ExtensionTranspilerFn> {
         Rc::new(move |specifier: FastString, code: FastString| {
             match ModuleSpecifier::parse(specifier.as_str()) {
-                Ok(_) => transpile::maybe_transpile_source(specifier, code),
+                Ok(_) => transpile::maybe_transpile_source(&specifier, code),
                 Err(e) => Err(JsErrorBox::from_err(Box::new(Error::new(
                     InvalidInput,
                     format!("Failed to parse module specifier '{specifier}': {e}"),
@@ -299,7 +323,7 @@ export default {{}};
         })
     }
 
-    fn find_package_directory(&self, current_dir: &Path, package_name: &str) -> Option<PathBuf> {
+    fn find_package_directory(current_dir: &Path, package_name: &str) -> Option<PathBuf> {
         let node_modules_path = current_dir.join("node_modules").join(package_name);
         if node_modules_path.exists() {
             return Some(node_modules_path);
@@ -365,9 +389,8 @@ export default {{}};
                 continue;
             }
 
-            let dir_name = match path.file_name().and_then(|n| n.to_str()) {
-                Some(name) => name,
-                None => continue,
+            let Some(dir_name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
             };
 
             if dir_name.starts_with('.')
@@ -504,7 +527,7 @@ export default {{}};
         self.module_resolver.get_package_base(&clean_referrer)
     }
 
-    fn resolve_relative_up(&self, specifier: &str, package_base: &str) -> String {
+    fn resolve_relative_up(specifier: &str, package_base: &str) -> String {
         let remaining = specifier.strip_prefix("../").unwrap_or(specifier);
         let parent_dir = if package_base.contains('/') {
             package_base.rsplit_once('/').map(|(dir, _)| dir).unwrap_or("")
@@ -515,7 +538,7 @@ export default {{}};
         path_to_file_url(&full_path)
     }
 
-    fn resolve_relative_current(&self, specifier: &str, package_base: &str) -> String {
+    fn resolve_relative_current(specifier: &str, package_base: &str) -> String {
         let remaining = specifier.strip_prefix("./").unwrap_or(specifier);
         let full_path = PathBuf::from(package_base).join(remaining);
         path_to_file_url(&full_path)
@@ -528,10 +551,8 @@ export default {{}};
     ) -> Option<ModuleLoadResponse> {
         if let Some(code) = self.storage.get_module_code(specifier_str) {
             let (final_code, module_type) = if needs_typescript_transpilation(specifier_str) {
-                match transpile::maybe_transpile_source(
-                    specifier_str.to_string().into(),
-                    code.into(),
-                ) {
+                let module_name: FastString = specifier_str.to_string().into();
+                match transpile::maybe_transpile_source(&module_name, code.into()) {
                     Ok((transpiled_code, _source_map)) => {
                         (transpiled_code.to_string(), ModuleType::JavaScript)
                     }
@@ -542,10 +563,8 @@ export default {{}};
                     }
                 }
             } else if needs_jsx_transpilation(specifier_str) {
-                match transpile::maybe_transpile_source(
-                    specifier_str.to_string().into(),
-                    code.into(),
-                ) {
+                let module_name: FastString = specifier_str.to_string().into();
+                match transpile::maybe_transpile_source(&module_name, code.into()) {
                     Ok((transpiled_code, _source_map)) => {
                         (transpiled_code.to_string(), ModuleType::JavaScript)
                     }
@@ -570,7 +589,6 @@ export default {{}};
     }
 
     fn handle_dynamic_import_validation(
-        &self,
         specifier_str: &str,
         maybe_referrer: Option<&ModuleSpecifier>,
         is_dyn_import: bool,
@@ -751,7 +769,7 @@ export default {{}};
         None
     }
 
-    fn wrap_cjs_module(&self, content: &str, file_path: &str) -> String {
+    fn wrap_cjs_module(content: &str, file_path: &str) -> String {
         let file_dir = if let Some(last_slash) = file_path.rfind('/') {
             &file_path[..last_slash]
         } else {
@@ -904,9 +922,8 @@ export {{ __exportProxy__ as __cjsExports__, __keys__ }};
         module_specifier: &ModuleSpecifier,
     ) -> Option<ModuleLoadResponse> {
         if specifier_str.starts_with(FILE_PROTOCOL) {
-            let file_path = match module_specifier.to_file_path() {
-                Ok(path) => path,
-                Err(()) => return None,
+            let Ok(file_path) = module_specifier.to_file_path() else {
+                return None;
             };
 
             let file_path_str = file_path.to_string_lossy();
@@ -928,7 +945,7 @@ export {{ __exportProxy__ as __cjsExports__, __keys__ }};
                 let final_code = if file_path_str.contains("node_modules")
                     && self.is_cjs_module(&content, &file_path_str)
                 {
-                    self.wrap_cjs_module(&content, &file_path_for_wrapper)
+                    Self::wrap_cjs_module(&content, &file_path_for_wrapper)
                 } else {
                     content
                 };
@@ -1086,8 +1103,8 @@ export {{ __exportProxy__ as __cjsExports__, __keys__ }};
             return Some(cached_path);
         }
 
-        if let Some(package_dir) = self.find_package_directory(start_dir, package_name) {
-            if let Some(entry_point) = self.resolve_package_entry_point(&package_dir) {
+        if let Some(package_dir) = Self::find_package_directory(start_dir, package_name) {
+            if let Some(entry_point) = Self::resolve_package_entry_point(&package_dir) {
                 self.cache_resolved_package(package_name, &entry_point);
                 return Some(entry_point);
             }
@@ -1106,7 +1123,7 @@ export {{ __exportProxy__ as __cjsExports__, __keys__ }};
         subpath: &str,
         start_dir: &Path,
     ) -> Option<String> {
-        let package_dir = self.find_package_directory(start_dir, package_name)?;
+        let package_dir = Self::find_package_directory(start_dir, package_name)?;
 
         let package_json_path = package_dir.join("package.json");
         if !package_json_path.exists() {
@@ -1114,7 +1131,7 @@ export {{ __exportProxy__ as __cjsExports__, __keys__ }};
         }
 
         let package_json_content = fs::read_to_string(&package_json_path).ok()?;
-        let package_info = self.parse_package_json(&package_json_content).ok()?;
+        let package_info = Self::parse_package_json(&package_json_content).ok()?;
 
         if let Some(exports) = &package_info.exports {
             return self.resolve_subpath_from_exports(exports, subpath, &package_dir);
@@ -1247,7 +1264,7 @@ export {{ __exportProxy__ as __cjsExports__, __keys__ }};
             .cache_package_resolution(package_name.to_string(), resolved_path.to_string());
     }
 
-    fn parse_package_json(&self, content: &str) -> Result<PackageInfo, serde_json::Error> {
+    fn parse_package_json(content: &str) -> Result<PackageInfo, serde_json::Error> {
         let json: serde_json::Value = serde_json::from_str(content)?;
 
         Ok(PackageInfo {
@@ -1257,12 +1274,11 @@ export {{ __exportProxy__ as __cjsExports__, __keys__ }};
     }
 
     fn resolve_entry_from_package_info(
-        &self,
         package_info: &PackageInfo,
         package_dir: &Path,
     ) -> Option<String> {
         if let Some(exports) = &package_info.exports
-            && let Some(resolved) = self.resolve_from_exports(exports, package_dir)
+            && let Some(resolved) = Self::resolve_from_exports(exports, package_dir)
         {
             return Some(resolved);
         }
@@ -1285,11 +1301,7 @@ export {{ __exportProxy__ as __cjsExports__, __keys__ }};
         None
     }
 
-    fn resolve_from_exports(
-        &self,
-        exports: &serde_json::Value,
-        package_dir: &Path,
-    ) -> Option<String> {
+    fn resolve_from_exports(exports: &serde_json::Value, package_dir: &Path) -> Option<String> {
         if let Some(export_path) = exports.as_str() {
             let clean_path = export_path.trim_start_matches("./");
             let full_path = package_dir.join(clean_path);
@@ -1357,12 +1369,12 @@ export {{ __exportProxy__ as __cjsExports__, __keys__ }};
         None
     }
 
-    fn resolve_package_entry_point(&self, package_dir: &Path) -> Option<String> {
+    fn resolve_package_entry_point(package_dir: &Path) -> Option<String> {
         let package_json_path = package_dir.join("package.json");
         if let Ok(content) = fs::read_to_string(&package_json_path)
-            && let Ok(package_info) = self.parse_package_json(&content)
+            && let Ok(package_info) = Self::parse_package_json(&content)
         {
-            return self.resolve_entry_from_package_info(&package_info, package_dir);
+            return Self::resolve_entry_from_package_info(&package_info, package_dir);
         }
 
         let default_files = ["index.mjs", "index.ts", "index.js"];
@@ -1418,11 +1430,8 @@ impl ModuleLoader for RariModuleLoader {
             if after_node_modules.find('/').is_some()
                 && (specifier.starts_with("./") || specifier.starts_with("../"))
             {
-                let referrer_dir = match Path::new(referrer).parent() {
-                    Some(dir) => dir,
-                    None => {
-                        return Err(JsErrorBox::generic("Module not found"));
-                    }
+                let Some(referrer_dir) = Path::new(referrer).parent() else {
+                    return Err(JsErrorBox::generic("Module not found"));
                 };
                 let resolved_path = referrer_dir.join(specifier);
 
@@ -1451,9 +1460,9 @@ impl ModuleLoader for RariModuleLoader {
                 && let Some(package_base) = self.extract_package_base_from_referrer(referrer)
             {
                 let resolved_path = if specifier.starts_with("../") {
-                    self.resolve_relative_up(specifier, &package_base)
+                    Self::resolve_relative_up(specifier, &package_base)
                 } else {
-                    self.resolve_relative_current(specifier, &package_base)
+                    Self::resolve_relative_current(specifier, &package_base)
                 };
 
                 let url = ModuleSpecifier::parse(&resolved_path)
@@ -1490,30 +1499,6 @@ impl ModuleLoader for RariModuleLoader {
                     } else {
                         ""
                     };
-
-                    fn append_extension_only(path: &str) -> (String, &str) {
-                        let (base_path, suffix) = if let Some(query_pos) = path.find('?') {
-                            (&path[..query_pos], &path[query_pos..])
-                        } else if let Some(hash_pos) = path.find('#') {
-                            (&path[..hash_pos], &path[hash_pos..])
-                        } else {
-                            (path, "")
-                        };
-
-                        let base_with_ext = if base_path.ends_with(".ts")
-                            || base_path.ends_with(".js")
-                            || base_path.ends_with(".tsx")
-                            || base_path.ends_with(".jsx")
-                            || base_path.ends_with(".mjs")
-                            || base_path.ends_with(".cjs")
-                        {
-                            base_path.to_string()
-                        } else {
-                            format!("{base_path}.ts")
-                        };
-
-                        (base_with_ext, suffix)
-                    }
 
                     let resolved_path = if specifier.starts_with("../") {
                         let remaining = specifier.strip_prefix("../").unwrap_or(specifier);
@@ -1650,7 +1635,7 @@ impl ModuleLoader for RariModuleLoader {
         }
 
         let maybe_referrer_spec = maybe_referrer.map(|r| r.specifier.clone());
-        if let Some(response) = self.handle_dynamic_import_validation(
+        if let Some(response) = Self::handle_dynamic_import_validation(
             &specifier_str,
             maybe_referrer_spec.as_ref(),
             is_dyn_import,

--- a/crates/rari/src/runtime/ops.rs
+++ b/crates/rari/src/runtime/ops.rs
@@ -107,9 +107,8 @@ pub async fn op_send_chunk_to_rust(
 
     let sender_option = {
         let mut op_state_ref = state.borrow_mut();
-        let stream_op_state = match op_state_ref.try_borrow_mut::<StreamOpState>() {
-            Some(sos) => sos,
-            None => return Err(JsErrorBox::generic("StreamOpState not found.")),
+        let Some(stream_op_state) = op_state_ref.try_borrow_mut::<StreamOpState>() else {
+            return Err(JsErrorBox::generic("StreamOpState not found."));
         };
 
         match &operation {
@@ -264,9 +263,8 @@ pub async fn op_fizz_chunk(
 ) -> Result<(), JsErrorBox> {
     let sender = {
         let mut op_state_ref = state.borrow_mut();
-        let stream_op_state = match op_state_ref.try_borrow_mut::<StreamOpState>() {
-            Some(sos) => sos,
-            None => return Err(JsErrorBox::generic("StreamOpState not found.")),
+        let Some(stream_op_state) = op_state_ref.try_borrow_mut::<StreamOpState>() else {
+            return Err(JsErrorBox::generic("StreamOpState not found."));
         };
         stream_op_state.chunk_sender.clone()
     };
@@ -443,6 +441,7 @@ async fn perform_simple_fetch(
     Ok((status, body, headers_obj))
 }
 
+#[allow(clippy::allow_attributes, clippy::needless_pass_by_value)]
 #[op2]
 #[string]
 pub fn op_get_cookies(state: Rc<RefCell<OpState>>) -> String {
@@ -514,6 +513,7 @@ pub struct SetCookieArgs {
     partitioned: bool,
 }
 
+#[allow(clippy::allow_attributes, clippy::needless_pass_by_value)]
 #[op2]
 #[serde]
 pub fn op_set_cookie(
@@ -573,6 +573,7 @@ pub fn op_set_cookie(
     Ok(())
 }
 
+#[allow(clippy::allow_attributes, clippy::needless_pass_by_value)]
 #[op2(fast)]
 pub fn op_delete_cookie(state: Rc<RefCell<OpState>>, #[string] name: String) {
     let op_state_ref = state.borrow();
@@ -627,20 +628,22 @@ pub fn op_delete_cookie(state: Rc<RefCell<OpState>>, #[string] name: String) {
     }
 }
 
+#[allow(clippy::allow_attributes, clippy::needless_pass_by_value)]
 #[op2]
 #[serde]
 pub fn op_cache_get(
     state: Rc<RefCell<OpState>>,
-    #[string] cache_key: String,
+    #[string] cache_key: &str,
 ) -> Option<serde_json::Value> {
     let op_state_ref = state.borrow();
     if let Some(ctx) = op_state_ref.try_borrow::<Arc<RequestContext>>() {
-        ctx.function_cache.get(&cache_key).map(|entry| entry.value().clone())
+        ctx.function_cache.get(cache_key).map(|entry| entry.value().clone())
     } else {
         None
     }
 }
 
+#[allow(clippy::allow_attributes, clippy::needless_pass_by_value)]
 #[op2]
 pub fn op_cache_set(
     state: Rc<RefCell<OpState>>,

--- a/crates/rari/src/runtime/transpile.rs
+++ b/crates/rari/src/runtime/transpile.rs
@@ -39,7 +39,7 @@ fn maybe_substitute_version_placeholders(name: &str, source: ModuleCodeString) -
 }
 
 pub fn maybe_transpile_source(
-    name: ModuleName,
+    name: &ModuleName,
     source: ModuleCodeString,
 ) -> Result<(ModuleCodeString, Option<SourceMapData>), JsErrorBox> {
     let name_string = name.to_string();
@@ -64,7 +64,7 @@ pub fn maybe_transpile_source(
     }
 
     let parsed = deno_ast::parse_module(ParseParams {
-        specifier: Url::parse(&name).unwrap_or_else(|_| {
+        specifier: Url::parse(name).unwrap_or_else(|_| {
             #[expect(clippy::expect_used, reason = "Fallback URL construction is infallible")]
             Url::parse(&format!("file:///__rari_script__/{name}"))
                 .expect("failed to create fallback URL")

--- a/crates/rari/src/server/cache/handler.rs
+++ b/crates/rari/src/server/cache/handler.rs
@@ -111,7 +111,7 @@ pub struct MemoryCacheHandler {
 }
 
 impl MemoryCacheHandler {
-    pub fn with_config(config: MemoryConfig) -> Self {
+    pub fn with_config(config: &MemoryConfig) -> Self {
         #[expect(clippy::expect_used, reason = "Value is clamped to >= 1, guaranteed non-zero")]
         let max_entries = NonZeroUsize::new(config.max_entries.max(1)).expect("clamped to >= 1");
         tracing::debug!(
@@ -193,7 +193,7 @@ impl MemoryCacheHandler {
 
 impl Default for MemoryCacheHandler {
     fn default() -> Self {
-        Self::with_config(MemoryConfig::default())
+        Self::with_config(&MemoryConfig::default())
     }
 }
 
@@ -498,7 +498,7 @@ mod tests {
     #[tokio::test]
     async fn test_memory_lru_eviction() {
         let handler =
-            MemoryCacheHandler::with_config(MemoryConfig { max_entries: 2, default_ttl: 60 });
+            MemoryCacheHandler::with_config(&MemoryConfig { max_entries: 2, default_ttl: 60 });
         handler.set("a", b"1".to_vec(), 60).await.unwrap();
         handler.set("b", b"2".to_vec(), 60).await.unwrap();
         let _ = handler.get("a").await.unwrap();

--- a/crates/rari/src/server/cache/response.rs
+++ b/crates/rari/src/server/cache/response.rs
@@ -12,10 +12,13 @@ use bytes::Bytes;
 use dashmap::DashMap;
 use parking_lot::Mutex;
 
-use crate::server::{
-    cache::handler::{CacheHandler, MemoryCacheHandler, MemoryConfig},
-    compression::CompressionEncoding,
-    config::CacheLayerConfig,
+use crate::{
+    server::{
+        cache::handler::{CacheHandler, MemoryCacheHandler, MemoryConfig},
+        compression::CompressionEncoding,
+        config::CacheLayerConfig,
+    },
+    utils::float,
 };
 
 #[derive(Clone)]
@@ -228,7 +231,7 @@ impl ResponseCache {
     }
 
     pub fn new(config: CacheConfig) -> Self {
-        let handler = MemoryCacheHandler::with_config(MemoryConfig {
+        let handler = MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: config.max_entries,
             default_ttl: config.default_ttl,
         });
@@ -414,9 +417,11 @@ impl ResponseCache {
 
     #[cfg(test)]
     pub async fn clear_percentage(&self, percentage: f64) {
+        use crate::utils::cast;
+
         let percentage = percentage.clamp(0.0, 1.0);
         let current_size = self.entry_count.load(Ordering::Relaxed);
-        let entries_to_remove = (current_size as f64 * percentage).ceil() as usize;
+        let entries_to_remove = cast::usize_fraction_ceil(current_size, percentage);
 
         let keys: Vec<String> = self
             .handler
@@ -437,7 +442,7 @@ impl ResponseCache {
     #[cfg(test)]
     pub fn should_clear_on_memory_pressure(&self) -> bool {
         let current_size = self.entry_count.load(Ordering::Relaxed);
-        let threshold = (self.config.max_entries as f64 * 0.9) as usize;
+        let threshold = self.config.max_entries * 9 / 10;
         current_size >= threshold
     }
 
@@ -458,19 +463,19 @@ impl ResponseCache {
     fn record_hit(&self) {
         let mut metrics = self.metrics.lock();
         metrics.cache_hits += 1;
-        self.update_hit_rate(&mut metrics);
+        Self::update_hit_rate(&mut metrics);
     }
 
     fn record_miss(&self) {
         let mut metrics = self.metrics.lock();
         metrics.cache_misses += 1;
-        self.update_hit_rate(&mut metrics);
+        Self::update_hit_rate(&mut metrics);
     }
 
-    fn update_hit_rate(&self, metrics: &mut CacheMetrics) {
+    fn update_hit_rate(metrics: &mut CacheMetrics) {
         let total = metrics.cache_hits + metrics.cache_misses;
         if total > 0 {
-            metrics.hit_rate = metrics.cache_hits as f64 / total as f64;
+            metrics.hit_rate = float::u64_ratio(metrics.cache_hits, total);
         }
     }
 
@@ -494,12 +499,15 @@ mod instant_serde {
 
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+    use crate::utils::cast;
+
     pub fn serialize<S: Serializer>(instant: &Instant, s: S) -> Result<S::Ok, S::Error> {
         let now_mono = Instant::now();
         let now_wall = SystemTime::now();
         let elapsed = now_mono.saturating_duration_since(*instant);
         let stored = now_wall.checked_sub(elapsed).unwrap_or(now_wall);
-        let stored_ms = stored.duration_since(UNIX_EPOCH).unwrap_or_default().as_millis() as u64;
+        let stored_ms =
+            cast::duration_millis_u64(stored.duration_since(UNIX_EPOCH).unwrap_or_default());
         stored_ms.serialize(s)
     }
 
@@ -910,7 +918,7 @@ mod tests {
         use crate::server::og::OgImageCache;
 
         let shared: Arc<dyn CacheHandler> =
-            Arc::new(MemoryCacheHandler::with_config(MemoryConfig {
+            Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
                 max_entries: 32,
                 default_ttl: 60,
             }));

--- a/crates/rari/src/server/cache/warmup.rs
+++ b/crates/rari/src/server/cache/warmup.rs
@@ -36,12 +36,9 @@ async fn warmup_render_lock() -> &'static Mutex<()> {
 }
 
 pub async fn warm_cache(state: &ServerState) {
-    let app_router = match &state.app_router {
-        Some(router) => router,
-        None => {
-            info!("[rari] Cache warmup: No app router available, skipping");
-            return;
-        }
+    let Some(app_router) = &state.app_router else {
+        info!("[rari] Cache warmup: No app router available, skipping");
+        return;
     };
 
     let paths = app_router.warmup_paths();

--- a/crates/rari/src/server/core/utils/path_validation.rs
+++ b/crates/rari/src/server/core/utils/path_validation.rs
@@ -38,18 +38,12 @@ pub fn validate_safe_path(base: &Path, requested: &str) -> Result<PathBuf, RariE
 
     let path = base.join(requested_clean);
 
-    let canonical_path = match path.canonicalize() {
-        Ok(p) => p,
-        Err(_) => {
-            return Err(RariError::not_found("File not found"));
-        }
+    let Ok(canonical_path) = path.canonicalize() else {
+        return Err(RariError::not_found("File not found"));
     };
 
-    let canonical_base = match base.canonicalize() {
-        Ok(b) => b,
-        Err(_) => {
-            return Err(RariError::internal("Invalid base directory configuration"));
-        }
+    let Ok(canonical_base) = base.canonicalize() else {
+        return Err(RariError::internal("Invalid base directory configuration"));
     };
 
     if !canonical_path.starts_with(&canonical_base) {
@@ -113,6 +107,8 @@ pub fn validate_component_path(file_path: &str) -> Result<(), RariError> {
 #[cfg(test)]
 #[allow(clippy::allow_attributes, clippy::expect_used, clippy::unwrap_used)]
 mod tests {
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
     use std::{env, fs};
 
     use super::*;
@@ -208,7 +204,6 @@ mod tests {
         let outside_file = outside_dir.join("secret.txt");
         fs::write(&outside_file, "secret").unwrap();
 
-        use std::os::unix::fs::symlink;
         let link_path = base.join("escape");
         let _ = fs::remove_file(&link_path);
         symlink(&outside_dir, &link_path).expect("Failed to create symlink for security test");

--- a/crates/rari/src/server/handlers/actions.rs
+++ b/crates/rari/src/server/handlers/actions.rs
@@ -13,11 +13,14 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::error;
 
-use crate::server::{
-    ServerState,
-    config::RedirectConfig,
-    core::utils::http::is_origin_allowed,
-    middleware::request_context::{PendingCookie, PendingCookieKey, RequestContext},
+use crate::{
+    server::{
+        ServerState,
+        config::RedirectConfig,
+        core::utils::http::is_origin_allowed,
+        middleware::request_context::{PendingCookie, PendingCookieKey, RequestContext},
+    },
+    utils::cast,
 };
 
 const MAX_BOUND_ARGS: usize = 1000;
@@ -725,8 +728,11 @@ fn validate_and_sanitize_value(
             if let Some(f) = n.as_f64() {
                 let abs_f = f.abs();
                 if abs_f > 1e100 {
-                    let estimated_digits =
-                        if abs_f == 0.0 { 1 } else { (abs_f.log10().floor() as usize) + 1 };
+                    let estimated_digits = if abs_f == 0.0 {
+                        1
+                    } else {
+                        cast::f64_log10_floor_usize(abs_f.log10()) + 1
+                    };
 
                     if estimated_digits > MAX_BIGINT_DIGITS {
                         return Err(RariError::bad_request(format!(

--- a/crates/rari/src/server/handlers/actions.rs
+++ b/crates/rari/src/server/handlers/actions.rs
@@ -728,11 +728,8 @@ fn validate_and_sanitize_value(
             if let Some(f) = n.as_f64() {
                 let abs_f = f.abs();
                 if abs_f > 1e100 {
-                    let estimated_digits = if abs_f == 0.0 {
-                        1
-                    } else {
-                        cast::f64_log10_floor_usize(abs_f.log10()) + 1
-                    };
+                    let estimated_digits =
+                        if abs_f == 0.0 { 1 } else { cast::f64_floor_usize(abs_f.log10()) + 1 };
 
                     if estimated_digits > MAX_BIGINT_DIGITS {
                         return Err(RariError::bad_request(format!(

--- a/crates/rari/src/server/handlers/api.rs
+++ b/crates/rari/src/server/handlers/api.rs
@@ -79,15 +79,12 @@ pub async fn handle_api_route(
     let origin = req.headers().get("origin").and_then(|v| v.to_str().ok()).map(ToString::to_string);
     let cors_config = state.config.cors_config();
 
-    let api_handler = match &state.api_route_handler {
-        Some(handler) => handler,
-        None => {
-            return Ok(create_generic_error_response(
-                StatusCode::NOT_FOUND,
-                "API routes not configured",
-                is_development,
-            ));
-        }
+    let Some(api_handler) = &state.api_route_handler else {
+        return Ok(create_generic_error_response(
+            StatusCode::NOT_FOUND,
+            "API routes not configured",
+            is_development,
+        ));
     };
 
     let route_match = match api_handler.match_route(&path, &method) {

--- a/crates/rari/src/server/handlers/app.rs
+++ b/crates/rari/src/server/handlers/app.rs
@@ -41,7 +41,7 @@ use crate::{
     server::{
         ServerState,
         cache::response,
-        compression::{CompressionEncoding, compress_stream},
+        compression::{CompressionEncoding, compress_body, compress_stream},
         config::Config,
         core::{
             types::request::{RenderMode, RequestTypeDetector},
@@ -153,6 +153,35 @@ pub(crate) fn wrap_html_with_metadata(
     }
 }
 
+fn convert_route_path_to_dist_path(path: &str) -> String {
+    let (base, ext) =
+        if let Some(pos) = path.rfind('.') { (&path[..pos], &path[pos..]) } else { (path, "") };
+
+    let converted_base = base
+        .chars()
+        .map(|c| if c.is_alphanumeric() || c == '/' || c == '-' || c == '_' { c } else { '_' })
+        .collect::<String>();
+
+    format!("{converted_base}{ext}")
+}
+
+fn component_dist_path(base_path: &Path, file_path: &str, component_id: Option<&str>) -> PathBuf {
+    if let Some(component_id) = component_id {
+        return base_path.join(format!("{component_id}.js"));
+    }
+
+    let js_filename = file_path.cow_replace(".tsx", ".js").cow_replace(".ts", ".js").into_owned();
+    let dist_filename = convert_route_path_to_dist_path(&js_filename);
+    base_path.join("app").join(&dist_filename)
+}
+
+fn should_use_streaming(route_match: &AppRouteMatch, config: &Config) -> bool {
+    if route_match.not_found.is_some() {
+        return false;
+    }
+    config.loading.enabled && route_match.loading.is_some()
+}
+
 pub(crate) async fn collect_page_metadata(
     state: &ServerState,
     route_match: &AppRouteMatch,
@@ -161,49 +190,10 @@ pub(crate) async fn collect_page_metadata(
     let dist_server_path =
         env::current_dir().ok().map(|p| p.join("dist/server")).and_then(|p| p.canonicalize().ok());
 
-    let base_path = match dist_server_path {
-        Some(path) => path,
-        None => {
-            error!("Could not determine dist/server path for metadata collection");
-            return None;
-        }
+    let Some(base_path) = dist_server_path else {
+        error!("Could not determine dist/server path for metadata collection");
+        return None;
     };
-
-    fn component_dist_path(
-        base_path: &Path,
-        file_path: &str,
-        component_id: Option<&str>,
-    ) -> PathBuf {
-        if let Some(component_id) = component_id {
-            return base_path.join(format!("{component_id}.js"));
-        }
-
-        fn convert_route_path_to_dist_path(path: &str) -> String {
-            let (base, ext) = if let Some(pos) = path.rfind('.') {
-                (&path[..pos], &path[pos..])
-            } else {
-                (path, "")
-            };
-
-            let converted_base =
-                base.chars()
-                    .map(|c| {
-                        if c.is_alphanumeric() || c == '/' || c == '-' || c == '_' {
-                            c
-                        } else {
-                            '_'
-                        }
-                    })
-                    .collect::<String>();
-
-            format!("{converted_base}{ext}")
-        }
-
-        let js_filename =
-            file_path.cow_replace(".tsx", ".js").cow_replace(".ts", ".js").into_owned();
-        let dist_filename = convert_route_path_to_dist_path(&js_filename);
-        base_path.join("app").join(&dist_filename)
-    }
 
     let layout_paths: Vec<String> = route_match
         .layouts
@@ -407,17 +397,14 @@ pub async fn render_rsc_navigation_streaming(
     };
 
     match render_result {
-        RenderResult::Streaming(rsc_stream) => {
-            render_rsc_streaming_response(
-                state,
-                route_match,
-                context,
-                rsc_stream,
-                is_not_found,
-                accept_encoding,
-            )
-            .await
-        }
+        RenderResult::Streaming(rsc_stream) => Ok(render_rsc_streaming_response(
+            &state,
+            route_match,
+            &context,
+            rsc_stream,
+            is_not_found,
+            accept_encoding,
+        )),
         RenderResult::FizzHtmlStream { .. } => {
             error!("FizzHtmlStream not supported in RSC-only mode");
             let status_code = if is_not_found { StatusCode::NOT_FOUND } else { StatusCode::OK };
@@ -486,14 +473,14 @@ pub async fn render_rsc_navigation_streaming(
     }
 }
 
-async fn render_rsc_streaming_response(
-    state: Arc<ServerState>,
+fn render_rsc_streaming_response(
+    state: &Arc<ServerState>,
     _route_match: AppRouteMatch,
-    context: LayoutRenderContext,
+    context: &LayoutRenderContext,
     mut rsc_stream: RscStream,
     is_not_found: bool,
     accept_encoding: Option<&str>,
-) -> Result<Response, StatusCode> {
+) -> http::Response<Body> {
     let should_continue = Arc::new(AtomicBool::new(true));
     let should_continue_clone = should_continue;
 
@@ -541,7 +528,7 @@ async fn render_rsc_streaming_response(
 
     let body = Body::from_stream(compressed_stream);
     #[expect(clippy::expect_used, reason = "Response::builder() with valid components never fails")]
-    Ok(response_builder.body(body).expect("Valid RSC streaming response"))
+    response_builder.body(body).expect("Valid RSC streaming response")
 }
 
 pub async fn render_synchronous(
@@ -592,19 +579,16 @@ pub async fn render_synchronous(
                     .body(Body::from(final_html))
                     .expect("Valid HTML response"))
             }
-            RenderResult::FizzHtmlStream { shell, closing, chunks } => {
-                render_fizz_html_stream(
-                    state,
-                    route_match,
-                    context,
-                    shell,
-                    closing,
-                    chunks,
-                    is_not_found,
-                    accept_encoding,
-                )
-                .await
-            }
+            RenderResult::FizzHtmlStream { shell, closing, chunks } => Ok(render_fizz_html_stream(
+                &state,
+                route_match,
+                &context,
+                shell,
+                closing,
+                chunks,
+                is_not_found,
+                accept_encoding,
+            )),
             RenderResult::Streaming(stream) => {
                 render_streaming_response(
                     state,
@@ -639,16 +623,16 @@ pub async fn render_synchronous(
 }
 
 #[expect(clippy::too_many_arguments)]
-async fn render_fizz_html_stream(
-    state: Arc<ServerState>,
+fn render_fizz_html_stream(
+    state: &Arc<ServerState>,
     _route_match: AppRouteMatch,
-    context: LayoutRenderContext,
+    context: &LayoutRenderContext,
     shell: bytes::Bytes,
     closing: bytes::Bytes,
     mut chunks: Receiver<Result<Vec<u8>, String>>,
     is_not_found: bool,
     accept_encoding: Option<&str>,
-) -> Result<Response, StatusCode> {
+) -> http::Response<Body> {
     use crate::server::compression::compress_stream;
 
     let stall_timeout = Duration::from_millis(fizz_stream_stall_timeout_ms());
@@ -704,7 +688,7 @@ async fn render_fizz_html_stream(
 
     let body = Body::from_stream(compressed_stream);
     #[expect(clippy::expect_used, reason = "Response::builder() with valid components never fails")]
-    Ok(response_builder.body(body).expect("Valid Fizz streaming response"))
+    response_builder.body(body).expect("Valid Fizz streaming response")
 }
 
 fn fizz_stream_stall_timeout_ms() -> u64 {
@@ -876,17 +860,16 @@ pub async fn render_streaming_with_layout(
     let rsc_stream = match render_result {
         RenderResult::Streaming(stream) => stream,
         RenderResult::FizzHtmlStream { shell, closing, chunks } => {
-            return render_fizz_html_stream(
-                state,
+            return Ok(render_fizz_html_stream(
+                &state,
                 route_match,
-                context,
+                &context,
                 shell,
                 closing,
                 chunks,
                 is_not_found,
                 accept_encoding,
-            )
-            .await;
+            ));
         }
         RenderResult::Static(html) => {
             use crate::server::compression::compress_body;
@@ -1073,13 +1056,6 @@ pub async fn handle_app_route(
 ) -> Result<Response, StatusCode> {
     let path = uri.path();
 
-    fn should_use_streaming(route_match: &AppRouteMatch, config: &Config) -> bool {
-        if route_match.not_found.is_some() {
-            return false;
-        }
-        config.loading.enabled && route_match.loading.is_some()
-    }
-
     if path.len() > 1 {
         let path_without_leading_slash = &path[1..];
 
@@ -1122,15 +1098,12 @@ pub async fn handle_app_route(
         }
     }
 
-    let app_router = match &state.app_router {
-        Some(router) => router,
-        None => {
-            tracing::error!(
-                "App router not initialized - routes.json may be missing or invalid. Path: {}",
-                path
-            );
-            return Err(StatusCode::NOT_FOUND);
-        }
+    let Some(app_router) = &state.app_router else {
+        tracing::error!(
+            "App router not initialized - routes.json may be missing or invalid. Path: {}",
+            path
+        );
+        return Err(StatusCode::NOT_FOUND);
     };
 
     let mut route_match = match app_router.match_route(path) {
@@ -1391,7 +1364,6 @@ pub async fn handle_app_route(
 
                 let merged_vary = merge_vary_with_accept(cached.headers.get("vary"));
 
-                use crate::server::compression::compress_body;
                 let encoding = CompressionEncoding::from_accept_encoding(accept_encoding);
 
                 let (body_bytes, actual_encoding) =
@@ -1755,8 +1727,6 @@ pub async fn handle_app_route(
 
             if cache_policy.enabled && state.response_cache.config.enabled {
                 let body_bytes = bytes::Bytes::from(final_html.clone());
-
-                use crate::server::compression::{CompressionEncoding, compress_body};
 
                 let (compressed_gzip, compressed_zstd, compressed_br) = {
                     let (gz, gz_enc) =

--- a/crates/rari/src/server/handlers/app.rs
+++ b/crates/rari/src/server/handlers/app.rs
@@ -1,7 +1,7 @@
 use std::{
     env,
     io::{Cursor, Error},
-    path::{Path, PathBuf},
+    path::PathBuf,
     string::String,
     sync::{
         Arc,
@@ -33,7 +33,8 @@ use crate::{
     rendering::{
         layout::{
             LayoutRenderContext, LayoutRenderer, OpenGraphImage, OpenGraphImageDescriptor,
-            OpenGraphMetadata, PageMetadata, RenderResult, TwitterMetadata, create_layout_context,
+            OpenGraphMetadata, PageMetadata, RenderResult, TwitterMetadata, component_dist_path,
+            create_layout_context,
         },
         r#static::RscToHtmlConverter,
         streaming::stream::RscStream,
@@ -151,28 +152,6 @@ pub(crate) fn wrap_html_with_metadata(
     } else {
         html_content
     }
-}
-
-fn convert_route_path_to_dist_path(path: &str) -> String {
-    let (base, ext) =
-        if let Some(pos) = path.rfind('.') { (&path[..pos], &path[pos..]) } else { (path, "") };
-
-    let converted_base = base
-        .chars()
-        .map(|c| if c.is_alphanumeric() || c == '/' || c == '-' || c == '_' { c } else { '_' })
-        .collect::<String>();
-
-    format!("{converted_base}{ext}")
-}
-
-fn component_dist_path(base_path: &Path, file_path: &str, component_id: Option<&str>) -> PathBuf {
-    if let Some(component_id) = component_id {
-        return base_path.join(format!("{component_id}.js"));
-    }
-
-    let js_filename = file_path.cow_replace(".tsx", ".js").cow_replace(".ts", ".js").into_owned();
-    let dist_filename = convert_route_path_to_dist_path(&js_filename);
-    base_path.join("app").join(&dist_filename)
 }
 
 fn should_use_streaming(route_match: &AppRouteMatch, config: &Config) -> bool {

--- a/crates/rari/src/server/handlers/hmr.rs
+++ b/crates/rari/src/server/handlers/hmr.rs
@@ -447,7 +447,7 @@ async fn handle_reload(
     }
 }
 
-fn handle_invalidate_api_route(state: &ServerState, file_path: &String) -> axum::Json<Value> {
+fn handle_invalidate_api_route(state: &ServerState, file_path: &str) -> axum::Json<Value> {
     let Some(api_handler) = &state.api_route_handler else {
         return Json(serde_json::json!({
             "success": false,

--- a/crates/rari/src/server/handlers/hmr.rs
+++ b/crates/rari/src/server/handlers/hmr.rs
@@ -80,7 +80,7 @@ pub async fn handle_hmr_action(
             handle_reload(state, component_id, file_path).await
         }
         HmrRequest::InvalidateApiRoute { file_path } => {
-            handle_invalidate_api_route(state, file_path).await
+            Ok(handle_invalidate_api_route(&state, &file_path))
         }
         HmrRequest::ReloadComponent { component_id, bundle_path } => {
             handle_reload_component(state, component_id, bundle_path).await
@@ -366,16 +366,13 @@ async fn handle_reload(
     component_id: String,
     file_path: String,
 ) -> Result<Json<Value>, StatusCode> {
-    let config = match Config::get() {
-        Some(config) => config,
-        None => {
-            error!("Failed to get global configuration for HMR reload");
-            return Ok(Json(serde_json::json!({
-                "success": false,
-                "componentId": component_id,
-                "error": "Configuration not available"
-            })));
-        }
+    let Some(config) = Config::get() else {
+        error!("Failed to get global configuration for HMR reload");
+        return Ok(Json(serde_json::json!({
+            "success": false,
+            "componentId": component_id,
+            "error": "Configuration not available"
+        })));
     };
 
     if file_path.contains("://") {
@@ -450,28 +447,22 @@ async fn handle_reload(
     }
 }
 
-async fn handle_invalidate_api_route(
-    state: ServerState,
-    file_path: String,
-) -> Result<Json<Value>, StatusCode> {
-    let api_handler = match &state.api_route_handler {
-        Some(handler) => handler,
-        None => {
-            return Ok(Json(serde_json::json!({
-                "success": false,
-                "filePath": file_path,
-                "error": "API route handler not available"
-            })));
-        }
+fn handle_invalidate_api_route(state: &ServerState, file_path: &String) -> axum::Json<Value> {
+    let Some(api_handler) = &state.api_route_handler else {
+        return Json(serde_json::json!({
+            "success": false,
+            "filePath": file_path,
+            "error": "API route handler not available"
+        }));
     };
 
-    api_handler.invalidate_handler(&file_path);
+    api_handler.invalidate_handler(file_path);
 
-    Ok(Json(serde_json::json!({
+    Json(serde_json::json!({
         "success": true,
         "filePath": file_path,
         "message": "API route handler cache invalidated"
-    })))
+    }))
 }
 
 async fn handle_reload_component(

--- a/crates/rari/src/server/handlers/route_info.rs
+++ b/crates/rari/src/server/handlers/route_info.rs
@@ -43,17 +43,14 @@ pub async fn get_route_info(
         ));
     }
 
-    let app_router = match &state.app_router {
-        Some(router) => router,
-        None => {
-            return Err((
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(RouteInfoError {
-                    error: "App router not available".to_string(),
-                    code: "SERVER_ERROR".to_string(),
-                }),
-            ));
-        }
+    let Some(app_router) = &state.app_router else {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(RouteInfoError {
+                error: "App router not available".to_string(),
+                code: "SERVER_ERROR".to_string(),
+            }),
+        ));
     };
 
     match app_router.match_route(&path) {

--- a/crates/rari/src/server/handlers/rsc.rs
+++ b/crates/rari/src/server/handlers/rsc.rs
@@ -30,7 +30,7 @@ pub async fn register_component(
     }
 
     let result = {
-        let mut renderer = state.renderer.lock().await;
+        let renderer = state.renderer.lock().await;
         renderer.register_component(&request.component_id, &request.component_code).await
     };
 

--- a/crates/rari/src/server/handlers/static.rs
+++ b/crates/rari/src/server/handlers/static.rs
@@ -15,12 +15,9 @@ use crate::server::{
 };
 
 pub async fn root_handler(State(_state): State<ServerState>) -> Result<Response, StatusCode> {
-    let config = match Config::get() {
-        Some(config) => config,
-        None => {
-            error!("Failed to get global configuration for root_handler");
-            return Err(StatusCode::INTERNAL_SERVER_ERROR);
-        }
+    let Some(config) = Config::get() else {
+        error!("Failed to get global configuration for root_handler");
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
     };
 
     let index_path = config.public_dir().join("index.html");
@@ -61,19 +58,13 @@ pub async fn static_or_spa_handler(
         }
     }
 
-    let config = match Config::get() {
-        Some(config) => config,
-        None => {
-            error!("Failed to get global configuration for static_or_spa_handler");
-            return Err(StatusCode::INTERNAL_SERVER_ERROR);
-        }
+    let Some(config) = Config::get() else {
+        error!("Failed to get global configuration for static_or_spa_handler");
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
     };
 
-    let file_path = match validate_safe_path(config.public_dir(), &path) {
-        Ok(path) => path,
-        Err(_) => {
-            return Err(StatusCode::NOT_FOUND);
-        }
+    let Ok(file_path) = validate_safe_path(config.public_dir(), &path) else {
+        return Err(StatusCode::NOT_FOUND);
     };
 
     if file_path.is_file() {
@@ -153,11 +144,8 @@ pub async fn serve_static_asset(
 
     let assets_dir = state.config.public_dir().join("assets");
 
-    let file_path = match validate_safe_path(&assets_dir, &asset_path) {
-        Ok(path) => path,
-        Err(_) => {
-            return Err(StatusCode::NOT_FOUND);
-        }
+    let Ok(file_path) = validate_safe_path(&assets_dir, &asset_path) else {
+        return Err(StatusCode::NOT_FOUND);
     };
 
     if !file_path.is_file() {

--- a/crates/rari/src/server/image/cache.rs
+++ b/crates/rari/src/server/image/cache.rs
@@ -41,7 +41,7 @@ impl ImageCache {
         #[expect(clippy::expect_used, reason = "Value is clamped to >= 20, guaranteed non-zero")]
         let capacity = NonZeroUsize::new((max_memory_size / 1024 / 50).max(20))
             .expect("capacity is always at least 20");
-        let handler = MemoryCacheHandler::with_config(MemoryConfig {
+        let handler = MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: capacity.get(),
             default_ttl: 0,
         });
@@ -188,7 +188,7 @@ mod tests {
     }
 
     fn fresh_cache(test_name: &str, max_memory_size: usize) -> ImageCache {
-        let handler = Arc::new(MemoryCacheHandler::with_config(MemoryConfig {
+        let handler = Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: 32,
             default_ttl: 0,
         }));
@@ -225,7 +225,7 @@ mod tests {
         let project_path = test_project_path("disk-persistence");
         let _ = fs::remove_dir_all(&project_path);
 
-        let handler_a = Arc::new(MemoryCacheHandler::with_config(MemoryConfig {
+        let handler_a = Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: 32,
             default_ttl: 0,
         }));
@@ -235,7 +235,7 @@ mod tests {
         assert!(cache_a.get("persistent").await.is_some());
         drop(cache_a);
 
-        let handler_b = Arc::new(MemoryCacheHandler::with_config(MemoryConfig {
+        let handler_b = Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: 32,
             default_ttl: 0,
         }));

--- a/crates/rari/src/server/image/optimizer.rs
+++ b/crates/rari/src/server/image/optimizer.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::unnecessary_debug_formatting)]
-
 use std::{
     path::{Path, PathBuf},
     sync::{
@@ -161,6 +159,7 @@ impl ImageOptimizer {
 
         while let Some(current_dir) = dirs_to_scan.pop() {
             let mut entries = fs::read_dir(&current_dir).await.map_err(|e| {
+                #[expect(clippy::unnecessary_debug_formatting)]
                 ImageError::ProcessingError(format!(
                     "Failed to read directory {current_dir:?}: {e}"
                 ))
@@ -172,6 +171,7 @@ impl ImageOptimizer {
                 let path = entry.path();
 
                 let file_type = entry.file_type().await.map_err(|e| {
+                    #[expect(clippy::unnecessary_debug_formatting)]
                     ImageError::ProcessingError(format!(
                         "Failed to read file type for {path:?}: {e}"
                     ))

--- a/crates/rari/src/server/image/optimizer.rs
+++ b/crates/rari/src/server/image/optimizer.rs
@@ -22,6 +22,7 @@ use super::{
     config::{ImageConfig, LocalPattern, RemotePattern},
     types::{ImageFormat, OptimizeParams, OptimizedImage},
 };
+use crate::utils::{cast, float};
 
 const MAX_SOURCE_IMAGE_SIZE: usize = 10 * 1024 * 1024;
 const MAX_OUTPUT_WIDTH: u32 = 3840;
@@ -321,7 +322,7 @@ impl ImageOptimizer {
                 q: *q,
                 f: Some(format.extension().to_string()),
             };
-            let cache_key = self.generate_cache_key(&params);
+            let cache_key = Self::generate_cache_key(&params);
             if self.cache.get(&cache_key).await.is_none() {
                 needs_optimization += 1;
             }
@@ -367,7 +368,7 @@ impl ImageOptimizer {
                         f: Some(format.extension().to_string()),
                     };
 
-                    let cache_key = self.generate_cache_key(&params);
+                    let cache_key = Self::generate_cache_key(&params);
 
                     if self.cache.get(&cache_key).await.is_some() {
                         return Ok::<_, ImageError>(false);
@@ -471,7 +472,7 @@ impl ImageOptimizer {
                 q: *q,
                 f: Some(format.extension().to_string()),
             };
-            let cache_key = self.generate_cache_key(&params);
+            let cache_key = Self::generate_cache_key(&params);
             if self.cache.get(&cache_key).await.is_none() {
                 needs_optimization += 1;
             }
@@ -506,7 +507,7 @@ impl ImageOptimizer {
                         f: Some(format.extension().to_string()),
                     };
 
-                    let cache_key = self.generate_cache_key(&params);
+                    let cache_key = Self::generate_cache_key(&params);
 
                     if self.cache.get(&cache_key).await.is_some() {
                         return Ok::<_, ImageError>(false);
@@ -555,7 +556,7 @@ impl ImageOptimizer {
         }
 
         for pattern in &self.config.local_patterns {
-            if self.matches_local_pattern(path, pattern) {
+            if Self::matches_local_pattern(path, pattern) {
                 return true;
             }
         }
@@ -584,7 +585,7 @@ impl ImageOptimizer {
             )));
         }
 
-        let cache_key = self.generate_cache_key(&params);
+        let cache_key = Self::generate_cache_key(&params);
 
         if let Some(cached) = self.cache.get(&cache_key).await {
             return Ok((
@@ -621,7 +622,7 @@ impl ImageOptimizer {
         let params_clone = params.clone();
         let config_clone = self.config.clone();
         let optimized = task::spawn_blocking(move || {
-            Self::process_image_blocking(source, &params_clone, &config_clone)
+            Self::process_image_blocking(&source, &params_clone, &config_clone)
         })
         .await
         .map_err(|e| ImageError::ProcessingError(format!("Image processing task failed: {e}")))??;
@@ -641,7 +642,7 @@ impl ImageOptimizer {
         Ok((optimized, false))
     }
 
-    fn generate_cache_key(&self, params: &OptimizeParams) -> String {
+    fn generate_cache_key(params: &OptimizeParams) -> String {
         use sha2::{Digest, Sha256};
 
         let mut hasher = Sha256::new();
@@ -665,7 +666,7 @@ impl ImageOptimizer {
 
             let mut allowed = false;
             for pattern in &self.config.local_patterns {
-                if self.matches_local_pattern(url_str, pattern) {
+                if Self::matches_local_pattern(url_str, pattern) {
                     allowed = true;
                     break;
                 }
@@ -681,8 +682,8 @@ impl ImageOptimizer {
         self.validate_remote_url(url_str)
     }
 
-    fn matches_local_pattern(&self, path: &str, pattern: &LocalPattern) -> bool {
-        if !self.pathname_matches(path, &pattern.pathname) {
+    fn matches_local_pattern(path: &str, pattern: &LocalPattern) -> bool {
+        if !Self::pathname_matches(path, &pattern.pathname) {
             return false;
         }
 
@@ -700,19 +701,19 @@ impl ImageOptimizer {
         true
     }
 
-    fn pathname_matches(&self, path: &str, pattern: &str) -> bool {
+    fn pathname_matches(path: &str, pattern: &str) -> bool {
         let path_without_query = if let Some(idx) = path.find('?') { &path[..idx] } else { path };
 
         if let Some(prefix) = pattern.strip_suffix("/**") {
             path_without_query.starts_with(prefix)
         } else if pattern.contains('*') {
-            self.glob_match(path_without_query, pattern)
+            Self::glob_match(path_without_query, pattern)
         } else {
             path_without_query == pattern
         }
     }
 
-    fn glob_match(&self, text: &str, pattern: &str) -> bool {
+    fn glob_match(text: &str, pattern: &str) -> bool {
         let pattern_parts: Vec<&str> = pattern.split('*').collect();
         if pattern_parts.len() == 1 {
             return text == pattern;
@@ -738,7 +739,7 @@ impl ImageOptimizer {
         true
     }
 
-    fn matches_pattern(&self, url: &Url, pattern: &RemotePattern) -> bool {
+    fn matches_pattern(url: &Url, pattern: &RemotePattern) -> bool {
         if let Some(ref protocol) = pattern.protocol
             && url.scheme() != protocol
         {
@@ -746,7 +747,7 @@ impl ImageOptimizer {
         }
 
         if let Some(host) = url.host_str() {
-            if !self.hostname_matches(host, &pattern.hostname) {
+            if !Self::hostname_matches(host, &pattern.hostname) {
                 return false;
             }
         } else {
@@ -760,7 +761,7 @@ impl ImageOptimizer {
         }
 
         if let Some(ref pathname) = pattern.pathname
-            && !self.pathname_matches(url.path(), pathname)
+            && !Self::pathname_matches(url.path(), pathname)
         {
             return false;
         }
@@ -779,7 +780,7 @@ impl ImageOptimizer {
         true
     }
 
-    fn hostname_matches(&self, host: &str, pattern: &str) -> bool {
+    fn hostname_matches(host: &str, pattern: &str) -> bool {
         if let Some(domain) = pattern.strip_prefix("*.") {
             host.ends_with(domain) || host == &domain[1..]
         } else {
@@ -878,10 +879,10 @@ impl ImageOptimizer {
                         }
 
                         let client_octets = [
-                            ((segments[6] >> 8) ^ 0xff) as u8,
-                            ((segments[6] & 0xff) ^ 0xff) as u8,
-                            ((segments[7] >> 8) ^ 0xff) as u8,
-                            ((segments[7] & 0xff) ^ 0xff) as u8,
+                            cast::u16_to_u8((segments[6] >> 8) ^ 0xff),
+                            cast::u16_to_u8((segments[6] & 0xff) ^ 0xff),
+                            cast::u16_to_u8((segments[7] >> 8) ^ 0xff),
+                            cast::u16_to_u8((segments[7] & 0xff) ^ 0xff),
                         ];
                         if is_private_ipv4(client_octets) {
                             return Err(ImageError::UnauthorizedDomain(format!(
@@ -920,7 +921,7 @@ impl ImageOptimizer {
 
         let mut allowed = false;
         for pattern in &self.config.remote_patterns {
-            if self.matches_pattern(&parsed, pattern) {
+            if Self::matches_pattern(&parsed, pattern) {
                 allowed = true;
                 break;
             }
@@ -1045,7 +1046,7 @@ impl ImageOptimizer {
             }
 
             if let Some(content_length) = response.content_length()
-                && content_length as usize > MAX_SOURCE_IMAGE_SIZE
+                && cast::u64_to_usize(content_length) > MAX_SOURCE_IMAGE_SIZE
             {
                 return Err(ImageError::InvalidParams(format!(
                     "Image too large: {content_length} bytes (max {MAX_SOURCE_IMAGE_SIZE} bytes)"
@@ -1053,7 +1054,7 @@ impl ImageOptimizer {
             }
 
             let mut bytes = if let Some(content_length) = response.content_length() {
-                let capacity = (content_length as usize).min(MAX_SOURCE_IMAGE_SIZE);
+                let capacity = cast::u64_to_usize(content_length).min(MAX_SOURCE_IMAGE_SIZE);
                 Vec::with_capacity(capacity)
             } else {
                 Vec::new()
@@ -1084,11 +1085,11 @@ impl ImageOptimizer {
     }
 
     fn process_image_blocking(
-        source: Vec<u8>,
+        source: &[u8],
         params: &OptimizeParams,
         _config: &ImageConfig,
     ) -> Result<OptimizedImage, ImageError> {
-        let img = image::load_from_memory(&source)
+        let img = image::load_from_memory(source)
             .map_err(|e| ImageError::ProcessingError(format!("Failed to decode image: {e}")))?;
 
         if img.width() > MAX_OUTPUT_WIDTH * 2 || img.height() > MAX_OUTPUT_HEIGHT * 2 {
@@ -1109,9 +1110,9 @@ impl ImageOptimizer {
                 img
             }
         } else if img.width() > MAX_OUTPUT_WIDTH || img.height() > MAX_OUTPUT_HEIGHT {
-            let scale = (MAX_OUTPUT_WIDTH as f32 / img.width() as f32)
-                .min(MAX_OUTPUT_HEIGHT as f32 / img.height() as f32);
-            let new_width = (img.width() as f32 * scale) as u32;
+            let scale = (float::u32_to_f32(MAX_OUTPUT_WIDTH) / float::u32_to_f32(img.width()))
+                .min(float::u32_to_f32(MAX_OUTPUT_HEIGHT) / float::u32_to_f32(img.height()));
+            let new_width = cast::f32_to_u32(float::u32_to_f32(img.width()) * scale);
             img.resize(new_width, u32::MAX, FilterType::Lanczos3)
         } else {
             img

--- a/crates/rari/src/server/loaders/component.rs
+++ b/crates/rari/src/server/loaders/component.rs
@@ -249,9 +249,8 @@ impl ComponentLoader {
                     .map(|s| s == "ts" || s == "tsx" || s == "js" || s == "jsx")
                     .unwrap_or(false)
                 {
-                    let code = match fs::read_to_string(&path) {
-                        Ok(c) => c,
-                        Err(_) => continue,
+                    let Ok(code) = fs::read_to_string(&path) else {
+                        continue;
                     };
 
                     if has_use_server_directive(&code) {
@@ -946,9 +945,8 @@ impl ComponentLoader {
                 continue;
             }
 
-            let code = match fs::read_to_string(&component_file) {
-                Ok(c) => c,
-                Err(_) => continue,
+            let Ok(code) = fs::read_to_string(&component_file) else {
+                continue;
             };
 
             let module_specifier = format!("file:///{}", bundle_path.cow_replace('\\', "/"));

--- a/crates/rari/src/server/middleware/proxy.rs
+++ b/crates/rari/src/server/middleware/proxy.rs
@@ -250,12 +250,9 @@ pub async fn initialize_proxy(state: &ServerState) -> Result<(), Box<dyn Error>>
     let renderer = state.renderer.lock().await;
     let runtime = &renderer.runtime;
 
-    let rari_pkg_dir = match resolve_rari_package_dir() {
-        Some(dir) => dir,
-        None => {
-            tracing::debug!("Proxy: rari package directory not found in node_modules");
-            return Ok(());
-        }
+    let Some(rari_pkg_dir) = resolve_rari_package_dir() else {
+        tracing::debug!("Proxy: rari package directory not found in node_modules");
+        return Ok(());
     };
 
     let executor_path = rari_pkg_dir.join("dist/proxy/runtime-executor.mjs");

--- a/crates/rari/src/server/middleware/request_context.rs
+++ b/crates/rari/src/server/middleware/request_context.rs
@@ -82,6 +82,17 @@ static GLOBAL_FETCH_CACHE: LazyLock<Arc<Mutex<LruCache<String, CachedFetchResult
 static GLOBAL_IN_FLIGHT_FETCHES: LazyLock<InFlightFetches> =
     LazyLock::new(|| Arc::new(DashMap::new()));
 
+struct FetchCleanupGuard<'a> {
+    in_flight_fetches: &'a InFlightFetches,
+    cache_key: String,
+}
+
+impl Drop for FetchCleanupGuard<'_> {
+    fn drop(&mut self) {
+        self.in_flight_fetches.remove(&self.cache_key);
+    }
+}
+
 pub struct RequestContext {
     fetch_cache: Arc<Mutex<LruCache<String, CachedFetchResult>>>,
     in_flight_fetches: InFlightFetches,
@@ -228,18 +239,7 @@ impl RequestContext {
             return Ok(cloned_result);
         }
 
-        struct CleanupGuard<'a> {
-            in_flight_fetches: &'a InFlightFetches,
-            cache_key: String,
-        }
-
-        impl Drop for CleanupGuard<'_> {
-            fn drop(&mut self) {
-                self.in_flight_fetches.remove(&self.cache_key);
-            }
-        }
-
-        let _cleanup = CleanupGuard {
+        let _cleanup = FetchCleanupGuard {
             in_flight_fetches: &self.in_flight_fetches,
             cache_key: cache_key.clone(),
         };

--- a/crates/rari/src/server/mod.rs
+++ b/crates/rari/src/server/mod.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::missing_errors_doc, clippy::too_many_lines)]
+
 pub mod cache;
 pub mod compression;
 pub mod config;

--- a/crates/rari/src/server/og/cache.rs
+++ b/crates/rari/src/server/og/cache.rs
@@ -28,7 +28,7 @@ pub struct OgImageCache {
 
 impl OgImageCache {
     pub fn new(memory_capacity: usize, project_path: &Path) -> Self {
-        let handler = MemoryCacheHandler::with_config(MemoryConfig {
+        let handler = MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: memory_capacity.max(1),
             default_ttl: 0,
         });
@@ -170,7 +170,7 @@ mod tests {
     }
 
     fn fresh_cache(test_name: &str, memory_capacity: usize) -> OgImageCache {
-        let handler = Arc::new(MemoryCacheHandler::with_config(MemoryConfig {
+        let handler = Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: memory_capacity.max(1),
             default_ttl: 0,
         }));
@@ -224,7 +224,7 @@ mod tests {
         let project_path = test_project_path("fallback-to-disk");
         let _ = StdFs::remove_dir_all(&project_path);
 
-        let handler_a = Arc::new(MemoryCacheHandler::with_config(MemoryConfig {
+        let handler_a = Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: 8,
             default_ttl: 0,
         }));
@@ -235,7 +235,7 @@ mod tests {
         cache_a.get("/persistent").await.expect("cache_a in-memory hit");
         drop(cache_a);
 
-        let handler_b = Arc::new(MemoryCacheHandler::with_config(MemoryConfig {
+        let handler_b = Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: 8,
             default_ttl: 0,
         }));

--- a/crates/rari/src/server/og/generator.rs
+++ b/crates/rari/src/server/og/generator.rs
@@ -10,7 +10,7 @@ use cow_utils::CowUtils;
 use rari_utils::path_to_file_url;
 use rustc_hash::FxHashMap;
 use serde_json::{Map, Value};
-use tokio::{fs, sync::RwLock};
+use tokio::{fs, sync::RwLock, task};
 
 use super::{
     OgImageError,
@@ -147,22 +147,26 @@ impl OgImageGenerator {
         let width = entry.width.unwrap_or(1200).min(MAX_OG_WIDTH);
         let height = entry.height.unwrap_or(630).min(MAX_OG_HEIGHT);
 
-        let (computed_layout, font_context) = {
-            let mut layout_engine = LayoutEngine::new();
-            let font_context = layout_engine.get_font_context();
-            let computed_layout = layout_engine
-                .layout(&jsx_element, float::u32_to_f32(width), float::u32_to_f32(height))
-                .map_err(|e| OgImageError::GenerationError(format!("Layout failed: {e}")))?;
-            (computed_layout, font_context)
-        };
+        let webp_data = task::spawn_blocking(move || -> Result<Vec<u8>, OgImageError> {
+            let (computed_layout, font_context) = {
+                let mut layout_engine = LayoutEngine::new();
+                let font_context = layout_engine.get_font_context();
+                let computed_layout = layout_engine
+                    .layout(&jsx_element, float::u32_to_f32(width), float::u32_to_f32(height))
+                    .map_err(|e| OgImageError::GenerationError(format!("Layout failed: {e}")))?;
+                (computed_layout, font_context)
+            };
 
-        let mut renderer = ImageRenderer::new(width, height, font_context);
-        let image = renderer
-            .render(&computed_layout)
-            .map_err(|e| OgImageError::GenerationError(format!("Image generation failed: {e}")))?;
+            let mut renderer = ImageRenderer::new(width, height, font_context);
+            let image = renderer.render(&computed_layout).map_err(|e| {
+                OgImageError::GenerationError(format!("Image generation failed: {e}"))
+            })?;
 
-        let webp_data = Self::encode_webp(&image)
-            .map_err(|e| OgImageError::GenerationError(format!("Failed to encode WebP: {e}")))?;
+            Self::encode_webp(&image)
+                .map_err(|e| OgImageError::GenerationError(format!("Failed to encode WebP: {e}")))
+        })
+        .await
+        .map_err(|e| OgImageError::GenerationError(format!("OG generation task failed: {e}")))??;
 
         if let Err(e) = self.cache.insert(route_path.to_string(), webp_data.clone()).await {
             tracing::warn!(error = %e, route_path, "OG cache insert failed");

--- a/crates/rari/src/server/og/generator.rs
+++ b/crates/rari/src/server/og/generator.rs
@@ -22,6 +22,7 @@ use super::{
 use crate::{
     runtime::JsExecutionRuntime,
     server::{cache::handler::CacheError, routing::types::ParamValue},
+    utils::float,
 };
 
 pub struct OgImageGenerator {
@@ -122,7 +123,7 @@ impl OgImageGenerator {
 
     pub async fn find_og_image_for_route(&self, route_path: &str) -> Option<OgImageEntry> {
         let manifest = self.manifest.read().await;
-        self.find_matching_entry(&manifest, route_path).map(|(entry, _)| entry.clone())
+        Self::find_matching_entry(&manifest, route_path).map(|(entry, _)| entry.clone())
     }
 
     pub async fn generate(&self, route_path: &str) -> Result<(Vec<u8>, bool), OgImageError> {
@@ -135,8 +136,7 @@ impl OgImageGenerator {
 
         let manifest = self.manifest.read().await;
 
-        let (entry, params) = self
-            .find_matching_entry(&manifest, route_path)
+        let (entry, params) = Self::find_matching_entry(&manifest, route_path)
             .ok_or_else(|| OgImageError::ComponentNotFound(route_path.to_string()))?;
 
         let entry = entry.clone();
@@ -150,10 +150,9 @@ impl OgImageGenerator {
         let (computed_layout, font_context) = {
             let mut layout_engine = LayoutEngine::new();
             let font_context = layout_engine.get_font_context();
-            let computed_layout =
-                layout_engine
-                    .layout(&jsx_element, width as f32, height as f32)
-                    .map_err(|e| OgImageError::GenerationError(format!("Layout failed: {e}")))?;
+            let computed_layout = layout_engine
+                .layout(&jsx_element, float::u32_to_f32(width), float::u32_to_f32(height))
+                .map_err(|e| OgImageError::GenerationError(format!("Layout failed: {e}")))?;
             (computed_layout, font_context)
         };
 
@@ -173,7 +172,6 @@ impl OgImageGenerator {
     }
 
     fn find_matching_entry<'a>(
-        &self,
         manifest: &'a FxHashMap<String, OgImageEntry>,
         route_path: &str,
     ) -> Option<(&'a OgImageEntry, FxHashMap<String, ParamValue>)> {

--- a/crates/rari/src/server/og/layout/mod.rs
+++ b/crates/rari/src/server/og/layout/mod.rs
@@ -23,8 +23,6 @@ use crate::{
     utils::{cast, float},
 };
 
-const MAX_IMAGE_SIZE: usize = 10 * 1024 * 1024;
-
 pub struct MeasureContext {
     font_context: RefCell<ParleyFontContext>,
 }
@@ -608,7 +606,7 @@ fn load_image_dimensions(src: &str) -> Option<Size<f32>> {
         }
 
         let mut buffer = Vec::new();
-        response.take(MAX_IMAGE_SIZE as u64).read_to_end(&mut buffer).ok()?;
+        response.take(super::MAX_OG_IMAGE_BYTES as u64).read_to_end(&mut buffer).ok()?;
 
         let img = image::load_from_memory(&buffer).ok()?;
         Some(Size {

--- a/crates/rari/src/server/og/layout/mod.rs
+++ b/crates/rari/src/server/og/layout/mod.rs
@@ -18,7 +18,12 @@ use super::{
     resources::fonts::FontContext,
     types::{JsxChild, JsxElement},
 };
-use crate::server::og::rendering::is_svg_element;
+use crate::{
+    server::og::rendering::is_svg_element,
+    utils::{cast, float},
+};
+
+const MAX_IMAGE_SIZE: usize = 10 * 1024 * 1024;
 
 pub struct MeasureContext {
     font_context: RefCell<ParleyFontContext>,
@@ -90,7 +95,7 @@ impl LayoutEngine {
         element: &JsxElement,
         inherited_color: &mut Option<String>,
     ) -> Result<NodeId, String> {
-        let mut style = self.parse_style(&element.props);
+        let mut style = Self::parse_style(&element.props);
 
         if !style.contains_key("color") {
             if let Some(color) = inherited_color {
@@ -100,8 +105,8 @@ impl LayoutEngine {
             *inherited_color = Some(color.clone());
         }
 
-        let has_text = self.has_text_content(element);
-        let taffy_style = self.style_to_taffy(&style);
+        let has_text = Self::has_text_content(element);
+        let taffy_style = Self::style_to_taffy(&style);
 
         let node_data = NodeData { element: element.clone(), style: style.clone(), has_text };
 
@@ -141,11 +146,11 @@ impl LayoutEngine {
         Ok(node)
     }
 
-    fn has_text_content(&self, element: &JsxElement) -> bool {
+    fn has_text_content(element: &JsxElement) -> bool {
         element.children.iter().any(|child| matches!(child, JsxChild::Text(_)))
     }
 
-    fn parse_style(&self, props: &Value) -> FxHashMap<String, String> {
+    fn parse_style(props: &Value) -> FxHashMap<String, String> {
         let mut style_map = FxHashMap::default();
 
         if let Some(Value::Object(style_obj)) = props.get("style") {
@@ -161,7 +166,7 @@ impl LayoutEngine {
         style_map
     }
 
-    fn style_to_taffy(&self, style: &FxHashMap<String, String>) -> Style {
+    fn style_to_taffy(style: &FxHashMap<String, String>) -> Style {
         let mut taffy_style = Style::default();
 
         if let Some(display) = style.get("display") {
@@ -210,62 +215,62 @@ impl LayoutEngine {
         }
 
         if let Some(width) = style.get("width") {
-            taffy_style.size.width = self.parse_dimension(width);
+            taffy_style.size.width = Self::parse_dimension(width);
         }
 
         if let Some(height) = style.get("height") {
-            taffy_style.size.height = self.parse_dimension(height);
+            taffy_style.size.height = Self::parse_dimension(height);
         }
 
         if let Some(padding) = style.get("padding") {
-            taffy_style.padding = self.parse_padding_margin(padding);
+            taffy_style.padding = Self::parse_padding_margin(padding);
         }
 
         if let Some(padding_left) = style.get("paddingLeft") {
-            taffy_style.padding.left = self.parse_length_percentage(padding_left);
+            taffy_style.padding.left = Self::parse_length_percentage(padding_left);
         }
         if let Some(padding_right) = style.get("paddingRight") {
-            taffy_style.padding.right = self.parse_length_percentage(padding_right);
+            taffy_style.padding.right = Self::parse_length_percentage(padding_right);
         }
         if let Some(padding_top) = style.get("paddingTop") {
-            taffy_style.padding.top = self.parse_length_percentage(padding_top);
+            taffy_style.padding.top = Self::parse_length_percentage(padding_top);
         }
         if let Some(padding_bottom) = style.get("paddingBottom") {
-            taffy_style.padding.bottom = self.parse_length_percentage(padding_bottom);
+            taffy_style.padding.bottom = Self::parse_length_percentage(padding_bottom);
         }
 
         if let Some(margin) = style.get("margin") {
-            taffy_style.margin = self.parse_padding_margin_auto(margin);
+            taffy_style.margin = Self::parse_padding_margin_auto(margin);
         }
 
         if let Some(margin_left) = style.get("marginLeft") {
-            taffy_style.margin.left = self.parse_length_percentage_auto(margin_left);
+            taffy_style.margin.left = Self::parse_length_percentage_auto(margin_left);
         }
         if let Some(margin_right) = style.get("marginRight") {
-            taffy_style.margin.right = self.parse_length_percentage_auto(margin_right);
+            taffy_style.margin.right = Self::parse_length_percentage_auto(margin_right);
         }
         if let Some(margin_top) = style.get("marginTop") {
-            taffy_style.margin.top = self.parse_length_percentage_auto(margin_top);
+            taffy_style.margin.top = Self::parse_length_percentage_auto(margin_top);
         }
         if let Some(margin_bottom) = style.get("marginBottom") {
-            taffy_style.margin.bottom = self.parse_length_percentage_auto(margin_bottom);
+            taffy_style.margin.bottom = Self::parse_length_percentage_auto(margin_bottom);
         }
 
         if let Some(gap) = style.get("gap") {
-            let gap_value = self.parse_length_percentage(gap);
+            let gap_value = Self::parse_length_percentage(gap);
             taffy_style.gap = Size { width: gap_value, height: gap_value };
         }
         if let Some(row_gap) = style.get("rowGap") {
-            taffy_style.gap.height = self.parse_length_percentage(row_gap);
+            taffy_style.gap.height = Self::parse_length_percentage(row_gap);
         }
         if let Some(column_gap) = style.get("columnGap") {
-            taffy_style.gap.width = self.parse_length_percentage(column_gap);
+            taffy_style.gap.width = Self::parse_length_percentage(column_gap);
         }
 
         taffy_style
     }
 
-    fn parse_dimension(&self, value: &str) -> Dimension {
+    fn parse_dimension(value: &str) -> Dimension {
         if value.ends_with('%') {
             if let Ok(percent) = value.trim_end_matches('%').parse::<f32>() {
                 return Dimension::percent(percent / 100.0);
@@ -276,7 +281,7 @@ impl LayoutEngine {
         Dimension::auto()
     }
 
-    fn parse_length_percentage(&self, value: &str) -> LengthPercentage {
+    fn parse_length_percentage(value: &str) -> LengthPercentage {
         if value.ends_with('%') {
             if let Ok(percent) = value.trim_end_matches('%').parse::<f32>() {
                 return LengthPercentage::percent(percent / 100.0);
@@ -287,7 +292,7 @@ impl LayoutEngine {
         LengthPercentage::length(0.0)
     }
 
-    fn parse_length_percentage_auto(&self, value: &str) -> LengthPercentageAuto {
+    fn parse_length_percentage_auto(value: &str) -> LengthPercentageAuto {
         if value == "auto" {
             return LengthPercentageAuto::auto();
         }
@@ -301,30 +306,30 @@ impl LayoutEngine {
         LengthPercentageAuto::length(0.0)
     }
 
-    fn parse_padding_margin(&self, value: &str) -> Rect<LengthPercentage> {
+    fn parse_padding_margin(value: &str) -> Rect<LengthPercentage> {
         let parts: Vec<&str> = value.split_whitespace().collect();
 
         match parts.len() {
             1 => {
-                let p = self.parse_length_percentage(parts[0]);
+                let p = Self::parse_length_percentage(parts[0]);
                 Rect { left: p, right: p, top: p, bottom: p }
             }
             2 => {
-                let vertical = self.parse_length_percentage(parts[0]);
-                let horizontal = self.parse_length_percentage(parts[1]);
+                let vertical = Self::parse_length_percentage(parts[0]);
+                let horizontal = Self::parse_length_percentage(parts[1]);
                 Rect { left: horizontal, right: horizontal, top: vertical, bottom: vertical }
             }
             3 => {
-                let top = self.parse_length_percentage(parts[0]);
-                let horizontal = self.parse_length_percentage(parts[1]);
-                let bottom = self.parse_length_percentage(parts[2]);
+                let top = Self::parse_length_percentage(parts[0]);
+                let horizontal = Self::parse_length_percentage(parts[1]);
+                let bottom = Self::parse_length_percentage(parts[2]);
                 Rect { left: horizontal, right: horizontal, top, bottom }
             }
             4 => {
-                let top = self.parse_length_percentage(parts[0]);
-                let right = self.parse_length_percentage(parts[1]);
-                let bottom = self.parse_length_percentage(parts[2]);
-                let left = self.parse_length_percentage(parts[3]);
+                let top = Self::parse_length_percentage(parts[0]);
+                let right = Self::parse_length_percentage(parts[1]);
+                let bottom = Self::parse_length_percentage(parts[2]);
+                let left = Self::parse_length_percentage(parts[3]);
                 Rect { left, right, top, bottom }
             }
             _ => Rect {
@@ -336,30 +341,30 @@ impl LayoutEngine {
         }
     }
 
-    fn parse_padding_margin_auto(&self, value: &str) -> Rect<LengthPercentageAuto> {
+    fn parse_padding_margin_auto(value: &str) -> Rect<LengthPercentageAuto> {
         let parts: Vec<&str> = value.split_whitespace().collect();
 
         match parts.len() {
             1 => {
-                let m = self.parse_length_percentage_auto(parts[0]);
+                let m = Self::parse_length_percentage_auto(parts[0]);
                 Rect { left: m, right: m, top: m, bottom: m }
             }
             2 => {
-                let vertical = self.parse_length_percentage_auto(parts[0]);
-                let horizontal = self.parse_length_percentage_auto(parts[1]);
+                let vertical = Self::parse_length_percentage_auto(parts[0]);
+                let horizontal = Self::parse_length_percentage_auto(parts[1]);
                 Rect { left: horizontal, right: horizontal, top: vertical, bottom: vertical }
             }
             3 => {
-                let top = self.parse_length_percentage_auto(parts[0]);
-                let horizontal = self.parse_length_percentage_auto(parts[1]);
-                let bottom = self.parse_length_percentage_auto(parts[2]);
+                let top = Self::parse_length_percentage_auto(parts[0]);
+                let horizontal = Self::parse_length_percentage_auto(parts[1]);
+                let bottom = Self::parse_length_percentage_auto(parts[2]);
                 Rect { left: horizontal, right: horizontal, top, bottom }
             }
             4 => {
-                let top = self.parse_length_percentage_auto(parts[0]);
-                let right = self.parse_length_percentage_auto(parts[1]);
-                let bottom = self.parse_length_percentage_auto(parts[2]);
-                let left = self.parse_length_percentage_auto(parts[3]);
+                let top = Self::parse_length_percentage_auto(parts[0]);
+                let right = Self::parse_length_percentage_auto(parts[1]);
+                let bottom = Self::parse_length_percentage_auto(parts[2]);
+                let left = Self::parse_length_percentage_auto(parts[3]);
                 Rect { left, right, top, bottom }
             }
             _ => Rect {
@@ -426,7 +431,7 @@ fn measure_node(
             .and_then(|v| {
                 v.as_str()
                     .and_then(|s| s.parse::<f32>().ok())
-                    .or_else(|| v.as_f64().map(|n| n as f32))
+                    .or_else(|| v.as_f64().map(cast::f64_to_f32))
             })
             .or_else(|| {
                 node_data.style.get("width").and_then(|s| s.trim_end_matches("px").parse().ok())
@@ -439,7 +444,7 @@ fn measure_node(
             .and_then(|v| {
                 v.as_str()
                     .and_then(|s| s.parse::<f32>().ok())
-                    .or_else(|| v.as_f64().map(|n| n as f32))
+                    .or_else(|| v.as_f64().map(cast::f64_to_f32))
             })
             .or_else(|| {
                 node_data.style.get("height").and_then(|s| s.trim_end_matches("px").parse().ok())
@@ -521,11 +526,19 @@ fn measure_image(
         Size { width: 0.0, height: 0.0 }
     };
 
-    let width_prop =
-        node_data.element.props.get("width").and_then(serde_json::Value::as_f64).map(|v| v as f32);
+    let width_prop = node_data
+        .element
+        .props
+        .get("width")
+        .and_then(serde_json::Value::as_f64)
+        .map(cast::f64_to_f32);
 
-    let height_prop =
-        node_data.element.props.get("height").and_then(serde_json::Value::as_f64).map(|v| v as f32);
+    let height_prop = node_data
+        .element
+        .props
+        .get("height")
+        .and_then(serde_json::Value::as_f64)
+        .map(cast::f64_to_f32);
 
     let width_is_100_percent = node_data.style.get("width").map(|w| w == "100%").unwrap_or(false);
     let height_is_100_percent = node_data.style.get("height").map(|h| h == "100%").unwrap_or(false);
@@ -594,12 +607,14 @@ fn load_image_dimensions(src: &str) -> Option<Size<f32>> {
             return None;
         }
 
-        const MAX_IMAGE_SIZE: usize = 10 * 1024 * 1024;
         let mut buffer = Vec::new();
         response.take(MAX_IMAGE_SIZE as u64).read_to_end(&mut buffer).ok()?;
 
         let img = image::load_from_memory(&buffer).ok()?;
-        Some(Size { width: img.width() as f32, height: img.height() as f32 })
+        Some(Size {
+            width: float::u32_to_f32(img.width()),
+            height: float::u32_to_f32(img.height()),
+        })
     } else if src.starts_with("data:") {
         use base64::{Engine as _, engine::general_purpose};
         let parts: Vec<&str> = src.splitn(2, ',').collect();
@@ -613,13 +628,19 @@ fn load_image_dimensions(src: &str) -> Option<Size<f32>> {
         if header.contains("base64") {
             let decoded = general_purpose::STANDARD.decode(data).ok()?;
             let img = image::load_from_memory(&decoded).ok()?;
-            Some(Size { width: img.width() as f32, height: img.height() as f32 })
+            Some(Size {
+                width: float::u32_to_f32(img.width()),
+                height: float::u32_to_f32(img.height()),
+            })
         } else {
             None
         }
     } else {
         let img = image::open(src).ok()?;
-        Some(Size { width: img.width() as f32, height: img.height() as f32 })
+        Some(Size {
+            width: float::u32_to_f32(img.width()),
+            height: float::u32_to_f32(img.height()),
+        })
     }
 }
 

--- a/crates/rari/src/server/og/layout/style/gradient.rs
+++ b/crates/rari/src/server/og/layout/style/gradient.rs
@@ -1,5 +1,7 @@
 use image::Rgba;
 
+use crate::utils::{cast, float};
+
 #[derive(Debug, Clone, Copy)]
 pub enum StopPosition {
     Percentage(f32),
@@ -215,7 +217,7 @@ impl LinearGradient {
                         let r = parts[0].parse().ok()?;
                         let g = parts[1].parse().ok()?;
                         let b = parts[2].parse().ok()?;
-                        let a = (parts[3].parse::<f32>().ok()? * 255.0) as u8;
+                        let a = cast::f32_to_u8(parts[3].parse::<f32>().ok()? * 255.0);
                         [r, g, b, a]
                     } else {
                         return None;
@@ -268,10 +270,11 @@ impl LinearGradient {
 
             let start_pos = resolved[start_idx].position;
             let end_pos = resolved[end_idx].position;
-            let segments = (end_idx - start_idx) as f32;
+            let segments = float::usize_to_f32(end_idx - start_idx);
 
             for (offset, stop) in resolved[(start_idx + 1)..end_idx].iter_mut().enumerate() {
-                stop.position = start_pos + (end_pos - start_pos) * (offset + 1) as f32 / segments;
+                stop.position =
+                    start_pos + (end_pos - start_pos) * float::usize_to_f32(offset + 1) / segments;
             }
 
             i = end_idx + 1;
@@ -329,10 +332,10 @@ impl LinearGradient {
         let c2 = right.color;
 
         Rgba([
-            (f32::from(c1[0]) * (1.0 - t) + f32::from(c2[0]) * t) as u8,
-            (f32::from(c1[1]) * (1.0 - t) + f32::from(c2[1]) * t) as u8,
-            (f32::from(c1[2]) * (1.0 - t) + f32::from(c2[2]) * t) as u8,
-            (f32::from(c1[3]) * (1.0 - t) + f32::from(c2[3]) * t) as u8,
+            cast::f32_to_u8(f32::from(c1[0]) * (1.0 - t) + f32::from(c2[0]) * t),
+            cast::f32_to_u8(f32::from(c1[1]) * (1.0 - t) + f32::from(c2[1]) * t),
+            cast::f32_to_u8(f32::from(c1[2]) * (1.0 - t) + f32::from(c2[2]) * t),
+            cast::f32_to_u8(f32::from(c1[3]) * (1.0 - t) + f32::from(c2[3]) * t),
         ])
     }
 

--- a/crates/rari/src/server/og/mod.rs
+++ b/crates/rari/src/server/og/mod.rs
@@ -5,6 +5,8 @@ mod rendering;
 mod resources;
 mod types;
 
+pub(super) const MAX_OG_IMAGE_BYTES: usize = 10 * 1024 * 1024;
+
 use std::sync::Arc;
 
 use axum::{

--- a/crates/rari/src/server/og/rendering/background.rs
+++ b/crates/rari/src/server/og/rendering/background.rs
@@ -5,6 +5,7 @@ use super::{
     mask::{MaskMemory, build_rounded_rect_path, mask_index},
     renderer::ImageRenderer,
 };
+use crate::utils::{cast, float};
 
 impl ImageRenderer {
     pub(super) fn render_background(
@@ -14,10 +15,10 @@ impl ImageRenderer {
         image: &mut RgbaImage,
         mask_memory: &mut MaskMemory,
     ) -> Result<(), String> {
-        let border_radius = self.parse_border_radius(&layout.style);
+        let border_radius = Self::parse_border_radius(&layout.style);
 
-        let x_start = layout.x as u32;
-        let y_start = layout.y as u32;
+        let x_start = cast::f32_to_u32(layout.x);
+        let y_start = cast::f32_to_u32(layout.y);
         let box_width = layout.width;
         let box_height = layout.height;
 
@@ -37,8 +38,8 @@ impl ImageRenderer {
         if let Some(gradient) = LinearGradient::parse(bg) {
             let params = gradient.calculate_params(box_width, box_height);
 
-            for rel_y in 0..box_height as u32 {
-                for rel_x in 0..box_width as u32 {
+            for rel_y in 0..cast::f32_to_u32(box_height) {
+                for rel_x in 0..cast::f32_to_u32(box_width) {
                     let canvas_x = x_start + rel_x;
                     let canvas_y = y_start + rel_y;
 
@@ -46,30 +47,31 @@ impl ImageRenderer {
                         continue;
                     }
 
-                    let alpha =
-                        if let Some((ref mask, mask_w, mask_h, mask_left, mask_top)) = mask_data {
-                            let mask_x = rel_x as i32 - mask_left;
-                            let mask_y = rel_y as i32 - mask_top;
+                    let alpha = if let Some((ref mask, mask_w, mask_h, mask_left, mask_top)) =
+                        mask_data
+                    {
+                        let mask_x = rel_x.cast_signed() - mask_left;
+                        let mask_y = rel_y.cast_signed() - mask_top;
 
-                            if mask_x >= 0
-                                && mask_x < mask_w as i32
-                                && mask_y >= 0
-                                && mask_y < mask_h as i32
-                            {
-                                mask[mask_index(mask_x as u32, mask_y as u32, mask_w)]
-                            } else {
-                                0
-                            }
+                        if mask_x >= 0
+                            && mask_x < mask_w.cast_signed()
+                            && mask_y >= 0
+                            && mask_y < mask_h.cast_signed()
+                        {
+                            mask[mask_index(mask_x.cast_unsigned(), mask_y.cast_unsigned(), mask_w)]
                         } else {
-                            255
-                        };
+                            0
+                        }
+                    } else {
+                        255
+                    };
 
                     if alpha == 0 {
                         continue;
                     }
 
-                    let dx = rel_x as f32 - params.cx;
-                    let dy = rel_y as f32 - params.cy;
+                    let dx = float::u32_to_f32(rel_x) - params.cx;
+                    let dy = float::u32_to_f32(rel_y) - params.cy;
                     let projection = dx * params.dir_x + dy * params.dir_y;
                     let position =
                         ((projection + params.max_extent) / params.axis_length).clamp(0.0, 1.0);
@@ -78,17 +80,17 @@ impl ImageRenderer {
 
                     if alpha < 255 {
                         let bg_pixel = image.get_pixel(canvas_x, canvas_y);
-                        color = self.blend_with_alpha(*bg_pixel, color, alpha);
+                        color = Self::blend_with_alpha(*bg_pixel, color, alpha);
                     }
 
                     image.put_pixel(canvas_x, canvas_y, color);
                 }
             }
         } else {
-            let color = self.parse_color(bg);
+            let color = Self::parse_color(bg);
 
-            for rel_y in 0..box_height as u32 {
-                for rel_x in 0..box_width as u32 {
+            for rel_y in 0..cast::f32_to_u32(box_height) {
+                for rel_x in 0..cast::f32_to_u32(box_width) {
                     let canvas_x = x_start + rel_x;
                     let canvas_y = y_start + rel_y;
 
@@ -96,23 +98,24 @@ impl ImageRenderer {
                         continue;
                     }
 
-                    let alpha =
-                        if let Some((ref mask, mask_w, mask_h, mask_left, mask_top)) = mask_data {
-                            let mask_x = rel_x as i32 - mask_left;
-                            let mask_y = rel_y as i32 - mask_top;
+                    let alpha = if let Some((ref mask, mask_w, mask_h, mask_left, mask_top)) =
+                        mask_data
+                    {
+                        let mask_x = rel_x.cast_signed() - mask_left;
+                        let mask_y = rel_y.cast_signed() - mask_top;
 
-                            if mask_x >= 0
-                                && mask_x < mask_w as i32
-                                && mask_y >= 0
-                                && mask_y < mask_h as i32
-                            {
-                                mask[mask_index(mask_x as u32, mask_y as u32, mask_w)]
-                            } else {
-                                0
-                            }
+                        if mask_x >= 0
+                            && mask_x < mask_w.cast_signed()
+                            && mask_y >= 0
+                            && mask_y < mask_h.cast_signed()
+                        {
+                            mask[mask_index(mask_x.cast_unsigned(), mask_y.cast_unsigned(), mask_w)]
                         } else {
-                            255
-                        };
+                            0
+                        }
+                    } else {
+                        255
+                    };
 
                     if alpha == 0 {
                         continue;
@@ -120,7 +123,7 @@ impl ImageRenderer {
 
                     let final_color = if alpha < 255 {
                         let bg_pixel = image.get_pixel(canvas_x, canvas_y);
-                        self.blend_with_alpha(*bg_pixel, color, alpha)
+                        Self::blend_with_alpha(*bg_pixel, color, alpha)
                     } else {
                         color
                     };
@@ -134,7 +137,6 @@ impl ImageRenderer {
     }
 
     fn blend_with_alpha(
-        &self,
         bg: image::Rgba<u8>,
         fg: image::Rgba<u8>,
         mask_alpha: u8,
@@ -143,9 +145,9 @@ impl ImageRenderer {
         let inv_alpha = 1.0 - alpha;
 
         image::Rgba([
-            ((f32::from(fg[0]) * alpha + f32::from(bg[0]) * inv_alpha) as u8),
-            ((f32::from(fg[1]) * alpha + f32::from(bg[1]) * inv_alpha) as u8),
-            ((f32::from(fg[2]) * alpha + f32::from(bg[2]) * inv_alpha) as u8),
+            cast::f32_to_u8(f32::from(fg[0]) * alpha + f32::from(bg[0]) * inv_alpha),
+            cast::f32_to_u8(f32::from(fg[1]) * alpha + f32::from(bg[1]) * inv_alpha),
+            cast::f32_to_u8(f32::from(fg[2]) * alpha + f32::from(bg[2]) * inv_alpha),
             255,
         ])
     }

--- a/crates/rari/src/server/og/rendering/border.rs
+++ b/crates/rari/src/server/og/rendering/border.rs
@@ -6,6 +6,7 @@ use super::{
     mask::{MaskMemory, build_rounded_rect_path, mask_index},
     renderer::ImageRenderer,
 };
+use crate::utils::{cast, float};
 
 #[derive(Debug, Clone, Copy)]
 pub(super) struct BorderWidth {
@@ -41,8 +42,8 @@ impl ImageRenderer {
         image: &mut RgbaImage,
         mask_memory: &mut MaskMemory,
     ) -> Result<(), String> {
-        let border_width = self.parse_border_width(&layout.style);
-        let border_color = self.parse_border_color(&layout.style);
+        let border_width = Self::parse_border_width(&layout.style);
+        let border_color = Self::parse_border_color(&layout.style);
 
         if border_width.top == 0.0
             && border_width.right == 0.0
@@ -52,10 +53,10 @@ impl ImageRenderer {
             return Ok(());
         }
 
-        let border_radius = self.parse_border_radius(&layout.style);
+        let border_radius = Self::parse_border_radius(&layout.style);
 
-        let x_start = layout.x as u32;
-        let y_start = layout.y as u32;
+        let x_start = cast::f32_to_u32(layout.x);
+        let y_start = cast::f32_to_u32(layout.y);
         let width = layout.width;
         let height = layout.height;
 
@@ -102,16 +103,18 @@ impl ImageRenderer {
         border_width: BorderWidth,
         color: image::Rgba<u8>,
     ) {
-        let x_end = (x as f32 + width).min(self.width as f32) as u32;
-        let y_end = (y as f32 + height).min(self.height as f32) as u32;
+        let x_end =
+            cast::f32_to_u32((float::u32_to_f32(x) + width).min(float::u32_to_f32(self.width)));
+        let y_end =
+            cast::f32_to_u32((float::u32_to_f32(y) + height).min(float::u32_to_f32(self.height)));
 
         if border_width.top > 0.0 {
-            let top_height = (border_width.top as u32).min(height as u32);
+            let top_height = cast::f32_to_u32(border_width.top).min(cast::f32_to_u32(height));
             for py in y..y.saturating_add(top_height).min(y_end) {
                 for px in x..x_end {
                     if px < self.width && py < self.height {
                         let bg = image.get_pixel(px, py);
-                        let blended = self.alpha_blend(*bg, color);
+                        let blended = Self::alpha_blend(*bg, color);
                         image.put_pixel(px, py, blended);
                     }
                 }
@@ -119,12 +122,12 @@ impl ImageRenderer {
         }
 
         if border_width.bottom > 0.0 {
-            let bottom_start = y_end.saturating_sub(border_width.bottom as u32);
+            let bottom_start = y_end.saturating_sub(cast::f32_to_u32(border_width.bottom));
             for py in bottom_start..y_end {
                 for px in x..x_end {
                     if px < self.width && py < self.height {
                         let bg = image.get_pixel(px, py);
-                        let blended = self.alpha_blend(*bg, color);
+                        let blended = Self::alpha_blend(*bg, color);
                         image.put_pixel(px, py, blended);
                     }
                 }
@@ -132,12 +135,12 @@ impl ImageRenderer {
         }
 
         if border_width.left > 0.0 {
-            let left_width = (border_width.left as u32).min(width as u32);
+            let left_width = cast::f32_to_u32(border_width.left).min(cast::f32_to_u32(width));
             for py in y..y_end {
                 for px in x..x.saturating_add(left_width).min(x_end) {
                     if px < self.width && py < self.height {
                         let bg = image.get_pixel(px, py);
-                        let blended = self.alpha_blend(*bg, color);
+                        let blended = Self::alpha_blend(*bg, color);
                         image.put_pixel(px, py, blended);
                     }
                 }
@@ -145,12 +148,12 @@ impl ImageRenderer {
         }
 
         if border_width.right > 0.0 {
-            let right_start = x_end.saturating_sub(border_width.right as u32);
+            let right_start = x_end.saturating_sub(cast::f32_to_u32(border_width.right));
             for py in y..y_end {
                 for px in right_start..x_end {
                     if px < self.width && py < self.height {
                         let bg = image.get_pixel(px, py);
-                        let blended = self.alpha_blend(*bg, color);
+                        let blended = Self::alpha_blend(*bg, color);
                         image.put_pixel(px, py, blended);
                     }
                 }
@@ -189,8 +192,8 @@ impl ImageRenderer {
 
         let (mask, placement) = mask_memory.render_with_style(&combined_path, Fill::EvenOdd.into());
 
-        for rel_y in 0..height as u32 {
-            for rel_x in 0..width as u32 {
+        for rel_y in 0..cast::f32_to_u32(height) {
+            for rel_x in 0..cast::f32_to_u32(width) {
                 let canvas_x = x_start + rel_x;
                 let canvas_y = y_start + rel_y;
 
@@ -198,15 +201,19 @@ impl ImageRenderer {
                     continue;
                 }
 
-                let mask_x = rel_x as i32 - placement.left;
-                let mask_y = rel_y as i32 - placement.top;
+                let mask_x = rel_x.cast_signed() - placement.left;
+                let mask_y = rel_y.cast_signed() - placement.top;
 
                 let alpha = if mask_x >= 0
-                    && mask_x < placement.width as i32
+                    && mask_x < placement.width.cast_signed()
                     && mask_y >= 0
-                    && mask_y < placement.height as i32
+                    && mask_y < placement.height.cast_signed()
                 {
-                    mask[mask_index(mask_x as u32, mask_y as u32, placement.width)]
+                    mask[mask_index(
+                        mask_x.cast_unsigned(),
+                        mask_y.cast_unsigned(),
+                        placement.width,
+                    )]
                 } else {
                     0
                 };
@@ -217,9 +224,9 @@ impl ImageRenderer {
 
                 let bg = image.get_pixel(canvas_x, canvas_y);
                 let blended = if alpha < 255 {
-                    self.blend_border_with_alpha(*bg, color, alpha)
+                    Self::blend_border_with_alpha(*bg, color, alpha)
                 } else {
-                    self.alpha_blend(*bg, color)
+                    Self::alpha_blend(*bg, color)
                 };
                 image.put_pixel(canvas_x, canvas_y, blended);
             }
@@ -227,7 +234,6 @@ impl ImageRenderer {
     }
 
     fn blend_border_with_alpha(
-        &self,
         bg: image::Rgba<u8>,
         fg: image::Rgba<u8>,
         mask_alpha: u8,
@@ -236,17 +242,14 @@ impl ImageRenderer {
         let inv_alpha = 1.0 - alpha;
 
         image::Rgba([
-            ((f32::from(fg[0]) * alpha + f32::from(bg[0]) * inv_alpha) as u8),
-            ((f32::from(fg[1]) * alpha + f32::from(bg[1]) * inv_alpha) as u8),
-            ((f32::from(fg[2]) * alpha + f32::from(bg[2]) * inv_alpha) as u8),
+            cast::f32_to_u8(f32::from(fg[0]) * alpha + f32::from(bg[0]) * inv_alpha),
+            cast::f32_to_u8(f32::from(fg[1]) * alpha + f32::from(bg[1]) * inv_alpha),
+            cast::f32_to_u8(f32::from(fg[2]) * alpha + f32::from(bg[2]) * inv_alpha),
             255,
         ])
     }
 
-    pub(super) fn parse_border_width(
-        &self,
-        style: &rustc_hash::FxHashMap<String, String>,
-    ) -> BorderWidth {
+    pub(super) fn parse_border_width(style: &rustc_hash::FxHashMap<String, String>) -> BorderWidth {
         if let Some(border) = style.get("border") {
             let parts: Vec<&str> = border.split_whitespace().collect();
             if let Some(width_str) = parts.first()
@@ -282,23 +285,22 @@ impl ImageRenderer {
         }
     }
 
-    fn parse_border_color(&self, style: &rustc_hash::FxHashMap<String, String>) -> image::Rgba<u8> {
+    fn parse_border_color(style: &rustc_hash::FxHashMap<String, String>) -> image::Rgba<u8> {
         if let Some(color) = style.get("borderColor") {
-            return self.parse_color(color);
+            return Self::parse_color(color);
         }
 
         if let Some(border) = style.get("border") {
             let parts: Vec<&str> = border.split_whitespace().collect();
             if parts.len() >= 3 {
-                return self.parse_color(parts[2]);
+                return Self::parse_color(parts[2]);
             }
         }
 
-        self.parse_color("black")
+        Self::parse_color("black")
     }
 
     pub(super) fn parse_border_radius(
-        &self,
         style: &rustc_hash::FxHashMap<String, String>,
     ) -> BorderRadius {
         if let Some(radius_str) = style.get("borderRadius")

--- a/crates/rari/src/server/og/rendering/image.rs
+++ b/crates/rari/src/server/og/rendering/image.rs
@@ -6,8 +6,6 @@ use reqwest::blocking::Client;
 use super::{super::layout::ComputedLayout, border::BorderRadius, renderer::ImageRenderer};
 use crate::utils::{cast, float};
 
-const MAX_IMAGE_SIZE: usize = 10 * 1024 * 1024;
-
 impl ImageRenderer {
     pub(super) fn render_image(
         &self,
@@ -269,11 +267,11 @@ impl ImageRenderer {
 
         let mut buffer = Vec::new();
         response
-            .take((MAX_IMAGE_SIZE + 1) as u64)
+            .take((super::super::MAX_OG_IMAGE_BYTES + 1) as u64)
             .read_to_end(&mut buffer)
             .map_err(|e| format!("Failed to read image data: {e}"))?;
 
-        if buffer.len() > MAX_IMAGE_SIZE {
+        if buffer.len() > super::super::MAX_OG_IMAGE_BYTES {
             return Err("Image too large (max 10MB)".to_string());
         }
 

--- a/crates/rari/src/server/og/rendering/image.rs
+++ b/crates/rari/src/server/og/rendering/image.rs
@@ -4,10 +4,13 @@ use image::{RgbaImage, imageops};
 use reqwest::blocking::Client;
 
 use super::{super::layout::ComputedLayout, border::BorderRadius, renderer::ImageRenderer};
+use crate::utils::{cast, float};
+
+const MAX_IMAGE_SIZE: usize = 10 * 1024 * 1024;
 
 impl ImageRenderer {
     pub(super) fn render_image(
-        &mut self,
+        &self,
         layout: &ComputedLayout,
         canvas: &mut RgbaImage,
     ) -> Result<(), String> {
@@ -18,20 +21,20 @@ impl ImageRenderer {
             .and_then(|v| v.as_str())
             .ok_or("Image element missing src attribute")?;
 
-        let source_image = self.load_image(src)?;
+        let source_image = Self::load_image(src)?;
 
         let object_fit = layout.style.get("objectFit").map(String::as_str).unwrap_or("fill");
 
-        let border_radius = self.parse_border_radius(&layout.style);
+        let border_radius = Self::parse_border_radius(&layout.style);
 
-        let target_width = layout.width as u32;
-        let target_height = layout.height as u32;
+        let target_width = cast::f32_to_u32(layout.width);
+        let target_height = cast::f32_to_u32(layout.height);
 
         let (processed_image, offset_x, offset_y) =
-            self.process_object_fit(source_image, target_width, target_height, object_fit)?;
+            Self::process_object_fit(source_image, target_width, target_height, object_fit)?;
 
-        let x_start = layout.x as u32 + offset_x;
-        let y_start = layout.y as u32 + offset_y;
+        let x_start = cast::f32_to_u32(layout.x) + offset_x;
+        let y_start = cast::f32_to_u32(layout.y) + offset_y;
 
         if border_radius.top_left > 0.0
             || border_radius.top_right > 0.0
@@ -52,7 +55,7 @@ impl ImageRenderer {
 
                 if canvas_x < self.width && canvas_y < self.height {
                     let bg = canvas.get_pixel(canvas_x, canvas_y);
-                    let blended = self.alpha_blend(*bg, *pixel);
+                    let blended = Self::alpha_blend(*bg, *pixel);
                     canvas.put_pixel(canvas_x, canvas_y, blended);
                 }
             }
@@ -62,22 +65,21 @@ impl ImageRenderer {
     }
 
     fn process_object_fit(
-        &self,
         source_image: RgbaImage,
         target_width: u32,
         target_height: u32,
         object_fit: &str,
     ) -> Result<(RgbaImage, u32, u32), String> {
-        let src_width = source_image.width() as f32;
-        let src_height = source_image.height() as f32;
-        let target_w = target_width as f32;
-        let target_h = target_height as f32;
+        let src_width = float::u32_to_f32(source_image.width());
+        let src_height = float::u32_to_f32(source_image.height());
+        let target_w = float::u32_to_f32(target_width);
+        let target_h = float::u32_to_f32(target_height);
 
         match object_fit {
             "contain" => {
                 let scale = (target_w / src_width).min(target_h / src_height);
-                let new_width = (src_width * scale) as u32;
-                let new_height = (src_height * scale) as u32;
+                let new_width = cast::f32_to_u32(src_width * scale);
+                let new_height = cast::f32_to_u32(src_height * scale);
 
                 let resized = imageops::resize(
                     &source_image,
@@ -93,8 +95,8 @@ impl ImageRenderer {
             }
             "cover" => {
                 let scale = (target_w / src_width).max(target_h / src_height);
-                let new_width = (src_width * scale) as u32;
-                let new_height = (src_height * scale) as u32;
+                let new_width = cast::f32_to_u32(src_width * scale);
+                let new_height = cast::f32_to_u32(src_height * scale);
 
                 let resized = imageops::resize(
                     &source_image,
@@ -114,8 +116,8 @@ impl ImageRenderer {
             }
             "scale-down" => {
                 let scale = (target_w / src_width).min(target_h / src_height).min(1.0);
-                let new_width = (src_width * scale) as u32;
-                let new_height = (src_height * scale) as u32;
+                let new_width = cast::f32_to_u32(src_width * scale);
+                let new_height = cast::f32_to_u32(src_height * scale);
 
                 let resized = if scale < 1.0 {
                     imageops::resize(
@@ -134,25 +136,31 @@ impl ImageRenderer {
                 Ok((resized, offset_x, offset_y))
             }
             "none" => {
-                let offset_x =
-                    if src_width < target_w { ((target_w - src_width) / 2.0) as u32 } else { 0 };
-                let offset_y =
-                    if src_height < target_h { ((target_h - src_height) / 2.0) as u32 } else { 0 };
+                let offset_x = if src_width < target_w {
+                    cast::f32_to_u32((target_w - src_width) / 2.0)
+                } else {
+                    0
+                };
+                let offset_y = if src_height < target_h {
+                    cast::f32_to_u32((target_h - src_height) / 2.0)
+                } else {
+                    0
+                };
 
                 if src_width > target_w || src_height > target_h {
                     let crop_x = if src_width > target_w {
-                        ((src_width - target_w) / 2.0) as u32
+                        cast::f32_to_u32((src_width - target_w) / 2.0)
                     } else {
                         0
                     };
                     let crop_y = if src_height > target_h {
-                        ((src_height - target_h) / 2.0) as u32
+                        cast::f32_to_u32((src_height - target_h) / 2.0)
                     } else {
                         0
                     };
 
-                    let crop_width = src_width.min(target_w) as u32;
-                    let crop_height = src_height.min(target_h) as u32;
+                    let crop_width = cast::f32_to_u32(src_width.min(target_w));
+                    let crop_height = cast::f32_to_u32(src_height.min(target_h));
 
                     let cropped =
                         imageops::crop_imm(&source_image, crop_x, crop_y, crop_width, crop_height)
@@ -190,8 +198,8 @@ impl ImageRenderer {
         y_start: u32,
         radius: BorderRadius,
     ) {
-        let img_width = image.width() as f32;
-        let img_height = image.height() as f32;
+        let img_width = float::u32_to_f32(image.width());
+        let img_height = float::u32_to_f32(image.height());
 
         for (x, y, pixel) in image.enumerate_pixels() {
             let canvas_x = x_start + x;
@@ -201,8 +209,8 @@ impl ImageRenderer {
                 continue;
             }
 
-            let fx = x as f32;
-            let fy = y as f32;
+            let fx = float::u32_to_f32(x);
+            let fy = float::u32_to_f32(y);
 
             let in_corner = if fx < radius.top_left && fy < radius.top_left {
                 let dx = radius.top_left - fx;
@@ -228,23 +236,23 @@ impl ImageRenderer {
 
             if in_corner {
                 let bg = canvas.get_pixel(canvas_x, canvas_y);
-                let blended = self.alpha_blend(*bg, *pixel);
+                let blended = Self::alpha_blend(*bg, *pixel);
                 canvas.put_pixel(canvas_x, canvas_y, blended);
             }
         }
     }
 
-    fn load_image(&self, src: &str) -> Result<RgbaImage, String> {
+    fn load_image(src: &str) -> Result<RgbaImage, String> {
         if src.starts_with("http://") || src.starts_with("https://") {
-            self.load_remote_image(src)
+            Self::load_remote_image(src)
         } else if src.starts_with("data:") {
-            self.load_data_url(src)
+            Self::load_data_url(src)
         } else {
             Ok(image::open(src).map_err(|e| format!("Failed to load image {src}: {e}"))?.to_rgba8())
         }
     }
 
-    fn load_remote_image(&self, url: &str) -> Result<RgbaImage, String> {
+    fn load_remote_image(url: &str) -> Result<RgbaImage, String> {
         use std::io::Read;
 
         let client = Client::builder()
@@ -259,7 +267,6 @@ impl ImageRenderer {
             return Err(format!("Failed to fetch image: HTTP {}", response.status()));
         }
 
-        const MAX_IMAGE_SIZE: usize = 10 * 1024 * 1024;
         let mut buffer = Vec::new();
         response
             .take((MAX_IMAGE_SIZE + 1) as u64)
@@ -275,7 +282,7 @@ impl ImageRenderer {
             .to_rgba8())
     }
 
-    fn load_data_url(&self, data_url: &str) -> Result<RgbaImage, String> {
+    fn load_data_url(data_url: &str) -> Result<RgbaImage, String> {
         let parts: Vec<&str> = data_url.splitn(2, ',').collect();
         if parts.len() != 2 {
             return Err("Invalid data URL format".to_string());

--- a/crates/rari/src/server/og/rendering/mask.rs
+++ b/crates/rari/src/server/og/rendering/mask.rs
@@ -3,6 +3,9 @@ use std::f32::consts::SQRT_2;
 use zeno::{Command, Mask, PathBuilder, Placement, Scratch, Style};
 
 use super::border::BorderRadius;
+use crate::utils::cast;
+
+const KAPPA: f32 = 4.0 / 3.0 * (SQRT_2 - 1.0);
 
 #[derive(Default)]
 pub(super) struct MaskMemory {
@@ -28,7 +31,8 @@ impl MaskMemory {
         bounds.max = bounds.max.ceil();
 
         self.buffer.clear();
-        self.buffer.resize((bounds.width() as usize) * (bounds.height() as usize), 0);
+        self.buffer
+            .resize(cast::f32_to_usize(bounds.width()) * cast::f32_to_usize(bounds.height()), 0);
 
         let placement = Mask::with_scratch(paths, &mut self.scratch)
             .style(style)
@@ -46,8 +50,6 @@ pub(super) fn build_rounded_rect_path(
     offset_y: f32,
 ) -> Vec<Command> {
     let mut path = Vec::with_capacity(10);
-
-    const KAPPA: f32 = 4.0 / 3.0 * (SQRT_2 - 1.0);
 
     let scale = 1.0f32
         .min(if radius.top_left + radius.top_right > width {

--- a/crates/rari/src/server/og/rendering/renderer.rs
+++ b/crates/rari/src/server/og/rendering/renderer.rs
@@ -7,6 +7,7 @@ use super::{
     super::{layout::ComputedLayout, resources::fonts::FontContext, types::JsxChild},
     mask::MaskMemory,
 };
+use crate::utils::cast;
 
 pub struct ImageRenderer {
     pub(super) width: u32,
@@ -56,7 +57,7 @@ impl ImageRenderer {
                 self.render_svg(layout, image)?;
             }
             _ => {
-                if self.has_text_content(&layout.element) {
+                if Self::has_text_content(&layout.element) {
                     self.render_text(layout, image)?;
                 }
             }
@@ -71,23 +72,23 @@ impl ImageRenderer {
         Ok(())
     }
 
-    pub(super) fn alpha_blend(&self, bg: Rgba<u8>, fg: Rgba<u8>) -> Rgba<u8> {
+    pub(super) fn alpha_blend(bg: Rgba<u8>, fg: Rgba<u8>) -> Rgba<u8> {
         let alpha = f32::from(fg[3]) / 255.0;
         let inv_alpha = 1.0 - alpha;
 
         Rgba([
-            ((f32::from(fg[0]) * alpha + f32::from(bg[0]) * inv_alpha) as u8),
-            ((f32::from(fg[1]) * alpha + f32::from(bg[1]) * inv_alpha) as u8),
-            ((f32::from(fg[2]) * alpha + f32::from(bg[2]) * inv_alpha) as u8),
+            cast::f32_to_u8(f32::from(fg[0]) * alpha + f32::from(bg[0]) * inv_alpha),
+            cast::f32_to_u8(f32::from(fg[1]) * alpha + f32::from(bg[1]) * inv_alpha),
+            cast::f32_to_u8(f32::from(fg[2]) * alpha + f32::from(bg[2]) * inv_alpha),
             255,
         ])
     }
 
-    fn has_text_content(&self, element: &super::super::types::JsxElement) -> bool {
+    fn has_text_content(element: &super::super::types::JsxElement) -> bool {
         element.children.iter().any(|child| matches!(child, JsxChild::Text(_)))
     }
 
-    pub(super) fn parse_font_weight(&self, style: &FxHashMap<String, String>) -> u16 {
+    pub(super) fn parse_font_weight(style: &FxHashMap<String, String>) -> u16 {
         style
             .get("fontWeight")
             .and_then(|w| match w.as_str() {
@@ -105,7 +106,7 @@ impl ImageRenderer {
             .unwrap_or(400)
     }
 
-    pub(super) fn parse_color(&self, color_str: &str) -> Rgba<u8> {
+    pub(super) fn parse_color(color_str: &str) -> Rgba<u8> {
         match color_str {
             "black" => Rgba([0, 0, 0, 255]),
             "white" => Rgba([255, 255, 255, 255]),

--- a/crates/rari/src/server/og/rendering/svg.rs
+++ b/crates/rari/src/server/og/rendering/svg.rs
@@ -12,6 +12,7 @@ use super::{
     },
     renderer::ImageRenderer,
 };
+use crate::utils::{cast, float};
 
 const SVG_ELEMENTS: &[&str] = &[
     "svg",
@@ -46,12 +47,12 @@ pub fn is_svg_element(element_type: &str) -> bool {
 
 impl ImageRenderer {
     pub(super) fn render_svg(
-        &mut self,
+        &self,
         layout: &ComputedLayout,
         image: &mut RgbaImage,
     ) -> Result<(), String> {
-        let width = layout.width.round() as u32;
-        let height = layout.height.round() as u32;
+        let width = cast::f32_to_u32(layout.width.round());
+        let height = cast::f32_to_u32(layout.height.round());
 
         if width == 0 || height == 0 {
             return Ok(());
@@ -60,13 +61,14 @@ impl ImageRenderer {
         let svg_string = jsx_to_svg_string(&layout.element);
 
         let options = Options {
-            default_size: Size::from_wh(width as f32, height as f32).unwrap_or_else(|| {
-                #[expect(
-                    clippy::expect_used,
-                    reason = "Hardcoded size (100x100) is guaranteed valid"
-                )]
-                Size::from_wh(100.0, 100.0).expect("hardcoded fallback size is always valid")
-            }),
+            default_size: Size::from_wh(float::u32_to_f32(width), float::u32_to_f32(height))
+                .unwrap_or_else(|| {
+                    #[expect(
+                        clippy::expect_used,
+                        reason = "Hardcoded size (100x100) is guaranteed valid"
+                    )]
+                    Size::from_wh(100.0, 100.0).expect("hardcoded fallback size is always valid")
+                }),
             ..Default::default()
         };
 
@@ -76,14 +78,14 @@ impl ImageRenderer {
         let mut pixmap = Pixmap::new(width, height).ok_or("Failed to create pixmap")?;
 
         let svg_size = tree.size();
-        let scale_x = width as f32 / svg_size.width();
-        let scale_y = height as f32 / svg_size.height();
+        let scale_x = float::u32_to_f32(width) / svg_size.width();
+        let scale_y = float::u32_to_f32(height) / svg_size.height();
         let transform = Transform::from_scale(scale_x, scale_y);
 
         resvg::render(&tree, transform, &mut pixmap.as_mut());
 
-        let x_start = layout.x.round() as u32;
-        let y_start = layout.y.round() as u32;
+        let x_start = cast::f32_to_u32(layout.x.round());
+        let y_start = cast::f32_to_u32(layout.y.round());
         let data = pixmap.data();
 
         for py in 0..height {
@@ -102,9 +104,9 @@ impl ImageRenderer {
                 } else {
                     let af = f32::from(a) / 255.0;
                     (
-                        (f32::from(data[idx]) / af).min(255.0) as u8,
-                        (f32::from(data[idx + 1]) / af).min(255.0) as u8,
-                        (f32::from(data[idx + 2]) / af).min(255.0) as u8,
+                        cast::f32_to_u8((f32::from(data[idx]) / af).min(255.0)),
+                        cast::f32_to_u8((f32::from(data[idx + 1]) / af).min(255.0)),
+                        cast::f32_to_u8((f32::from(data[idx + 2]) / af).min(255.0)),
                     )
                 };
 
@@ -113,7 +115,7 @@ impl ImageRenderer {
                 if canvas_x < self.width && canvas_y < self.height {
                     let bg = image.get_pixel(canvas_x, canvas_y);
                     let fg = Rgba([r, g, b, a]);
-                    let blended = self.alpha_blend(*bg, fg);
+                    let blended = Self::alpha_blend(*bg, fg);
                     image.put_pixel(canvas_x, canvas_y, blended);
                 }
             }

--- a/crates/rari/src/server/og/rendering/text.rs
+++ b/crates/rari/src/server/og/rendering/text.rs
@@ -16,6 +16,7 @@ use super::{
     super::{layout::ComputedLayout, types::JsxChild},
     renderer::ImageRenderer,
 };
+use crate::utils::{cast, float};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum TextDecoration {
@@ -42,7 +43,7 @@ impl ImageRenderer {
         layout: &ComputedLayout,
         image: &mut RgbaImage,
     ) -> Result<(), String> {
-        let text = self.extract_text(&layout.element);
+        let text = Self::extract_text(&layout.element);
         if text.is_empty() {
             return Ok(());
         }
@@ -51,15 +52,15 @@ impl ImageRenderer {
             layout.style.get("fontSize").and_then(|s| s.parse::<f32>().ok()).unwrap_or(16.0);
 
         let color =
-            layout.style.get("color").map(|c| self.parse_color(c)).unwrap_or(Rgba([0, 0, 0, 255]));
+            layout.style.get("color").map(|c| Self::parse_color(c)).unwrap_or(Rgba([0, 0, 0, 255]));
 
-        let font_weight = self.parse_font_weight(&layout.style);
+        let font_weight = Self::parse_font_weight(&layout.style);
 
-        let line_height = self.parse_line_height(&layout.style, font_size);
+        let line_height = Self::parse_line_height(&layout.style, font_size);
 
-        let text_align = self.parse_text_align(&layout.style);
+        let text_align = Self::parse_text_align(&layout.style);
 
-        let text_decoration = self.parse_text_decoration(&layout.style);
+        let text_decoration = Self::parse_text_decoration(&layout.style);
 
         let params = GlyphRenderParams {
             x: layout.x + layout.border.left + layout.padding.left,
@@ -84,7 +85,7 @@ impl ImageRenderer {
         Ok(())
     }
 
-    fn extract_text(&self, element: &super::super::types::JsxElement) -> String {
+    fn extract_text(element: &super::super::types::JsxElement) -> String {
         element
             .children
             .iter()
@@ -96,11 +97,7 @@ impl ImageRenderer {
             .join("")
     }
 
-    fn parse_line_height(
-        &self,
-        style: &rustc_hash::FxHashMap<String, String>,
-        font_size: f32,
-    ) -> f32 {
+    fn parse_line_height(style: &rustc_hash::FxHashMap<String, String>, font_size: f32) -> f32 {
         if let Some(lh) = style.get("lineHeight") {
             if let Ok(multiplier) = lh.parse::<f32>() {
                 return font_size * multiplier;
@@ -132,7 +129,7 @@ impl ImageRenderer {
         font_size * 1.2
     }
 
-    fn parse_text_align(&self, style: &rustc_hash::FxHashMap<String, String>) -> Alignment {
+    fn parse_text_align(style: &rustc_hash::FxHashMap<String, String>) -> Alignment {
         style
             .get("textAlign")
             .map(|ta| {
@@ -151,10 +148,7 @@ impl ImageRenderer {
             .unwrap_or(Alignment::Start)
     }
 
-    fn parse_text_decoration(
-        &self,
-        style: &rustc_hash::FxHashMap<String, String>,
-    ) -> Vec<TextDecoration> {
+    fn parse_text_decoration(style: &rustc_hash::FxHashMap<String, String>) -> Vec<TextDecoration> {
         let mut decorations = Vec::new();
 
         if let Some(td) = style.get("textDecoration") {
@@ -247,12 +241,14 @@ impl ImageRenderer {
                     let glyph_y = params.y + glyph.y;
 
                     if let Some(bitmap) =
-                        scaler.scale_color_bitmap(glyph.id as u16, StrikeWith::BestFit)
+                        scaler.scale_color_bitmap(cast::u32_to_u16(glyph.id), StrikeWith::BestFit)
                     {
                         self.draw_color_bitmap(&bitmap, glyph_x, glyph_y, image);
-                    } else if let Some(outline) = scaler.scale_color_outline(glyph.id as u16) {
+                    } else if let Some(outline) =
+                        scaler.scale_color_outline(cast::u32_to_u16(glyph.id))
+                    {
                         self.draw_color_outline(&outline, glyph_x, glyph_y, palette, image)?;
-                    } else if let Some(outline) = scaler.scale_outline(glyph.id as u16) {
+                    } else if let Some(outline) = scaler.scale_outline(cast::u32_to_u16(glyph.id)) {
                         self.draw_outline(&outline, glyph_x, glyph_y, params.color, image)?;
                     }
                 }
@@ -319,16 +315,16 @@ impl ImageRenderer {
         color: Rgba<u8>,
         image: &mut RgbaImage,
     ) {
-        let x_start = x.max(0.0) as u32;
-        let x_end = ((x + width) as u32).min(self.width);
-        let y_start = y.max(0.0) as u32;
-        let y_end = ((y + thickness) as u32).min(self.height);
+        let x_start = cast::f32_to_u32(x.max(0.0));
+        let x_end = cast::f32_to_u32(x + width).min(self.width);
+        let y_start = cast::f32_to_u32(y.max(0.0));
+        let y_end = cast::f32_to_u32(y + thickness).min(self.height);
 
         for py in y_start..y_end {
             for px in x_start..x_end {
                 if px < self.width && py < self.height {
                     let bg = image.get_pixel(px, py);
-                    let blended = self.alpha_blend(*bg, color);
+                    let blended = Self::alpha_blend(*bg, color);
                     image.put_pixel(px, py, blended);
                 }
             }
@@ -341,22 +337,30 @@ impl ImageRenderer {
 
         for row in 0..placement.height {
             for col in 0..placement.width {
-                let pixel_x = (x + placement.left as f32 + col as f32) as i32;
-                let pixel_y = (y - placement.top as f32 + row as f32) as i32;
+                let pixel_x = cast::f32_to_i32(
+                    x + float::i32_to_f32(placement.left) + float::u32_to_f32(col),
+                );
+                let pixel_y =
+                    cast::f32_to_i32(y - float::i32_to_f32(placement.top) + float::u32_to_f32(row));
 
                 if pixel_x >= 0
-                    && pixel_x < self.width as i32
+                    && pixel_x < self.width.cast_signed()
                     && pixel_y >= 0
-                    && pixel_y < self.height as i32
+                    && pixel_y < self.height.cast_signed()
                 {
                     let idx = ((row * placement.width + col) * 4) as usize;
                     if idx + 3 < data.len() {
                         let pixel = Rgba([data[idx], data[idx + 1], data[idx + 2], data[idx + 3]]);
 
                         if pixel[3] > 0 {
-                            let bg = image.get_pixel(pixel_x as u32, pixel_y as u32);
-                            let blended = self.alpha_blend(*bg, pixel);
-                            image.put_pixel(pixel_x as u32, pixel_y as u32, blended);
+                            let bg =
+                                image.get_pixel(pixel_x.cast_unsigned(), pixel_y.cast_unsigned());
+                            let blended = Self::alpha_blend(*bg, pixel);
+                            image.put_pixel(
+                                pixel_x.cast_unsigned(),
+                                pixel_y.cast_unsigned(),
+                                blended,
+                            );
                         }
                     }
                 }
@@ -462,23 +466,28 @@ impl ImageRenderer {
 
         for row in 0..placement.height {
             for col in 0..placement.width {
-                let mask_x = placement.left + col as i32;
-                let mask_y = placement.top + row as i32;
+                let mask_x = placement.left + col.cast_signed();
+                let mask_y = placement.top + row.cast_signed();
 
                 if mask_x >= 0
-                    && mask_x < self.width as i32
+                    && mask_x < self.width.cast_signed()
                     && mask_y >= 0
-                    && mask_y < self.height as i32
+                    && mask_y < self.height.cast_signed()
                 {
                     let idx = (row * placement.width + col) as usize;
                     if idx < buffer.len() {
                         let alpha = buffer[idx];
 
                         if alpha > 0 {
-                            let bg = image.get_pixel(mask_x as u32, mask_y as u32);
+                            let bg =
+                                image.get_pixel(mask_x.cast_unsigned(), mask_y.cast_unsigned());
                             let fg = Rgba([color[0], color[1], color[2], alpha]);
-                            let blended = self.alpha_blend(*bg, fg);
-                            image.put_pixel(mask_x as u32, mask_y as u32, blended);
+                            let blended = Self::alpha_blend(*bg, fg);
+                            image.put_pixel(
+                                mask_x.cast_unsigned(),
+                                mask_y.cast_unsigned(),
+                                blended,
+                            );
                         }
                     }
                 }

--- a/crates/rari/src/server/og/resources/fonts.rs
+++ b/crates/rari/src/server/og/resources/fonts.rs
@@ -130,6 +130,7 @@ mod tests {
     use swash::scale::StrikeWith::BestFit;
 
     use super::*;
+    use crate::utils::cast;
 
     #[test]
     fn test_font_context_creation() {
@@ -209,18 +210,24 @@ mod tests {
                     for glyph in gr.positioned_glyphs() {
                         println!("Glyph ID: {}", glyph.id);
 
-                        if let Some(bitmap) = scaler.scale_color_bitmap(glyph.id as u16, BestFit) {
+                        if let Some(bitmap) =
+                            scaler.scale_color_bitmap(cast::u32_to_u16(glyph.id), BestFit)
+                        {
                             println!(
                                 "  -> Color bitmap: {}x{}",
                                 bitmap.placement.width, bitmap.placement.height
                             );
-                        } else if let Some(outline) = scaler.scale_color_outline(glyph.id as u16) {
+                        } else if let Some(outline) =
+                            scaler.scale_color_outline(cast::u32_to_u16(glyph.id))
+                        {
                             println!(
                                 "  -> Color outline with {} layers, is_color: {}",
                                 outline.len(),
                                 outline.is_color()
                             );
-                        } else if let Some(_outline) = scaler.scale_outline(glyph.id as u16) {
+                        } else if let Some(_outline) =
+                            scaler.scale_outline(cast::u32_to_u16(glyph.id))
+                        {
                             println!("  -> Regular outline");
                         } else {
                             println!("  -> NO GLYPH DATA!");

--- a/crates/rari/src/server/rendering/metadata.rs
+++ b/crates/rari/src/server/rendering/metadata.rs
@@ -3,9 +3,8 @@ use serde_json::{Map, Value};
 
 pub fn merge_metadata(parent: &Value, child: &Value) -> Value {
     let parent_obj = parent.as_object();
-    let child_obj = match child.as_object() {
-        Some(obj) => obj,
-        None => return parent.clone(),
+    let Some(child_obj) = child.as_object() else {
+        return parent.clone();
     };
 
     let mut merged = parent_obj.cloned().unwrap_or_default();

--- a/crates/rari/src/server/rendering/utils.rs
+++ b/crates/rari/src/server/rendering/utils.rs
@@ -235,15 +235,12 @@ async fn inject_assets_into_complete_document(
 
     let template_path = if config.is_development() { "index.html" } else { "dist/index.html" };
 
-    let template = match fs::read_to_string(template_path).await {
-        Ok(t) => t,
-        Err(_) => {
-            let trimmed_lower = html.trim_start().cow_to_lowercase();
-            if trimmed_lower.starts_with("<!doctype") {
-                return Ok(html.to_string());
-            }
-            return Ok(format!("<!DOCTYPE html>\n{html}"));
+    let Ok(template) = fs::read_to_string(template_path).await else {
+        let trimmed_lower = html.trim_start().cow_to_lowercase();
+        if trimmed_lower.starts_with("<!doctype") {
+            return Ok(html.to_string());
         }
+        return Ok(format!("<!DOCTYPE html>\n{html}"));
     };
 
     let mut asset_tags = Vec::new();
@@ -444,11 +441,9 @@ async fn inject_content_into_template(
 ) -> Result<String, StatusCode> {
     let template_path = if config.is_development() { "index.html" } else { "dist/index.html" };
 
-    let template = match fs::read_to_string(template_path).await {
-        Ok(t) => t,
-        Err(_) => {
-            return Ok(format!(
-                r#"<!DOCTYPE html>
+    let Ok(template) = fs::read_to_string(template_path).await else {
+        return Ok(format!(
+            r#"<!DOCTYPE html>
 <html>
 <head>
   <meta charset="UTF-8" />
@@ -458,8 +453,7 @@ async fn inject_content_into_template(
   <div id="root">{content}</div>
 </body>
 </html>"#
-            ));
-        }
+        ));
     };
 
     let final_html = if let Some(root_start) = template.find(r#"<div id="root""#) {

--- a/crates/rari/src/server/rendering/utils.rs
+++ b/crates/rari/src/server/rendering/utils.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::needless_continue)]
-
 use std::fmt::Write;
 
 use axum::http::StatusCode;
@@ -169,7 +167,6 @@ pub async fn extract_body_scripts_from_index_html() -> Option<String> {
                     if trimmed.contains("</script>") {
                         in_inline_script = false;
                     }
-                    continue;
                 }
             }
 

--- a/crates/rari/src/server/routing/api_routes.rs
+++ b/crates/rari/src/server/routing/api_routes.rs
@@ -128,7 +128,7 @@ impl ApiRouteHandler {
         let normalized_path = Self::normalize_path(path);
 
         for route in &self.manifest.api_routes {
-            if self.match_route_pattern(route, &normalized_path).is_some() {
+            if Self::match_route_pattern(route, &normalized_path).is_some() {
                 return Some(route.methods.clone());
             }
         }
@@ -140,7 +140,7 @@ impl ApiRouteHandler {
         let normalized_path = Self::normalize_path(path);
 
         for route in &self.manifest.api_routes {
-            if let Some(params) = self.match_route_pattern(route, &normalized_path) {
+            if let Some(params) = Self::match_route_pattern(route, &normalized_path) {
                 if !route.methods.iter().any(|m| m.eq_ignore_ascii_case(method)) {
                     return Err(RariError::bad_request(format!(
                         "Method {} not allowed for route {}. Supported methods: {}",
@@ -163,11 +163,7 @@ impl ApiRouteHandler {
         Err(RariError::not_found(format!("No API route found for path: {path}")))
     }
 
-    fn match_route_pattern(
-        &self,
-        route: &ApiRouteEntry,
-        path: &str,
-    ) -> Option<FxHashMap<String, String>> {
+    fn match_route_pattern(route: &ApiRouteEntry, path: &str) -> Option<FxHashMap<String, String>> {
         let route_segments = route.path.split('/').filter(|s| !s.is_empty()).collect::<Vec<_>>();
         let path_segments = parse_decoded_path_segments(path);
 
@@ -416,7 +412,7 @@ impl ApiRouteHandler {
 
         let body_string = String::from_utf8_lossy(&body_bytes).to_string();
 
-        let request_obj = self.create_request_object(
+        let request_obj = Self::create_request_object(
             parts.method.as_ref(),
             &parts.uri.to_string(),
             &parts.headers,
@@ -517,7 +513,7 @@ impl ApiRouteHandler {
                         RariError::js_execution(format!("Handler execution failed: {e}"))
                     })?;
 
-                let response = self.create_response(result).await.map_err(|e| {
+                let response = Self::create_response(&result).map_err(|e| {
                     error!(
                         route_path = %route_match.route.path,
                         method = %route_match.method,
@@ -533,7 +529,6 @@ impl ApiRouteHandler {
     }
     #[expect(clippy::unnecessary_wraps, reason = "Result return type maintains API consistency")]
     fn create_request_object(
-        &self,
         method: &str,
         uri: &str,
         headers: &HeaderMap,
@@ -584,8 +579,7 @@ impl ApiRouteHandler {
             .map_err(|e| RariError::js_execution(format!("Failed to execute handler: {e}")))
     }
 
-    #[expect(clippy::unused_async_trait_impl, reason = "Async required by trait implementation")]
-    async fn create_response(&self, result: Value) -> Result<Response<Body>, RariError> {
+    fn create_response(result: &Value) -> Result<Response<Body>, RariError> {
         let is_http_envelope = if let Some(status_val) = result.get("status") {
             if let Some(status_num) = status_val.as_u64() {
                 (100..=599).contains(&status_num)
@@ -643,10 +637,6 @@ mod tests {
 
     #[test]
     fn test_create_request_object_basic() {
-        let runtime = Arc::new(JsExecutionRuntime::default());
-        let manifest = ApiRouteManifest { api_routes: vec![] };
-        let handler = ApiRouteHandler::new(runtime, manifest);
-
         let mut headers = HeaderMap::new();
         headers.insert("content-type", HeaderValue::from_static("application/json"));
         headers.insert("user-agent", HeaderValue::from_static("test-agent"));
@@ -654,7 +644,8 @@ mod tests {
         let params = FxHashMap::default();
 
         let result =
-            handler.create_request_object("GET", "/api/test", &headers, "", &params).unwrap();
+            ApiRouteHandler::create_request_object("GET", "/api/test", &headers, "", &params)
+                .unwrap();
 
         assert_eq!(result["method"], "GET");
         assert_eq!(result["url"], "/api/test");
@@ -664,17 +655,14 @@ mod tests {
 
     #[test]
     fn test_create_request_object_with_params() {
-        let runtime = Arc::new(JsExecutionRuntime::default());
-        let manifest = ApiRouteManifest { api_routes: vec![] };
-        let handler = ApiRouteHandler::new(runtime, manifest);
-
         let headers = HeaderMap::new();
         let mut params = FxHashMap::default();
         params.insert("id".to_string(), "123".to_string());
         params.insert("name".to_string(), "test".to_string());
 
         let result =
-            handler.create_request_object("GET", "/api/users/123", &headers, "", &params).unwrap();
+            ApiRouteHandler::create_request_object("GET", "/api/users/123", &headers, "", &params)
+                .unwrap();
 
         assert_eq!(result["params"]["id"], "123");
         assert_eq!(result["params"]["name"], "test");
@@ -682,10 +670,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_response_with_status() {
-        let runtime = Arc::new(JsExecutionRuntime::default());
-        let manifest = ApiRouteManifest { api_routes: vec![] };
-        let handler = ApiRouteHandler::new(runtime, manifest);
-
         let response_json = json!({
             "status": 201,
             "headers": {
@@ -695,7 +679,7 @@ mod tests {
             "body": r#"{"success":true}"#
         });
 
-        let response = handler.create_response(response_json).await.unwrap();
+        let response = ApiRouteHandler::create_response(&response_json).unwrap();
 
         assert_eq!(response.status(), StatusCode::CREATED);
         assert_eq!(response.headers().get("content-type").unwrap(), "application/json");
@@ -704,16 +688,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_response_plain_json() {
-        let runtime = Arc::new(JsExecutionRuntime::default());
-        let manifest = ApiRouteManifest { api_routes: vec![] };
-        let handler = ApiRouteHandler::new(runtime, manifest);
-
         let plain_json = json!({
             "message": "Hello",
             "count": 42
         });
 
-        let response = handler.create_response(plain_json).await.unwrap();
+        let response = ApiRouteHandler::create_response(&plain_json).unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.headers().get("content-type").unwrap(), "application/json");

--- a/crates/rari/src/server/routing/api_routes.rs
+++ b/crates/rari/src/server/routing/api_routes.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::unused_async_trait_impl)]
-
 use std::{
     path::{Path, PathBuf},
     sync::Arc,

--- a/crates/rari/src/server/routing/app_router.rs
+++ b/crates/rari/src/server/routing/app_router.rs
@@ -162,7 +162,7 @@ impl AppRouter {
         let normalized_path = Self::normalize_path(path);
 
         for route in &self.manifest.routes {
-            if let Some(params) = self.match_route_pattern(route, &normalized_path) {
+            if let Some(params) = Self::match_route_pattern(route, &normalized_path) {
                 let layouts = self.resolve_layouts_for_route(route);
                 let templates = self.resolve_templates_for_route(route);
 
@@ -220,7 +220,6 @@ impl AppRouter {
     }
 
     fn match_route_pattern(
-        &self,
         route: &AppRouteEntry,
         path: &str,
     ) -> Option<FxHashMap<String, ParamValue>> {
@@ -578,7 +577,7 @@ impl AppRouter {
                 paths.push(route.path.clone());
             } else if let Some(ref static_params) = route.static_params {
                 for params in static_params {
-                    let concrete_path = self.expand_route_path(&route.path, params);
+                    let concrete_path = Self::expand_route_path(&route.path, params);
                     if let Some(p) = concrete_path {
                         paths.push(p);
                     }
@@ -590,7 +589,6 @@ impl AppRouter {
     }
 
     fn expand_route_path(
-        &self,
         route_path: &str,
         params: &FxHashMap<String, serde_json::Value>,
     ) -> Option<String> {

--- a/crates/rari/src/server/vite.rs
+++ b/crates/rari/src/server/vite.rs
@@ -34,15 +34,12 @@ fn create_client() -> Client {
 }
 
 pub async fn vite_src_proxy(req: Request) -> impl IntoResponse {
-    let config = match Config::get() {
-        Some(config) => config,
-        None => {
-            error!("Failed to get global configuration for Vite proxy");
-            return create_error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Configuration not available",
-            );
-        }
+    let Some(config) = Config::get() else {
+        error!("Failed to get global configuration for Vite proxy");
+        return create_error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Configuration not available",
+        );
     };
 
     let client = create_client();
@@ -114,15 +111,12 @@ pub async fn vite_src_proxy(req: Request) -> impl IntoResponse {
 }
 
 pub async fn vite_reverse_proxy(req: Request) -> impl IntoResponse {
-    let config = match Config::get() {
-        Some(config) => config,
-        None => {
-            error!("Failed to get global configuration for Vite proxy");
-            return create_error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Configuration not available",
-            );
-        }
+    let Some(config) = Config::get() else {
+        error!("Failed to get global configuration for Vite proxy");
+        return create_error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Configuration not available",
+        );
     };
 
     let client = create_client();
@@ -203,13 +197,10 @@ async fn handle_websocket(mut client_socket: WebSocket, uri: Uri) {
         return;
     }
 
-    let config = match Config::get() {
-        Some(config) => config,
-        None => {
-            error!("Failed to get global configuration for WebSocket proxy");
-            let _ = client_socket.send(WsMessage::Close(None)).await;
-            return;
-        }
+    let Some(config) = Config::get() else {
+        error!("Failed to get global configuration for WebSocket proxy");
+        let _ = client_socket.send(WsMessage::Close(None)).await;
+        return;
     };
 
     let path_and_query = uri.path_and_query().map(PathAndQuery::as_str).unwrap_or("/");
@@ -256,16 +247,12 @@ async fn handle_websocket(mut client_socket: WebSocket, uri: Uri) {
 
     let mut client_to_vite = tokio::spawn(async move {
         while let Some(msg) = client_receiver.next().await {
-            let msg = match msg {
-                Ok(msg) => msg,
-                Err(_) => {
-                    break;
-                }
+            let Ok(msg) = msg else {
+                break;
             };
 
-            let vite_msg = match convert_axum_to_tungstenite_message(msg) {
-                Some(msg) => msg,
-                None => continue,
+            let Some(vite_msg) = convert_axum_to_tungstenite_message(msg) else {
+                continue;
             };
 
             if vite_sender.send(vite_msg).await.is_err() {
@@ -276,16 +263,12 @@ async fn handle_websocket(mut client_socket: WebSocket, uri: Uri) {
 
     let mut vite_to_client = tokio::spawn(async move {
         while let Some(msg) = vite_receiver.next().await {
-            let msg = match msg {
-                Ok(msg) => msg,
-                Err(_) => {
-                    break;
-                }
+            let Ok(msg) = msg else {
+                break;
             };
 
-            let client_msg = match convert_tungstenite_to_axum_message(msg) {
-                Some(msg) => msg,
-                None => continue,
+            let Some(client_msg) = convert_tungstenite_to_axum_message(msg) else {
+                continue;
             };
 
             if client_sender.send(client_msg).await.is_err() {

--- a/crates/rari/src/utils/cast.rs
+++ b/crates/rari/src/utils/cast.rs
@@ -31,7 +31,7 @@ pub fn usize_fraction_ceil(value: usize, factor: f64) -> usize {
 #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 #[inline]
 #[must_use]
-pub fn f64_log10_floor_usize(value: f64) -> usize {
+pub fn f64_floor_usize(value: f64) -> usize {
     value.floor() as usize
 }
 

--- a/crates/rari/src/utils/cast.rs
+++ b/crates/rari/src/utils/cast.rs
@@ -1,0 +1,78 @@
+//! Conversions where truncation is acceptable or explicitly handled.
+
+use std::time::Duration;
+
+#[inline]
+#[must_use]
+pub fn duration_millis_u64(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+#[inline]
+#[must_use]
+pub fn u64_to_usize(value: u64) -> usize {
+    usize::try_from(value).unwrap_or(usize::MAX)
+}
+
+#[inline]
+#[must_use]
+pub fn u32_to_u16(value: u32) -> u16 {
+    u16::try_from(value).unwrap_or(u16::MAX)
+}
+
+#[cfg(test)]
+#[expect(clippy::cast_possible_truncation, clippy::cast_precision_loss, clippy::cast_sign_loss)]
+#[inline]
+#[must_use]
+pub fn usize_fraction_ceil(value: usize, factor: f64) -> usize {
+    (value as f64 * factor).ceil() as usize
+}
+
+#[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+#[inline]
+#[must_use]
+pub fn f64_log10_floor_usize(value: f64) -> usize {
+    value.floor() as usize
+}
+
+#[expect(clippy::cast_possible_truncation)]
+#[inline]
+#[must_use]
+pub const fn u16_to_u8(value: u16) -> u8 {
+    value as u8
+}
+
+#[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+#[inline]
+#[must_use]
+pub const fn f32_to_u32(value: f32) -> u32 {
+    value as u32
+}
+
+#[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+#[inline]
+#[must_use]
+pub const fn f32_to_u8(value: f32) -> u8 {
+    value as u8
+}
+
+#[expect(clippy::cast_possible_truncation)]
+#[inline]
+#[must_use]
+pub const fn f32_to_i32(value: f32) -> i32 {
+    value as i32
+}
+
+#[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+#[inline]
+#[must_use]
+pub const fn f32_to_usize(value: f32) -> usize {
+    value as usize
+}
+
+#[expect(clippy::cast_possible_truncation)]
+#[inline]
+#[must_use]
+pub const fn f64_to_f32(value: f64) -> f32 {
+    value as f32
+}

--- a/crates/rari/src/utils/float.rs
+++ b/crates/rari/src/utils/float.rs
@@ -1,0 +1,29 @@
+//! Integer-to-float conversions where reduced precision is acceptable.
+
+#[expect(clippy::cast_precision_loss)]
+#[inline]
+#[must_use]
+pub const fn u32_to_f32(value: u32) -> f32 {
+    value as f32
+}
+
+#[expect(clippy::cast_precision_loss)]
+#[inline]
+#[must_use]
+pub const fn i32_to_f32(value: i32) -> f32 {
+    value as f32
+}
+
+#[expect(clippy::cast_precision_loss)]
+#[inline]
+#[must_use]
+pub const fn usize_to_f32(value: usize) -> f32 {
+    value as f32
+}
+
+#[expect(clippy::cast_precision_loss)]
+#[inline]
+#[must_use]
+pub fn u64_ratio(numerator: u64, denominator: u64) -> f64 {
+    numerator as f64 / denominator as f64
+}

--- a/crates/rari/src/utils/mod.rs
+++ b/crates/rari/src/utils/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod cast;
+pub(crate) mod float;

--- a/crates/rari/src/utils/mod.rs
+++ b/crates/rari/src/utils/mod.rs
@@ -1,2 +1,2 @@
-pub(crate) mod cast;
-pub(crate) mod float;
+pub mod cast;
+pub mod float;

--- a/tools/snapshot/src/main.rs
+++ b/tools/snapshot/src/main.rs
@@ -1,7 +1,16 @@
 #![allow(clippy::too_many_lines, clippy::cast_precision_loss)]
 
-use std::{env, fmt::Write, fs, path::PathBuf, ptr, rc::Rc, string::String};
+use std::{
+    env,
+    fmt::Write,
+    fs,
+    path::{Path, PathBuf},
+    ptr,
+    rc::Rc,
+    string::String,
+};
 
+use deno_ast::MediaType;
 use deno_core::{ModuleCodeString, ModuleName, SourceMapData, snapshot, v8};
 use deno_error::JsErrorBox;
 use deno_node::{ContextInitMode, VM_CONTEXT_INDEX, create_v8_context, init_global_template};
@@ -36,7 +45,8 @@ fn main() {
     let ext_options = ExtensionOptions::default();
     let extensions = ext::extensions(&ext_options, false);
 
-    let transpiler: Rc<Transpiler> = Rc::new(transpile::maybe_transpile_source);
+    let transpiler: Rc<Transpiler> =
+        Rc::new(|name, source| transpile::maybe_transpile_source(&name, source));
 
     #[expect(clippy::expect_used, reason = "Infallible operation with valid inputs")]
     let output = snapshot::create_snapshot(
@@ -147,10 +157,6 @@ fn write_line(buf: &mut String, line: &str) {
 }
 
 fn maybe_transpile(specifier: &str, source: &str) -> String {
-    use std::path::Path;
-
-    use deno_ast::MediaType;
-
     let media_type = if specifier.starts_with("node:") {
         MediaType::TypeScript
     } else {


### PR DESCRIPTION
- Convert `normalize_component_id` to static method in ComponentRegistry and update all call sites
- Convert `parse_line`, `parse_json_element`, and `parse_react_element` to static methods in RscFlightParser
- Update `parse_suspense_element` and `parse_promise_element` signatures to accept references instead of self
- Simplify method calls by using `Self::` prefix for static methods throughout codebase
- Extract utility functions into new `utils/cast.rs` and `utils/float.rs` modules
- Remove unnecessary instance state requirements from parser and component registry methods
- Improves code clarity and reduces implicit dependencies on instance state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safeguards to stop processing overly large RSC payloads and OG image data.
* **Bug Fixes**
  * Improved rendering, routing, and cache calculations with more consistent numeric conversions, more reliable duration/ratio math, and updated memory-pressure/cache-eviction heuristics.
  * Tightened streaming/error handling, response creation, and safer static-path validation to reduce edge-case failures.
* **Refactor**
  * Streamlined internal parsing/dispatch and helper flows across server, runtime, and image/OG rendering for more consistent borrowing and execution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->