### PR TITLE
refactor: migrate clippy attributes from allow to expect

### DIFF
--- a/crates/rari-error/src/lib.rs
+++ b/crates/rari-error/src/lib.rs
@@ -652,7 +652,7 @@ impl From<DataError> for RariError {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::disallowed_methods, clippy::unwrap_used)]
+    #![expect(clippy::unwrap_used)]
     use super::*;
 
     #[test]

--- a/crates/rari-rsc/src/components.rs
+++ b/crates/rari-rsc/src/components.rs
@@ -74,6 +74,7 @@ impl ComponentRegistry {
         id.cow_replace('\\', "/")
     }
 
+    #[expect(clippy::missing_errors_doc)]
     pub fn register_component(
         &mut self,
         id: &str,
@@ -454,7 +455,7 @@ impl Default for ComponentRegistry {
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::expect_used, clippy::unwrap_used)]
+#[expect(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use smallvec::smallvec;
 

--- a/crates/rari-rsc/src/flight/parser.rs
+++ b/crates/rari-rsc/src/flight/parser.rs
@@ -40,6 +40,7 @@ impl RscFlightParser {
         }
     }
 
+    #[expect(clippy::missing_errors_doc)]
     pub fn parse(&mut self) -> Result<(), RariError> {
         for line in &self.lines {
             let line = line.trim();
@@ -287,7 +288,7 @@ impl RscFlightParser {
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::panic)]
+#[expect(clippy::panic)]
 mod tests {
     use super::*;
 

--- a/crates/rari-rsc/src/lib.rs
+++ b/crates/rari-rsc/src/lib.rs
@@ -1,5 +1,3 @@
-#![expect(clippy::missing_errors_doc)]
-
 pub mod components;
 pub mod core;
 pub mod flight;

--- a/crates/rari-rsc/src/types.rs
+++ b/crates/rari-rsc/src/types.rs
@@ -404,7 +404,7 @@ impl RSCRenderResult {
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::panic, clippy::unwrap_used)]
+#[expect(clippy::panic, clippy::unwrap_used)]
 mod tests {
     use serde_json::json;
 

--- a/crates/rari-use-cache/src/closure.rs
+++ b/crates/rari-use-cache/src/closure.rs
@@ -334,7 +334,7 @@ fn collect_pat_idents(pattern: &Pat, idents: &mut FxHashSet<Id>) {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::default_trait_access, clippy::expect_used)]
+    #![expect(clippy::default_trait_access, clippy::expect_used)]
     use deno_ast::swc::{
         ast::{
             AssignPatProp, BindingIdent, Class, ClassDecl, ClassExpr, Decl, DefaultDecl,

--- a/crates/rari-use-cache/src/directive.rs
+++ b/crates/rari-use-cache/src/directive.rs
@@ -103,7 +103,7 @@ pub fn detect_use_cache(source: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::default_trait_access)]
+    #![expect(clippy::default_trait_access)]
     use super::*;
 
     #[test]

--- a/crates/rari-use-cache/src/lib.rs
+++ b/crates/rari-use-cache/src/lib.rs
@@ -26,8 +26,11 @@ pub struct TransformResult {
 }
 
 #[napi]
-#[allow(clippy::allow_attributes, reason = "NAPI macro interface requires this pattern")]
-#[allow(clippy::needless_pass_by_value)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::needless_pass_by_value,
+    reason = "NAPI macro interface requires this pattern"
+)]
 pub fn detect_use_cache(source: String) -> bool {
     directive::detect_use_cache(&source)
 }
@@ -38,8 +41,11 @@ pub fn detect_use_cache(source: String) -> bool {
 ///
 /// Returns an error if transformation fails due to parsing or code generation errors.
 #[napi]
-#[allow(clippy::allow_attributes, reason = "NAPI macro interface requires this pattern")]
-#[allow(clippy::needless_pass_by_value)]
+#[allow(
+    clippy::allow_attributes,
+    clippy::needless_pass_by_value,
+    reason = "NAPI macro interface requires this pattern"
+)]
 pub fn transform_use_cache(source: String, options: TransformOptions) -> Result<TransformResult> {
     let hash_salt = options.hash_salt.unwrap_or_else(|| "rari-use-cache-v1".to_string());
 

--- a/crates/rari/src/rendering/base/loader.rs
+++ b/crates/rari/src/rendering/base/loader.rs
@@ -18,6 +18,7 @@ fn create_js_wrapper(js_code: &str) -> String {
 }
 
 impl RscJsLoader {
+    #[expect(clippy::missing_errors_doc)]
     pub fn load_component_render_with_data(
         component_id: &str,
         component_hash: &str,

--- a/crates/rari/src/rendering/base/mod.rs
+++ b/crates/rari/src/rendering/base/mod.rs
@@ -11,7 +11,7 @@ pub use sanitizer::sanitize_component_output;
 pub use types::{ResourceLimits, ResourceMetrics, ResourceTracker};
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::expect_used, clippy::unwrap_used)]
+#[expect(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use std::sync::Arc;
 

--- a/crates/rari/src/rendering/base/renderer.rs
+++ b/crates/rari/src/rendering/base/renderer.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::missing_errors_doc)]
+
 use std::{
     env,
     fmt::Write,

--- a/crates/rari/src/rendering/layout/core.rs
+++ b/crates/rari/src/rendering/layout/core.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::missing_errors_doc)]
+
 use std::{env, sync::Arc};
 
 use base64::{Engine, engine::general_purpose::STANDARD};
@@ -1245,7 +1247,7 @@ impl LayoutRenderer {
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::expect_used, clippy::unwrap_used)]
+#[expect(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::server::cache::handler::NoOpCacheHandler;

--- a/crates/rari/src/rendering/layout/mod.rs
+++ b/crates/rari/src/rendering/layout/mod.rs
@@ -12,7 +12,7 @@ pub(crate) use utils::component_dist_path;
 pub use utils::create_layout_context;
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::unwrap_used)]
+#[expect(clippy::unwrap_used)]
 mod tests {
     use std::sync::Arc;
 

--- a/crates/rari/src/rendering/layout/route_composer.rs
+++ b/crates/rari/src/rendering/layout/route_composer.rs
@@ -254,7 +254,7 @@ impl RouteComposer {
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::expect_used)]
+#[expect(clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/rendering/mod.rs
+++ b/crates/rari/src/rendering/mod.rs
@@ -1,5 +1,3 @@
-#![expect(clippy::missing_errors_doc)]
-
 pub mod base;
 pub mod layout;
 pub mod r#static;

--- a/crates/rari/src/rendering/static.rs
+++ b/crates/rari/src/rendering/static.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::missing_errors_doc)]
+
 use std::{
     fmt::Write,
     future::Future,
@@ -2189,7 +2191,7 @@ impl Default for RscToHtmlConverter {
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::panic, clippy::unwrap_used, clippy::clone_on_ref_ptr)]
+#[expect(clippy::panic, clippy::unwrap_used, clippy::clone_on_ref_ptr)]
 mod tests {
     use super::*;
     use crate::server::config::Mode;

--- a/crates/rari/src/runtime/ext/rari/cache/redis_cache.rs
+++ b/crates/rari/src/runtime/ext/rari/cache/redis_cache.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::exhaustive_structs)]
-
 use std::{cell::RefCell, fmt::Display, rc::Rc, sync::Arc, time::Duration};
 
 use deno_core::{Extension, OpState, extension, op2};

--- a/crates/rari/src/runtime/ext/web/permissions.rs
+++ b/crates/rari/src/runtime/ext/web/permissions.rs
@@ -1,4 +1,4 @@
-#![allow(unused)]
+#![expect(unused)]
 use std::{
     borrow::Cow,
     fmt::{Debug, Display},

--- a/crates/rari/src/runtime/factory/runtime.rs
+++ b/crates/rari/src/runtime/factory/runtime.rs
@@ -112,6 +112,7 @@ pub struct RariRuntime {
 }
 
 impl RariRuntime {
+    #[expect(clippy::too_many_lines)]
     pub fn new(env_vars: Option<FxHashMap<String, String>>) -> Self {
         let (request_sender, mut request_receiver) = mpsc::channel(CHANNEL_CAPACITY);
 
@@ -370,6 +371,7 @@ async fn handle_get_module_namespace(
     Ok::<(), RariError>(())
 }
 
+#[expect(clippy::too_many_lines)]
 async fn handle_js_request(
     request: JsRequest,
     js_runtime: &mut deno_core::JsRuntime,
@@ -600,6 +602,7 @@ fn setup_concurrent_batch(
     })
 }
 
+#[expect(clippy::too_many_lines)]
 fn check_pending_batches(
     js_runtime: &mut deno_core::JsRuntime,
     pending_batches: &mut [PendingBatch],

--- a/crates/rari/src/runtime/mod.rs
+++ b/crates/rari/src/runtime/mod.rs
@@ -1,5 +1,3 @@
-#![expect(clippy::missing_errors_doc, clippy::too_many_lines)]
-
 use std::{
     future::Future,
     sync::{Arc, OnceLock},
@@ -58,6 +56,7 @@ fn is_esm_code(code: &str) -> bool {
     regex.is_match(code)
 }
 
+#[expect(clippy::missing_errors_doc)]
 impl JsExecutionRuntime {
     pub fn new(env_vars: Option<rustc_hash::FxHashMap<String, String>>) -> Self {
         let runtime = if let Some(env_vars) = env_vars {
@@ -361,6 +360,7 @@ impl JsExecutionRuntime {
         }
     }
 
+    #[expect(clippy::too_many_lines)]
     pub async fn load_component_code(
         &self,
         component_id: &str,

--- a/crates/rari/src/runtime/module_loader/cache.rs
+++ b/crates/rari/src/runtime/module_loader/cache.rs
@@ -75,6 +75,7 @@ impl ModuleCaching {
         }
     }
 
+    #[expect(clippy::missing_errors_doc)]
     pub async fn insert(&self, key: String, value: Value) -> result::Result<(), RariError> {
         let bytes = serde_json::to_vec(&value)
             .map_err(|e| RariError::cache(format!("json serialize: {e}")))?;
@@ -118,7 +119,7 @@ impl ModuleCaching {
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::unwrap_used, clippy::clone_on_ref_ptr)]
+#[expect(clippy::unwrap_used, clippy::clone_on_ref_ptr)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/runtime/module_loader/core.rs
+++ b/crates/rari/src/runtime/module_loader/core.rs
@@ -767,6 +767,7 @@ export default {{}};
         None
     }
 
+    #[expect(clippy::too_many_lines)]
     fn wrap_cjs_module(content: &str, file_path: &str) -> String {
         let file_dir = if let Some(last_slash) = file_path.rfind('/') {
             &file_path[..last_slash]
@@ -1387,6 +1388,7 @@ impl Default for RariModuleLoader {
 }
 
 impl ModuleLoader for RariModuleLoader {
+    #[expect(clippy::too_many_lines)]
     fn resolve(
         &self,
         specifier: &str,

--- a/crates/rari/src/runtime/ops.rs
+++ b/crates/rari/src/runtime/ops.rs
@@ -86,8 +86,6 @@ fn parse_hex_row_id(row_id: &str, context: &str) -> Result<u32, JsErrorBox> {
     })
 }
 
-#[allow(clippy::allow_attributes)]
-#[allow(clippy::disallowed_methods)]
 #[op2]
 pub async fn op_send_chunk_to_rust(
     state: Rc<RefCell<OpState>>,
@@ -254,8 +252,6 @@ pub fn get_streaming_ops() -> Vec<OpDecl> {
     ]
 }
 
-#[allow(clippy::allow_attributes)]
-#[allow(clippy::disallowed_methods)]
 #[op2]
 pub async fn op_fizz_chunk(
     state: Rc<RefCell<OpState>>,
@@ -284,8 +280,6 @@ pub async fn op_fizz_chunk(
     }
 }
 
-#[allow(clippy::allow_attributes)]
-#[allow(clippy::disallowed_methods)]
 #[op2(fast)]
 pub fn op_fizz_done(state: &mut OpState) {
     if let Some(stream_op_state) = state.try_borrow_mut::<StreamOpState>() {
@@ -340,8 +334,6 @@ fn headers_to_json(headers: &HeaderMap) -> serde_json::Map<String, serde_json::V
     headers_obj
 }
 
-#[allow(clippy::allow_attributes)]
-#[allow(clippy::disallowed_methods)]
 #[op2]
 #[serde]
 pub async fn op_fetch_with_cache(

--- a/crates/rari/src/runtime/transpile.rs
+++ b/crates/rari/src/runtime/transpile.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::exhaustive_structs)]
+#![expect(clippy::exhaustive_structs)]
 
 use std::{
     borrow::Cow,
@@ -38,6 +38,7 @@ fn maybe_substitute_version_placeholders(name: &str, source: ModuleCodeString) -
     result.into_owned().into()
 }
 
+#[expect(clippy::missing_errors_doc)]
 pub fn maybe_transpile_source(
     name: &ModuleName,
     source: ModuleCodeString,

--- a/crates/rari/src/server/cache/handler.rs
+++ b/crates/rari/src/server/cache/handler.rs
@@ -470,7 +470,7 @@ impl CacheHandlerRegistry {
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::expect_used, clippy::unwrap_used)]
+#[expect(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use std::{sync::Arc, time::Duration};
 

--- a/crates/rari/src/server/cache/response.rs
+++ b/crates/rari/src/server/cache/response.rs
@@ -546,12 +546,7 @@ mod header_map_serde {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::allow_attributes,
-    clippy::expect_used,
-    clippy::unwrap_used,
-    clippy::clone_on_ref_ptr
-)]
+#[expect(clippy::expect_used, clippy::unwrap_used, clippy::clone_on_ref_ptr)]
 mod tests {
     use std::{sync::Arc, time::Duration};
 

--- a/crates/rari/src/server/compression/stream.rs
+++ b/crates/rari/src/server/compression/stream.rs
@@ -254,7 +254,7 @@ impl GzipCompressor {
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::unwrap_used)]
+#[expect(clippy::unwrap_used)]
 mod tests {
     use futures::stream;
 

--- a/crates/rari/src/server/config.rs
+++ b/crates/rari/src/server/config.rs
@@ -880,7 +880,7 @@ pub enum ConfigError {
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::unwrap_used)]
+#[expect(clippy::unwrap_used)]
 mod tests {
     use std::{fs::File, io::Write, process};
 

--- a/crates/rari/src/server/core/utils/http.rs
+++ b/crates/rari/src/server/core/utils/http.rs
@@ -246,7 +246,7 @@ pub fn add_api_security_headers(headers: &mut HeaderMap) {
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::unwrap_used)]
+#[expect(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/server/core/utils/path_validation.rs
+++ b/crates/rari/src/server/core/utils/path_validation.rs
@@ -105,7 +105,7 @@ pub fn validate_component_path(file_path: &str) -> Result<(), RariError> {
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::expect_used, clippy::unwrap_used)]
+#[expect(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     #[cfg(unix)]
     use std::os::unix::fs::symlink;

--- a/crates/rari/src/server/handlers/actions.rs
+++ b/crates/rari/src/server/handlers/actions.rs
@@ -928,7 +928,7 @@ pub fn build_set_cookie_header(cookie: &PendingCookie) -> Result<String, String>
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::unwrap_used, clippy::float_cmp, clippy::approx_constant)]
+#[expect(clippy::unwrap_used, clippy::float_cmp, clippy::approx_constant)]
 mod tests {
     use serde_json::json;
 

--- a/crates/rari/src/server/image/cache.rs
+++ b/crates/rari/src/server/image/cache.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::exhaustive_structs)]
+#![expect(clippy::exhaustive_structs)]
 
 use std::{
     env, fs,
@@ -176,7 +176,7 @@ impl ImageCache {
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::expect_used, clippy::unwrap_used)]
+#[expect(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use std::env::temp_dir;
 

--- a/crates/rari/src/server/og/cache.rs
+++ b/crates/rari/src/server/og/cache.rs
@@ -158,7 +158,7 @@ impl OgImageCache {
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::expect_used, clippy::unwrap_used)]
+#[expect(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use std::env::temp_dir;
 

--- a/crates/rari/src/server/og/generator.rs
+++ b/crates/rari/src/server/og/generator.rs
@@ -407,7 +407,7 @@ impl OgImageGenerator {
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::unwrap_used)]
+#[expect(clippy::unwrap_used)]
 mod tests {
     use std::env;
 

--- a/crates/rari/src/server/og/generator.rs
+++ b/crates/rari/src/server/og/generator.rs
@@ -2,7 +2,6 @@
     clippy::unnecessary_wraps,
     reason = "Generator methods return Result for API consistency with error-handling variants"
 )]
-#![allow(clippy::explicit_counter_loop)]
 
 use std::{path::PathBuf, string::ToString, sync::Arc, vec::Vec};
 
@@ -206,6 +205,7 @@ impl OgImageGenerator {
                 let mut matches = true;
                 let mut path_idx = 0;
 
+                #[expect(clippy::explicit_counter_loop)]
                 for pattern_seg in &pattern_segments {
                     if pattern_seg.starts_with("[...") && pattern_seg.ends_with(']') {
                         let param_name = &pattern_seg[4..pattern_seg.len() - 1];

--- a/crates/rari/src/server/og/layout/mod.rs
+++ b/crates/rari/src/server/og/layout/mod.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::match_wildcard_for_single_variants)]
-
 use std::time::Duration;
 
 use parley::style::FontWeight;
@@ -458,6 +456,7 @@ fn measure_node(
         return Size::ZERO;
     }
 
+    #[expect(clippy::match_wildcard_for_single_variants)]
     let text: String = node_data
         .element
         .children

--- a/crates/rari/src/server/og/layout/style/gradient.rs
+++ b/crates/rari/src/server/og/layout/style/gradient.rs
@@ -364,7 +364,7 @@ pub struct GradientParams {
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::unwrap_used, clippy::float_cmp)]
+#[expect(clippy::unwrap_used, clippy::float_cmp)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/server/og/resources/fonts.rs
+++ b/crates/rari/src/server/og/resources/fonts.rs
@@ -124,7 +124,7 @@ impl FontContext {
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::expect_used, clippy::print_stdout)]
+#[expect(clippy::expect_used, clippy::print_stdout)]
 mod tests {
     use parley::PositionedLayoutItem::GlyphRun;
     use swash::scale::StrikeWith::BestFit;

--- a/crates/rari/src/server/rendering/metadata.rs
+++ b/crates/rari/src/server/rendering/metadata.rs
@@ -100,7 +100,7 @@ pub fn finalize_metadata(metadata: &mut Value) {
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::unwrap_used)]
+#[expect(clippy::unwrap_used)]
 mod tests {
     use serde_json::json;
 

--- a/crates/rari/src/server/rendering/metadata_injection.rs
+++ b/crates/rari/src/server/rendering/metadata_injection.rs
@@ -541,7 +541,7 @@ pub fn inject_metadata(
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::expect_used)]
+#[expect(clippy::expect_used)]
 mod tests {
     use rustc_hash::FxHashMap;
 

--- a/crates/rari/src/server/rendering/streaming_response.rs
+++ b/crates/rari/src/server/rendering/streaming_response.rs
@@ -77,7 +77,7 @@ impl IntoResponse for StreamingHtmlResponse {
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::unwrap_used)]
+#[expect(clippy::unwrap_used)]
 mod tests {
     use async_stream::stream;
     use axum::body::to_bytes;

--- a/crates/rari/src/server/routing/api_routes.rs
+++ b/crates/rari/src/server/routing/api_routes.rs
@@ -627,7 +627,7 @@ impl ApiRouteHandler {
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::unwrap_used)]
+#[expect(clippy::unwrap_used)]
 mod tests {
     use axum::http::HeaderValue;
 

--- a/crates/rari/src/server/routing/app_router.rs
+++ b/crates/rari/src/server/routing/app_router.rs
@@ -656,7 +656,7 @@ impl AppRouter {
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::unwrap_used)]
+#[expect(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/rari/src/server/routing/types.rs
+++ b/crates/rari/src/server/routing/types.rs
@@ -58,7 +58,7 @@ impl ParamValue {
 }
 
 #[cfg(test)]
-#[allow(clippy::allow_attributes, clippy::unwrap_used)]
+#[expect(clippy::unwrap_used)]
 mod tests {
     use rustc_hash::FxHashMap;
 

--- a/tools/prepare-binaries/src/common.rs
+++ b/tools/prepare-binaries/src/common.rs
@@ -67,10 +67,12 @@ pub const TARGETS: &[Target] = &[
     },
 ];
 
+#[expect(clippy::print_stdout)]
 pub fn log(message: &str) {
     println!("{} {}", "➜".cyan(), message);
 }
 
+#[expect(clippy::print_stdout)]
 pub fn log_success(message: &str) {
     println!("{} {}", "✓".green(), message);
 }
@@ -79,6 +81,7 @@ pub fn log_error(message: &str) {
     eprintln!("{} {}", "✗".red(), message);
 }
 
+#[expect(clippy::print_stdout)]
 pub fn log_warning(message: &str) {
     println!("{} {}", "⚠".yellow(), message);
 }

--- a/tools/prepare-binaries/src/common.rs
+++ b/tools/prepare-binaries/src/common.rs
@@ -14,11 +14,6 @@ pub struct Target {
     pub platform: &'static str,
     pub binary_name: &'static str,
     pub package_dir: &'static str,
-    #[allow(
-        clippy::allow_attributes,
-        reason = "Field naming follows convention, clippy suggestion less clear"
-    )]
-    #[allow(clippy::struct_field_names)]
     pub addon_package_dir: &'static str,
 }
 

--- a/tools/prepare-binaries/src/main.rs
+++ b/tools/prepare-binaries/src/main.rs
@@ -1,5 +1,3 @@
-#![expect(clippy::print_stdout)]
-
 mod common;
 mod rari_binary;
 mod use_cache_addon;
@@ -35,6 +33,7 @@ struct Args {
     bin: bool,
 }
 
+#[expect(clippy::print_stdout)]
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();

--- a/tools/release/src/main.rs
+++ b/tools/release/src/main.rs
@@ -1,5 +1,3 @@
-#![expect(clippy::print_stdout)]
-
 mod app;
 mod changelog;
 mod git;
@@ -43,6 +41,7 @@ struct Args {
     no_push: bool,
 }
 
+#[expect(clippy::print_stdout)]
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
@@ -112,10 +111,7 @@ async fn run_app(
     Ok(())
 }
 
-#[expect(
-    clippy::too_many_lines,
-    reason = "Non-interactive release orchestration requires comprehensive workflow steps"
-)]
+#[expect(clippy::too_many_lines, clippy::print_stdout)]
 async fn run_non_interactive(
     only: Option<Vec<String>>,
     dry_run: bool,

--- a/tools/snapshot/src/main.rs
+++ b/tools/snapshot/src/main.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::too_many_lines, clippy::cast_precision_loss)]
-
 use std::{
     env,
     fmt::Write,
@@ -25,6 +23,7 @@ type Transpiler = dyn Fn(
     ModuleCodeString,
 ) -> Result<(ModuleCodeString, Option<SourceMapData>), JsErrorBox>;
 
+#[expect(clippy::too_many_lines, clippy::cast_precision_loss)]
 fn main() {
     let output_dir = env::args()
         .nth(1)


### PR DESCRIPTION
- Replace `#![allow(...)]` module-level attributes with `#[expect(...)]` on specific functions and blocks
- Convert `clippy::disallowed_methods` allows in runtime ops to remove unnecessary suppressions
- Move `clippy::explicit_counter_loop` from module-level to inline expect attribute in og generator
- Move `clippy::match_wildcard_for_single_variants` from module-level to inline expect in layout module
- Add `#[expect(clippy::print_stdout)]` to individual logging functions in prepare-binaries
- Move `#[expect(clippy::print_stdout)]` from crate root to main function in prepare-binaries and release tools
- Consolidate multiple expects in release tool's `run_non_interactive` function
- Move `#[expect(...)]` attributes from module-level to main function in snapshot tool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened lint suppressions across the codebase by replacing broad file-level allowances with narrower, scoped lint expectations (including stdout-printing and loop patterns).
  * Updated multiple `expect/allow` configurations in test-only sections (notably around `unwrap/expect`, panic usage, and related clippy lints) without changing runtime behavior.
  * No user-facing features, APIs, or production logic were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->