### PR TITLE
refactor: apply use_self clippy lint across codebase

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,42 @@ categories = [
   "web-programming::http-server"
 ]
 
+[workspace.dependencies]
+anyhow = "1.0.103"
+base64 = "0.22.1"
+clap = { version = "4.6.1", features = [ "derive" ] }
+colored = "3.1.1"
+cow-utils = "0.1.3"
+deno_ast = { version = "=0.53.2", features = [
+  "transpiling",
+  "codegen",
+  "visit",
+  "transforms",
+] }
+deno_core = "0.406.0"
+deno_error = "=0.7.1"
+deno_node = "0.191.0"
+hex = "0.4.3"
+parking_lot = "0.12.5"
+rari = { path = "crates/rari" }
+rari-error = { path = "crates/rari-error" }
+rari-rsc = { path = "crates/rari-rsc" }
+rari-utils = { path = "crates/rari-utils" }
+regex = "1.12.4"
+rustc-hash = "2.1.2"
+serde = { version = "1.0.228", features = [ "derive" ] }
+serde_json = "1.0.150"
+sha2 = "0.11.0"
+smallvec = "1.15.2"
+thiserror = "2.0.18"
+tokio = { version = "1.52.3", features = [
+  "full",
+  "process"
+] }
+tracing = "0.1.44"
+url = "2.5.8"
+uuid = { version = "1.23.4", features = [ "v4" ] }
+
 [workspace.lints.clippy]
 # Restriction rules for better code quality
 allow_attributes = "deny"
@@ -80,6 +116,7 @@ new_without_default = "allow"
 similar_names = "allow"
 single_match = "allow"
 single_match_else = "allow"
+use_self = "warn"
 
 # Nursery rules that are useful
 absolute_paths = "warn"
@@ -93,42 +130,6 @@ unused_peekable = "warn"
 
 [workspace.lints.rust]
 linker_messages = "allow"
-
-[workspace.dependencies]
-anyhow = "1.0.103"
-base64 = "0.22.1"
-clap = { version = "4.6.1", features = [ "derive" ] }
-colored = "3.1.1"
-cow-utils = "0.1.3"
-deno_ast = { version = "=0.53.2", features = [
-  "transpiling",
-  "codegen",
-  "visit",
-  "transforms",
-] }
-deno_core = "0.406.0"
-deno_error = "=0.7.1"
-deno_node = "0.191.0"
-hex = "0.4.3"
-parking_lot = "0.12.5"
-rari = { path = "crates/rari" }
-rari-error = { path = "crates/rari-error" }
-rari-rsc = { path = "crates/rari-rsc" }
-rari-utils = { path = "crates/rari-utils" }
-regex = "1.12.4"
-rustc-hash = "2.1.2"
-serde = { version = "1.0.228", features = [ "derive" ] }
-serde_json = "1.0.150"
-sha2 = "0.11.0"
-smallvec = "1.15.2"
-thiserror = "2.0.18"
-tokio = { version = "1.52.3", features = [
-  "full",
-  "process"
-] }
-tracing = "0.1.44"
-url = "2.5.8"
-uuid = { version = "1.23.4", features = [ "v4" ] }
 
 [profile.dev]
 # Minimal debug info to speed up local and CI builds

--- a/crates/rari-error/src/lib.rs
+++ b/crates/rari-error/src/lib.rs
@@ -44,37 +44,37 @@ pub enum Error {
 
 impl From<CoreError> for Error {
     fn from(e: CoreError) -> Self {
-        Error::Runtime(e.to_string())
+        Self::Runtime(e.to_string())
     }
 }
 
 impl From<JsError> for Error {
     fn from(e: JsError) -> Self {
-        Error::Js(Box::new(e))
+        Self::Js(Box::new(e))
     }
 }
 
 impl From<BorrowMutError> for Error {
     fn from(e: BorrowMutError) -> Self {
-        Error::Runtime(e.to_string())
+        Self::Runtime(e.to_string())
     }
 }
 
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
-        Error::JsonDecode(e.to_string())
+        Self::JsonDecode(e.to_string())
     }
 }
 
 impl From<String> for Error {
     fn from(e: String) -> Self {
-        Error::Runtime(e)
+        Self::Runtime(e)
     }
 }
 
 impl From<&str> for Error {
     fn from(e: &str) -> Self {
-        Error::Runtime(e.to_string())
+        Self::Runtime(e.to_string())
     }
 }
 
@@ -488,7 +488,7 @@ impl From<StreamingError> for RariError {
             }
         }
 
-        RariError::Internal(
+        Self::Internal(
             message,
             Some(Box::new(ErrorMetadata {
                 code: "STREAMING_ERROR".to_string(),
@@ -574,7 +574,7 @@ impl From<LoadingStateError> for RariError {
             }
         }
 
-        RariError::Internal(
+        Self::Internal(
             message,
             Some(Box::new(ErrorMetadata {
                 code: "LOADING_STATE_ERROR".to_string(),
@@ -640,13 +640,13 @@ impl RariError {
 
 impl From<RariError> for JsErrorBox {
     fn from(err: RariError) -> Self {
-        JsErrorBox::generic(err.to_string())
+        Self::generic(err.to_string())
     }
 }
 
 impl From<DataError> for RariError {
     fn from(err: DataError) -> Self {
-        RariError::JsRuntime(format!("V8 Data Error: {err}"), None)
+        Self::JsRuntime(format!("V8 Data Error: {err}"), None)
     }
 }
 

--- a/crates/rari-rsc/src/core.rs
+++ b/crates/rari-rsc/src/core.rs
@@ -25,7 +25,7 @@ pub enum RscElement {
     Reference(String),
     Text(String),
     Fragment {
-        children: Vec<RscElement>,
+        children: Vec<Self>,
     },
 }
 

--- a/crates/rari-rsc/src/types.rs
+++ b/crates/rari-rsc/src/types.rs
@@ -49,15 +49,15 @@ pub enum RSCTree {
     ServerElement {
         tag: String,
         props: Option<FxHashMap<String, Value>>,
-        children: Option<Vec<RSCTree>>,
+        children: Option<Vec<Self>>,
         key: Option<String>,
     },
     Text(String),
     Fragment {
-        children: Vec<RSCTree>,
+        children: Vec<Self>,
         key: Option<String>,
     },
-    Array(Vec<RSCTree>),
+    Array(Vec<Self>),
     Null,
     Primitive(Value),
     Error {
@@ -70,17 +70,17 @@ pub enum RSCTree {
 impl RSCTree {
     #[cfg(test)]
     pub fn client_reference(id: &str, key: Option<&str>, props: FxHashMap<String, Value>) -> Self {
-        RSCTree::ClientReference { id: id.to_string(), key: key.map(ToString::to_string), props }
+        Self::ClientReference { id: id.to_string(), key: key.map(ToString::to_string), props }
     }
 
     #[cfg(test)]
     pub fn server_element(
         tag: &str,
         props: Option<FxHashMap<String, Value>>,
-        children: Option<Vec<RSCTree>>,
+        children: Option<Vec<Self>>,
         key: Option<&str>,
     ) -> Self {
-        RSCTree::ServerElement {
+        Self::ServerElement {
             tag: tag.to_string(),
             props,
             children,
@@ -89,27 +89,27 @@ impl RSCTree {
     }
 
     pub fn text(content: &str) -> Self {
-        RSCTree::Text(content.to_string())
+        Self::Text(content.to_string())
     }
 
-    pub fn fragment(children: Vec<RSCTree>, key: Option<&str>) -> Self {
-        RSCTree::Fragment { children, key: key.map(ToString::to_string) }
+    pub fn fragment(children: Vec<Self>, key: Option<&str>) -> Self {
+        Self::Fragment { children, key: key.map(ToString::to_string) }
     }
 
-    pub fn array(elements: Vec<RSCTree>) -> Self {
-        RSCTree::Array(elements)
+    pub fn array(elements: Vec<Self>) -> Self {
+        Self::Array(elements)
     }
 
     pub fn null() -> Self {
-        RSCTree::Null
+        Self::Null
     }
 
     pub fn primitive(value: Value) -> Self {
-        RSCTree::Primitive(value)
+        Self::Primitive(value)
     }
 
     pub fn error(message: &str, component_name: &str, stack: Option<&str>) -> Self {
-        RSCTree::Error {
+        Self::Error {
             message: message.to_string(),
             component_name: component_name.to_string(),
             stack: stack.map(ToString::to_string),
@@ -118,14 +118,12 @@ impl RSCTree {
 
     pub fn has_client_components(&self) -> bool {
         match self {
-            RSCTree::ClientReference { .. } => true,
-            RSCTree::ServerElement { children, .. } => {
-                children.as_ref().is_some_and(|c| c.iter().any(RSCTree::has_client_components))
+            Self::ClientReference { .. } => true,
+            Self::ServerElement { children, .. } => {
+                children.as_ref().is_some_and(|c| c.iter().any(Self::has_client_components))
             }
-            RSCTree::Fragment { children, .. } => {
-                children.iter().any(RSCTree::has_client_components)
-            }
-            RSCTree::Array(elements) => elements.iter().any(RSCTree::has_client_components),
+            Self::Fragment { children, .. } => children.iter().any(Self::has_client_components),
+            Self::Array(elements) => elements.iter().any(Self::has_client_components),
             _ => false,
         }
     }
@@ -138,30 +136,30 @@ impl RSCTree {
 
     fn collect_client_component_ids_recursive(&self, ids: &mut Vec<String>) {
         match self {
-            RSCTree::ClientReference { id, .. } => {
+            Self::ClientReference { id, .. } => {
                 ids.push(id.clone());
             }
-            RSCTree::ServerElement { children: Some(children), .. }
-            | RSCTree::Fragment { children, .. } => {
+            Self::ServerElement { children: Some(children), .. }
+            | Self::Fragment { children, .. } => {
                 for child in children {
                     child.collect_client_component_ids_recursive(ids);
                 }
             }
-            RSCTree::Array(elements) => {
+            Self::Array(elements) => {
                 for element in elements {
                     element.collect_client_component_ids_recursive(ids);
                 }
             }
-            RSCTree::ServerElement { children: None, .. } | _ => {}
+            Self::ServerElement { children: None, .. } | _ => {}
         }
     }
 
     pub fn to_json(&self) -> Value {
         match self {
-            RSCTree::ClientReference { id, key, props } => {
+            Self::ClientReference { id, key, props } => {
                 serde_json::json!(["$", id, key, props])
             }
-            RSCTree::ServerElement { tag, props, children, key } => {
+            Self::ServerElement { tag, props, children, key } => {
                 let mut element = serde_json::json!({
                     "$$typeof": "react.transitional.element",
                     "type": tag,
@@ -170,7 +168,7 @@ impl RSCTree {
                 });
 
                 if let Some(children) = children {
-                    let children_json: Vec<Value> = children.iter().map(RSCTree::to_json).collect();
+                    let children_json: Vec<Value> = children.iter().map(Self::to_json).collect();
                     if let Some(props) = element.get_mut("props")
                         && let Some(props_obj) = props.as_object_mut()
                     {
@@ -180,18 +178,18 @@ impl RSCTree {
 
                 element
             }
-            RSCTree::Text(content) => Value::String(content.clone()),
-            RSCTree::Fragment { children, .. } => {
-                let children_json: Vec<Value> = children.iter().map(RSCTree::to_json).collect();
+            Self::Text(content) => Value::String(content.clone()),
+            Self::Fragment { children, .. } => {
+                let children_json: Vec<Value> = children.iter().map(Self::to_json).collect();
                 Value::Array(children_json)
             }
-            RSCTree::Array(elements) => {
-                let elements_json: Vec<Value> = elements.iter().map(RSCTree::to_json).collect();
+            Self::Array(elements) => {
+                let elements_json: Vec<Value> = elements.iter().map(Self::to_json).collect();
                 Value::Array(elements_json)
             }
-            RSCTree::Null => Value::Null,
-            RSCTree::Primitive(value) => value.clone(),
-            RSCTree::Error { message, component_name, .. } => {
+            Self::Null => Value::Null,
+            Self::Primitive(value) => value.clone(),
+            Self::Error { message, component_name, .. } => {
                 serde_json::json!({
                     "$$typeof": "react.transitional.element",
                     "type": "div",
@@ -231,10 +229,10 @@ impl RSCTree {
     /// Returns an error if the JSON structure is invalid or cannot be parsed as an RSCTree.
     pub fn from_json(value: &Value) -> Result<Self, String> {
         match value {
-            Value::String(s) => Ok(RSCTree::Text(s.clone())),
-            Value::Number(n) => Ok(RSCTree::Primitive(Value::Number(n.clone()))),
-            Value::Bool(b) => Ok(RSCTree::Primitive(Value::Bool(*b))),
-            Value::Null => Ok(RSCTree::Null),
+            Value::String(s) => Ok(Self::Text(s.clone())),
+            Value::Number(n) => Ok(Self::Primitive(Value::Number(n.clone()))),
+            Value::Bool(b) => Ok(Self::Primitive(Value::Bool(*b))),
+            Value::Null => Ok(Self::Null),
             Value::Array(arr) => {
                 if arr.len() == 4 && arr[0] == "$" {
                     let id = arr[1].as_str().ok_or("Invalid reference ID")?;
@@ -249,7 +247,7 @@ impl RSCTree {
                             .map(|(k, v)| (k.clone(), v.clone()))
                             .collect();
 
-                        Ok(RSCTree::ClientReference { id: id.to_string(), key, props })
+                        Ok(Self::ClientReference { id: id.to_string(), key, props })
                     } else {
                         let tag = id;
                         let key = arr[2].as_str().map(ToString::to_string);
@@ -265,15 +263,15 @@ impl RSCTree {
                                     c.as_array()
                                         .ok_or("Invalid children array")?
                                         .iter()
-                                        .map(RSCTree::from_json)
-                                        .collect::<Result<Vec<RSCTree>, String>>()
+                                        .map(Self::from_json)
+                                        .collect::<Result<Vec<Self>, String>>()
                                 } else {
-                                    Ok(vec![RSCTree::from_json(&c)?])
+                                    Ok(vec![Self::from_json(&c)?])
                                 }
                             })
                             .transpose()?;
 
-                        Ok(RSCTree::ServerElement {
+                        Ok(Self::ServerElement {
                             tag: tag.to_string(),
                             props: if props.is_empty() { None } else { Some(props) },
                             children,
@@ -281,20 +279,20 @@ impl RSCTree {
                         })
                     }
                 } else {
-                    let elements: Result<Vec<RSCTree>, String> =
-                        arr.iter().map(RSCTree::from_json).collect();
-                    Ok(RSCTree::Array(elements?))
+                    let elements: Result<Vec<Self>, String> =
+                        arr.iter().map(Self::from_json).collect();
+                    Ok(Self::Array(elements?))
                 }
             }
             Value::Object(obj) => {
                 if obj.contains_key("~preSerializedSuspense") && obj.contains_key("rscArray") {
                     if let Some(rsc_array) = obj.get("rscArray") {
-                        return RSCTree::from_json(rsc_array);
+                        return Self::from_json(rsc_array);
                     }
                     tracing::error!(
                         "Pre-serialized Suspense marker found but rscArray is missing or invalid"
                     );
-                    return Ok(RSCTree::Primitive(value.clone()));
+                    return Ok(Self::Primitive(value.clone()));
                 }
 
                 if obj.contains_key("$$typeof") && obj.contains_key("type") {
@@ -315,22 +313,22 @@ impl RSCTree {
                                 c.as_array()
                                     .ok_or("Invalid children array")?
                                     .iter()
-                                    .map(RSCTree::from_json)
-                                    .collect::<Result<Vec<RSCTree>, String>>()
+                                    .map(Self::from_json)
+                                    .collect::<Result<Vec<Self>, String>>()
                             } else {
-                                Ok(vec![RSCTree::from_json(c)?])
+                                Ok(vec![Self::from_json(c)?])
                             }
                         })
                         .transpose()?;
 
-                    Ok(RSCTree::ServerElement {
+                    Ok(Self::ServerElement {
                         tag: tag.to_string(),
                         props: Some(props),
                         children,
                         key,
                     })
                 } else {
-                    Ok(RSCTree::Primitive(value.clone()))
+                    Ok(Self::Primitive(value.clone()))
                 }
             }
         }
@@ -362,7 +360,7 @@ impl RSCRenderResult {
         let client_components = tree.collect_client_component_ids();
         let has_client_components = !client_components.is_empty();
 
-        RSCRenderResult {
+        Self {
             tree,
             has_suspense: false,
             client_components,
@@ -378,7 +376,7 @@ impl RSCRenderResult {
     }
 
     pub fn error(error: &str, component_id: &str) -> Self {
-        RSCRenderResult {
+        Self {
             tree: RSCTree::error(error, component_id, None),
             has_suspense: false,
             client_components: vec![],

--- a/crates/rari-use-cache/src/transform.rs
+++ b/crates/rari-use-cache/src/transform.rs
@@ -41,7 +41,7 @@ struct TransformVisitor {
 
 impl TransformVisitor {
     fn new(filename: &str, hash_salt: &str) -> Self {
-        TransformVisitor {
+        Self {
             filename: filename.to_string(),
             hash_salt: hash_salt.to_string(),
             index: 0,

--- a/crates/rari/src/rendering/static.rs
+++ b/crates/rari/src/rendering/static.rs
@@ -515,10 +515,7 @@ impl RscHtmlRenderer {
             .iter()
             .filter(|href| !template.contains(href.as_str()))
             .map(|href| {
-                format!(
-                    r#"<link rel="stylesheet" href="{}">"#,
-                    RscHtmlRenderer::escape_html_attribute(href)
-                )
+                format!(r#"<link rel="stylesheet" href="{}">"#, Self::escape_html_attribute(href))
             })
             .collect::<Vec<_>>();
 

--- a/crates/rari/src/runtime/ext/cache/mod.rs
+++ b/crates/rari/src/runtime/ext/cache/mod.rs
@@ -10,13 +10,13 @@ extension!(
 );
 impl ExtensionTrait<()> for init_cache {
     fn init((): ()) -> Extension {
-        init_cache::init()
+        Self::init()
     }
 }
 
 impl ExtensionTrait<()> for deno_cache::deno_cache {
     fn init((): ()) -> Extension {
-        deno_cache::deno_cache::init(None)
+        Self::init(None)
     }
 }
 

--- a/crates/rari/src/runtime/ext/cron/mod.rs
+++ b/crates/rari/src/runtime/ext/cron/mod.rs
@@ -11,12 +11,12 @@ extension!(
 );
 impl ExtensionTrait<()> for init_cron {
     fn init((): ()) -> Extension {
-        init_cron::init()
+        Self::init()
     }
 }
 impl ExtensionTrait<()> for deno_cron::deno_cron {
     fn init((): ()) -> Extension {
-        deno_cron::deno_cron::init(Box::new(LocalCronHandler::new()))
+        Self::init(Box::new(LocalCronHandler::new()))
     }
 }
 

--- a/crates/rari/src/runtime/ext/crypto/mod.rs
+++ b/crates/rari/src/runtime/ext/crypto/mod.rs
@@ -10,12 +10,12 @@ extension!(
 );
 impl ExtensionTrait<()> for init_crypto {
     fn init((): ()) -> Extension {
-        init_crypto::init()
+        Self::init()
     }
 }
 impl ExtensionTrait<Option<u64>> for deno_crypto::deno_crypto {
     fn init(seed: Option<u64>) -> Extension {
-        deno_crypto::deno_crypto::init(seed)
+        Self::init(seed)
     }
 }
 

--- a/crates/rari/src/runtime/ext/fetch/mod.rs
+++ b/crates/rari/src/runtime/ext/fetch/mod.rs
@@ -3,14 +3,14 @@ use std::sync::Arc;
 use deno_core::{Extension, extension};
 
 use super::ExtensionTrait;
-use crate::server::middleware::request_context::RequestContext;
+use crate::{runtime::ops, server::middleware::request_context::RequestContext};
 
 extension!(
     rari_fetch,
     ops = [
-        crate::runtime::ops::op_fetch_with_cache,
-        crate::runtime::ops::op_cache_get,
-        crate::runtime::ops::op_cache_set,
+        ops::op_fetch_with_cache,
+        ops::op_cache_get,
+        ops::op_cache_set,
     ],
     options = {
         request_context: Option<Arc<RequestContext>>,
@@ -24,7 +24,7 @@ extension!(
 
 impl ExtensionTrait<Option<Arc<RequestContext>>> for rari_fetch {
     fn init(request_context: Option<Arc<RequestContext>>) -> Extension {
-        rari_fetch::init(request_context)
+        Self::init(request_context)
     }
 }
 

--- a/crates/rari/src/runtime/ext/ffi/mod.rs
+++ b/crates/rari/src/runtime/ext/ffi/mod.rs
@@ -10,12 +10,12 @@ extension!(
 );
 impl ExtensionTrait<()> for init_ffi {
     fn init((): ()) -> Extension {
-        init_ffi::init()
+        Self::init()
     }
 }
 impl ExtensionTrait<()> for deno_ffi::deno_ffi {
     fn init((): ()) -> Extension {
-        deno_ffi::deno_ffi::init(None)
+        Self::init(None)
     }
 }
 

--- a/crates/rari/src/runtime/ext/fs/mod.rs
+++ b/crates/rari/src/runtime/ext/fs/mod.rs
@@ -12,13 +12,13 @@ extension!(
 
 impl ExtensionTrait<()> for init_fs {
     fn init((): ()) -> Extension {
-        init_fs::init()
+        Self::init()
     }
 }
 
 impl ExtensionTrait<FileSystemRc> for deno_fs::deno_fs {
     fn init(fs: FileSystemRc) -> Extension {
-        deno_fs::deno_fs::init(fs)
+        Self::init(fs)
     }
 }
 

--- a/crates/rari/src/runtime/ext/http/mod.rs
+++ b/crates/rari/src/runtime/ext/http/mod.rs
@@ -6,7 +6,7 @@ mod runtime;
 use runtime::deno_http_runtime;
 impl ExtensionTrait<()> for deno_http_runtime {
     fn init((): ()) -> Extension {
-        deno_http_runtime::init()
+        Self::init()
     }
 }
 
@@ -18,12 +18,12 @@ extension!(
 );
 impl ExtensionTrait<()> for init_http {
     fn init((): ()) -> Extension {
-        init_http::init()
+        Self::init()
     }
 }
 impl ExtensionTrait<()> for deno_http::deno_http {
     fn init((): ()) -> Extension {
-        deno_http::deno_http::init(deno_http::Options {
+        Self::init(deno_http::Options {
             http2_builder_hook: None,
             no_legacy_abort: false,
             automatic_compression: false,

--- a/crates/rari/src/runtime/ext/http/runtime.rs
+++ b/crates/rari/src/runtime/ext/http/runtime.rs
@@ -41,14 +41,14 @@ pub enum HttpStartError {
 impl Display for HttpStartError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            HttpStartError::TcpStreamInUse => write!(f, "TCP stream is currently in use"),
-            HttpStartError::TlsStreamInUse => write!(f, "TLS stream is currently in use"),
-            HttpStartError::UnixSocketInUse => write!(f, "Unix socket is currently in use"),
-            HttpStartError::ReuniteTcp(err) => write!(f, "{err}"),
+            Self::TcpStreamInUse => write!(f, "TCP stream is currently in use"),
+            Self::TlsStreamInUse => write!(f, "TLS stream is currently in use"),
+            Self::UnixSocketInUse => write!(f, "Unix socket is currently in use"),
+            Self::ReuniteTcp(err) => write!(f, "{err}"),
             #[cfg(unix)]
-            HttpStartError::ReuniteUnix(err) => write!(f, "{err}"),
-            HttpStartError::Io(err) => write!(f, "{err}"),
-            HttpStartError::Resource(err) => write!(f, "{err}"),
+            Self::ReuniteUnix(err) => write!(f, "{err}"),
+            Self::Io(err) => write!(f, "{err}"),
+            Self::Resource(err) => write!(f, "{err}"),
         }
     }
 }
@@ -56,11 +56,11 @@ impl Display for HttpStartError {
 impl error::Error for HttpStartError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
-            HttpStartError::ReuniteTcp(err) => Some(err),
+            Self::ReuniteTcp(err) => Some(err),
             #[cfg(unix)]
-            HttpStartError::ReuniteUnix(err) => Some(err),
-            HttpStartError::Io(err) => Some(err),
-            HttpStartError::Resource(err) => Some(err),
+            Self::ReuniteUnix(err) => Some(err),
+            Self::Io(err) => Some(err),
+            Self::Resource(err) => Some(err),
             _ => None,
         }
     }
@@ -68,26 +68,26 @@ impl error::Error for HttpStartError {
 
 impl From<tcp::ReuniteError> for HttpStartError {
     fn from(err: tcp::ReuniteError) -> Self {
-        HttpStartError::ReuniteTcp(err)
+        Self::ReuniteTcp(err)
     }
 }
 
 #[cfg(unix)]
 impl From<unix::ReuniteError> for HttpStartError {
     fn from(err: unix::ReuniteError) -> Self {
-        HttpStartError::ReuniteUnix(err)
+        Self::ReuniteUnix(err)
     }
 }
 
 impl From<io::Error> for HttpStartError {
     fn from(err: io::Error) -> Self {
-        HttpStartError::Io(err)
+        Self::Io(err)
     }
 }
 
 impl From<ResourceError> for HttpStartError {
     fn from(err: ResourceError) -> Self {
-        HttpStartError::Resource(err)
+        Self::Resource(err)
     }
 }
 

--- a/crates/rari/src/runtime/ext/io/mod.rs
+++ b/crates/rari/src/runtime/ext/io/mod.rs
@@ -20,17 +20,17 @@ extension!(
 );
 impl ExtensionTrait<()> for init_io {
     fn init((): ()) -> Extension {
-        init_io::init()
+        Self::init()
     }
 }
 impl ExtensionTrait<Option<deno_io::Stdio>> for deno_io::deno_io {
     fn init(pipes: Option<deno_io::Stdio>) -> Extension {
-        deno_io::deno_io::init(pipes)
+        Self::init(pipes)
     }
 }
 impl ExtensionTrait<()> for tty::deno_tty {
     fn init((): ()) -> Extension {
-        tty::deno_tty::init()
+        Self::init()
     }
 }
 

--- a/crates/rari/src/runtime/ext/io/tty_unix.rs
+++ b/crates/rari/src/runtime/ext/io/tty_unix.rs
@@ -59,10 +59,10 @@ pub enum TtyError {
 impl Display for TtyError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            TtyError::Resource(err) => write!(f, "{err}"),
-            TtyError::Io(err) => write!(f, "{err}"),
-            TtyError::Nix(err) => write!(f, "{err}"),
-            TtyError::Other(err) => write!(f, "{err}"),
+            Self::Resource(err) => write!(f, "{err}"),
+            Self::Io(err) => write!(f, "{err}"),
+            Self::Nix(err) => write!(f, "{err}"),
+            Self::Other(err) => write!(f, "{err}"),
         }
     }
 }
@@ -70,23 +70,23 @@ impl Display for TtyError {
 impl error::Error for TtyError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
-            TtyError::Resource(err) => Some(err),
-            TtyError::Io(err) => Some(err),
-            TtyError::Nix(err) => Some(err),
-            TtyError::Other(err) => Some(err),
+            Self::Resource(err) => Some(err),
+            Self::Io(err) => Some(err),
+            Self::Nix(err) => Some(err),
+            Self::Other(err) => Some(err),
         }
     }
 }
 
 impl From<ResourceError> for TtyError {
     fn from(err: ResourceError) -> Self {
-        TtyError::Resource(err)
+        Self::Resource(err)
     }
 }
 
 impl From<Error> for TtyError {
     fn from(err: Error) -> Self {
-        TtyError::Io(err)
+        Self::Io(err)
     }
 }
 

--- a/crates/rari/src/runtime/ext/kv/mod.rs
+++ b/crates/rari/src/runtime/ext/kv/mod.rs
@@ -17,12 +17,12 @@ extension!(
 );
 impl ExtensionTrait<()> for init_kv {
     fn init((): ()) -> Extension {
-        init_kv::init()
+        Self::init()
     }
 }
 impl ExtensionTrait<KvStore> for deno_kv::deno_kv {
     fn init(store: KvStore) -> Extension {
-        deno_kv::deno_kv::init(Box::new(store.handler()), store.config())
+        Self::init(Box::new(store.handler()), store.config())
     }
 }
 
@@ -76,7 +76,7 @@ impl Default for KvConfig {
         const MAX_TOTAL_MUTATION_SIZE_BYTES: usize = 800 * 1024;
         const MAX_TOTAL_KEY_SIZE_BYTES: usize = 80 * 1024;
 
-        KvConfig {
+        Self {
             max_write_key_size_bytes: MAX_WRITE_KEY_SIZE_BYTES,
             max_value_size_bytes: MAX_VALUE_SIZE_BYTES,
             max_read_ranges: MAX_READ_RANGES,

--- a/crates/rari/src/runtime/ext/napi/mod.rs
+++ b/crates/rari/src/runtime/ext/napi/mod.rs
@@ -4,7 +4,7 @@ use super::ExtensionTrait;
 
 impl ExtensionTrait<()> for deno_napi::deno_napi {
     fn init((): ()) -> Extension {
-        deno_napi::deno_napi::init(None)
+        Self::init(None)
     }
 }
 

--- a/crates/rari/src/runtime/ext/node/cjs_translator.rs
+++ b/crates/rari/src/runtime/ext/node/cjs_translator.rs
@@ -37,13 +37,13 @@ impl From<ExtNodeCjsAnalysis<'_>> for CjsAnalysis {
     fn from(analysis: ExtNodeCjsAnalysis) -> Self {
         match analysis {
             ExtNodeCjsAnalysis::Esm(_, Some(exports)) => {
-                CjsAnalysis::EsmAnalysis(ModuleExportsAndReExports {
+                Self::EsmAnalysis(ModuleExportsAndReExports {
                     exports: exports.exports,
                     reexports: exports.reexports,
                 })
             }
-            ExtNodeCjsAnalysis::Esm(_, None) => CjsAnalysis::Esm,
-            ExtNodeCjsAnalysis::Cjs(analysis) => CjsAnalysis::Cjs(ModuleExportsAndReExports {
+            ExtNodeCjsAnalysis::Esm(_, None) => Self::Esm,
+            ExtNodeCjsAnalysis::Cjs(analysis) => Self::Cjs(ModuleExportsAndReExports {
                 exports: analysis.exports,
                 reexports: analysis.reexports,
             }),

--- a/crates/rari/src/runtime/ext/node/mod.rs
+++ b/crates/rari/src/runtime/ext/node/mod.rs
@@ -19,7 +19,7 @@ extension!(
 
 impl ExtensionTrait<()> for init_node {
     fn init((): ()) -> Extension {
-        init_node::init()
+        Self::init()
     }
 }
 
@@ -29,7 +29,7 @@ impl ExtensionTrait<Arc<Resolver>> for deno_node::deno_node {
 
         let fs = resolver.filesystem();
 
-        deno_node::deno_node::init::<DenoInNpmPackageChecker, NpmPackageFolderResolverImpl, RealSys>(
+        Self::init::<DenoInNpmPackageChecker, NpmPackageFolderResolverImpl, RealSys>(
             Some(services),
             fs,
         )

--- a/crates/rari/src/runtime/ext/node_crypto/mod.rs
+++ b/crates/rari/src/runtime/ext/node_crypto/mod.rs
@@ -4,7 +4,7 @@ use super::ExtensionTrait;
 
 impl ExtensionTrait<()> for deno_node_crypto::deno_node_crypto {
     fn init((): ()) -> Extension {
-        deno_node_crypto::deno_node_crypto::init()
+        Self::init()
     }
 }
 

--- a/crates/rari/src/runtime/ext/node_sqlite/mod.rs
+++ b/crates/rari/src/runtime/ext/node_sqlite/mod.rs
@@ -4,7 +4,7 @@ use super::ExtensionTrait;
 
 impl ExtensionTrait<()> for deno_node_sqlite::deno_node_sqlite {
     fn init((): ()) -> Extension {
-        deno_node_sqlite::deno_node_sqlite::init()
+        Self::init()
     }
 }
 

--- a/crates/rari/src/runtime/ext/rari/cache/redis_cache.rs
+++ b/crates/rari/src/runtime/ext/rari/cache/redis_cache.rs
@@ -22,7 +22,7 @@ extension!(
 
 impl ExtensionTrait<()> for rari_redis_cache {
     fn init((): ()) -> Extension {
-        rari_redis_cache::init()
+        Self::init()
     }
 }
 

--- a/crates/rari/src/runtime/ext/rari/mod.rs
+++ b/crates/rari/src/runtime/ext/rari/mod.rs
@@ -34,7 +34,7 @@ extension!(
 
 impl ExtensionTrait<()> for rari {
     fn init((): ()) -> Extension {
-        rari::init()
+        Self::init()
     }
 }
 

--- a/crates/rari/src/runtime/ext/runtime/mod.rs
+++ b/crates/rari/src/runtime/ext/runtime/mod.rs
@@ -21,7 +21,6 @@ use deno_runtime::{
         worker_host::{CreateWebWorkerCb, deno_worker_host},
     },
     permissions::RuntimePermissionDescriptorParser,
-    runtime,
     web_worker::{WebWorker, WebWorkerOptions, WebWorkerServiceOptions},
 };
 use deno_telemetry::OtelConfig;
@@ -72,19 +71,19 @@ extension!(
 impl ExtensionTrait<()> for init_console {
     fn init((): ()) -> Extension {
         colors::set_use_color(true);
-        init_console::init()
+        Self::init()
     }
 }
 
 impl ExtensionTrait<()> for init_runtime {
     fn init((): ()) -> Extension {
-        init_runtime::init()
+        Self::init()
     }
 }
 
 impl ExtensionTrait<()> for deno_runtime::runtime {
     fn init((): ()) -> Extension {
-        let mut ext = runtime::init();
+        let mut ext = Self::init();
 
         ext.esm_files = ext
             .esm_files
@@ -107,7 +106,7 @@ impl ExtensionTrait<()> for deno_runtime::runtime {
 
 impl ExtensionTrait<()> for deno_permissions {
     fn init((): ()) -> Extension {
-        deno_permissions::init()
+        Self::init()
     }
 }
 
@@ -119,37 +118,37 @@ impl ExtensionTrait<(&ExtensionOptions, Option<CrossIsolateStore<SharedRef<Backi
     ) -> Extension {
         let options = WebWorkerCallbackOptions::new(options.0, options.1);
         let callback = create_web_worker_callback(options);
-        deno_worker_host::init(callback, None)
+        Self::init(callback, None)
     }
 }
 
 impl ExtensionTrait<()> for deno_web_worker {
     fn init((): ()) -> Extension {
-        deno_web_worker::init()
+        Self::init()
     }
 }
 
 impl ExtensionTrait<Arc<Resolver>> for deno_process {
     fn init(resolver: Arc<Resolver>) -> Extension {
-        deno_process::init(Some(resolver))
+        Self::init(Some(resolver))
     }
 }
 
 impl ExtensionTrait<()> for deno_os {
     fn init((): ()) -> Extension {
-        deno_os::init(Some(ExitCode::default()))
+        Self::init(Some(ExitCode::default()))
     }
 }
 
 impl ExtensionTrait<()> for deno_bootstrap {
     fn init((): ()) -> Extension {
-        deno_bootstrap::init(None, false)
+        Self::init(None, false)
     }
 }
 
 impl ExtensionTrait<()> for deno_fs_events {
     fn init((): ()) -> Extension {
-        deno_fs_events::init()
+        Self::init()
     }
 }
 

--- a/crates/rari/src/runtime/ext/utilities/mod.rs
+++ b/crates/rari/src/runtime/ext/utilities/mod.rs
@@ -10,7 +10,7 @@ extension!(
 
 impl ExtensionTrait<()> for init_utilities {
     fn init((): ()) -> Extension {
-        init_utilities::init()
+        Self::init()
     }
 }
 

--- a/crates/rari/src/runtime/ext/web/mod.rs
+++ b/crates/rari/src/runtime/ext/web/mod.rs
@@ -19,7 +19,7 @@ extension!(
 impl ExtensionTrait<WebOptions> for init_fetch {
     #[expect(unused_variables)]
     fn init(options: WebOptions) -> Extension {
-        init_fetch::init()
+        Self::init()
     }
 }
 impl ExtensionTrait<WebOptions> for deno_fetch::deno_fetch {
@@ -36,7 +36,7 @@ impl ExtensionTrait<WebOptions> for deno_fetch::deno_fetch {
             resolver: options.resolver.clone(),
         };
 
-        deno_fetch::deno_fetch::init(options)
+        Self::init(options)
     }
 }
 
@@ -49,12 +49,12 @@ extension!(
 impl ExtensionTrait<WebOptions> for init_net {
     #[expect(unused_variables)]
     fn init(options: WebOptions) -> Extension {
-        init_net::init()
+        Self::init()
     }
 }
 impl ExtensionTrait<WebOptions> for deno_net::deno_net {
     fn init(options: WebOptions) -> Extension {
-        deno_net::deno_net::init(
+        Self::init(
             options.root_cert_store_provider.clone(),
             options.unsafely_ignore_certificate_errors.clone(),
         )
@@ -69,13 +69,13 @@ extension!(
 );
 impl ExtensionTrait<()> for init_telemetry {
     fn init((): ()) -> Extension {
-        init_telemetry::init()
+        Self::init()
     }
 }
 
 impl ExtensionTrait<()> for deno_telemetry::deno_telemetry {
     fn init((): ()) -> Extension {
-        deno_telemetry::deno_telemetry::init()
+        Self::init()
     }
 }
 
@@ -91,24 +91,19 @@ extension!(
 );
 impl ExtensionTrait<WebOptions> for init_web {
     fn init(options: WebOptions) -> Extension {
-        init_web::init(options.permissions)
+        Self::init(options.permissions)
     }
 }
 
 impl ExtensionTrait<WebOptions> for deno_web::deno_web {
     fn init(options: WebOptions) -> Extension {
-        deno_web::deno_web::init(
-            options.blob_store,
-            options.base_url,
-            false,
-            options.broadcast_channel,
-        )
+        Self::init(options.blob_store, options.base_url, false, options.broadcast_channel)
     }
 }
 
 impl ExtensionTrait<()> for deno_tls::deno_tls {
     fn init((): ()) -> Extension {
-        deno_tls::deno_tls::init()
+        Self::init()
     }
 }
 

--- a/crates/rari/src/runtime/ext/webgpu/mod.rs
+++ b/crates/rari/src/runtime/ext/webgpu/mod.rs
@@ -4,7 +4,7 @@ use super::ExtensionTrait;
 
 impl ExtensionTrait<()> for deno_webgpu::deno_webgpu {
     fn init((): ()) -> Extension {
-        deno_webgpu::deno_webgpu::init()
+        Self::init()
     }
 }
 

--- a/crates/rari/src/runtime/ext/webidl/mod.rs
+++ b/crates/rari/src/runtime/ext/webidl/mod.rs
@@ -11,7 +11,7 @@ extension!(
 
 impl ExtensionTrait<()> for init_webidl {
     fn init((): ()) -> Extension {
-        init_webidl::init()
+        Self::init()
     }
 }
 

--- a/crates/rari/src/runtime/ext/websocket/mod.rs
+++ b/crates/rari/src/runtime/ext/websocket/mod.rs
@@ -10,12 +10,12 @@ extension!(
 );
 impl ExtensionTrait<()> for init_websocket {
     fn init((): ()) -> Extension {
-        init_websocket::init()
+        Self::init()
     }
 }
 impl ExtensionTrait<WebOptions> for deno_websocket::deno_websocket {
     fn init(_options: WebOptions) -> Extension {
-        deno_websocket::deno_websocket::init()
+        Self::init()
     }
 }
 

--- a/crates/rari/src/runtime/ext/webstorage/mod.rs
+++ b/crates/rari/src/runtime/ext/webstorage/mod.rs
@@ -12,12 +12,12 @@ extension!(
 );
 impl ExtensionTrait<()> for init_webstorage {
     fn init((): ()) -> Extension {
-        init_webstorage::init()
+        Self::init()
     }
 }
 impl ExtensionTrait<Option<PathBuf>> for deno_webstorage::deno_webstorage {
     fn init(origin_storage_dir: Option<PathBuf>) -> Extension {
-        deno_webstorage::deno_webstorage::init(origin_storage_dir)
+        Self::init(origin_storage_dir)
     }
 }
 

--- a/crates/rari/src/server/cache/warmup.rs
+++ b/crates/rari/src/server/cache/warmup.rs
@@ -81,6 +81,7 @@ pub async fn warm_cache(state: &ServerState) {
     );
 }
 
+#[expect(clippy::too_many_lines)]
 async fn warm_route(
     state: &ServerState,
     app_router: &Arc<AppRouter>,

--- a/crates/rari/src/server/compression/stream.rs
+++ b/crates/rari/src/server/compression/stream.rs
@@ -40,6 +40,7 @@ impl CompressionEncoding {
     }
 }
 
+#[expect(clippy::too_many_lines)]
 pub fn compress_stream<S>(
     input: S,
     encoding: CompressionEncoding,

--- a/crates/rari/src/server/config.rs
+++ b/crates/rari/src/server/config.rs
@@ -1,3 +1,5 @@
+#![expect(clippy::missing_errors_doc, clippy::too_many_lines)]
+
 use std::{
     cmp::Ordering,
     env,

--- a/crates/rari/src/server/config.rs
+++ b/crates/rari/src/server/config.rs
@@ -27,8 +27,8 @@ pub enum Mode {
 impl Display for Mode {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Mode::Development => write!(f, "development"),
-            Mode::Production => write!(f, "production"),
+            Self::Development => write!(f, "development"),
+            Self::Production => write!(f, "production"),
         }
     }
 }
@@ -226,26 +226,24 @@ enum RoutePattern {
 impl RoutePattern {
     fn from_pattern(pattern: &str) -> Self {
         if let Some(prefix) = pattern.strip_suffix("/*") {
-            RoutePattern::Prefix(prefix.to_string())
+            Self::Prefix(prefix.to_string())
         } else if pattern.contains('*') {
             let escaped = regex::escape(pattern);
             let regex_pattern = escaped.cow_replace(r"\*", ".*");
             match regex::Regex::new(&format!("^{regex_pattern}$")) {
-                Ok(regex) => RoutePattern::Regex(regex),
-                Err(_) => RoutePattern::Exact(pattern.to_string()),
+                Ok(regex) => Self::Regex(regex),
+                Err(_) => Self::Exact(pattern.to_string()),
             }
         } else {
-            RoutePattern::Exact(pattern.to_string())
+            Self::Exact(pattern.to_string())
         }
     }
 
     fn matches(&self, path: &str) -> bool {
         match self {
-            RoutePattern::Exact(pattern) => pattern == path,
-            RoutePattern::Prefix(prefix) => {
-                path == prefix || path.starts_with(&format!("{prefix}/"))
-            }
-            RoutePattern::Regex(regex) => regex.is_match(path),
+            Self::Exact(pattern) => pattern == path,
+            Self::Prefix(prefix) => path == prefix || path.starts_with(&format!("{prefix}/")),
+            Self::Regex(regex) => regex.is_match(path),
         }
     }
 }
@@ -291,7 +289,7 @@ impl From<&CacheControlConfig> for CompiledCacheControlConfig {
             }
         });
 
-        CompiledCacheControlConfig { routes }
+        Self { routes }
     }
 }
 
@@ -674,11 +672,11 @@ impl Config {
         Ok(config)
     }
 
-    pub fn get() -> Option<&'static Config> {
+    pub fn get() -> Option<&'static Self> {
         GLOBAL_CONFIG.get()
     }
 
-    pub fn set_global(config: Config) -> Result<(), Box<Config>> {
+    pub fn set_global(config: Self) -> Result<(), Box<Self>> {
         GLOBAL_CONFIG.set(config).map_err(Box::new)
     }
 

--- a/crates/rari/src/server/core/mod.rs
+++ b/crates/rari/src/server/core/mod.rs
@@ -96,6 +96,7 @@ pub struct Server {
 }
 
 impl Server {
+    #[expect(clippy::missing_errors_doc, clippy::too_many_lines)]
     pub async fn new(config: Config) -> Result<Self, RariError> {
         Config::set_global(config.clone())
             .map_err(|_| RariError::configuration("Failed to set global config".to_string()))?;
@@ -367,6 +368,7 @@ impl Server {
         Ok(router)
     }
 
+    #[expect(clippy::missing_errors_doc)]
     pub async fn start(self) -> Result<(), RariError> {
         self.display_startup_message();
 

--- a/crates/rari/src/server/core/utils/client.rs
+++ b/crates/rari/src/server/core/utils/client.rs
@@ -4,6 +4,7 @@ use reqwest::Client;
 
 static HTTP_CLIENT: OnceLock<Result<Client, reqwest::Error>> = OnceLock::new();
 
+#[expect(clippy::missing_errors_doc)]
 pub fn get_http_client() -> Result<&'static Client, String> {
     HTTP_CLIENT
         .get_or_init(|| Client::builder().build())

--- a/crates/rari/src/server/core/utils/component.rs
+++ b/crates/rari/src/server/core/utils/component.rs
@@ -113,6 +113,7 @@ if (!globalThis.{module_key}) {{
     )
 }
 
+#[expect(clippy::missing_errors_doc)]
 pub fn extract_component_id(file_path: &str) -> Result<String, Box<dyn Error + Send + Sync>> {
     let path = Path::new(file_path);
 
@@ -142,6 +143,7 @@ pub fn extract_component_id(file_path: &str) -> Result<String, Box<dyn Error + S
     ))
 }
 
+#[expect(clippy::missing_errors_doc)]
 pub fn get_dist_path_for_component(
     file_path: &str,
 ) -> Result<PathBuf, Box<dyn Error + Send + Sync>> {

--- a/crates/rari/src/server/core/utils/path_validation.rs
+++ b/crates/rari/src/server/core/utils/path_validation.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use cow_utils::CowUtils;
 use rari_error::RariError;
 
+#[expect(clippy::missing_errors_doc)]
 pub fn validate_safe_path(base: &Path, requested: &str) -> Result<PathBuf, RariError> {
     if requested.contains("..") {
         return Err(RariError::bad_request("Invalid path: contains '..' pattern"));
@@ -71,6 +72,7 @@ pub fn normalize_component_path(file_path: &str) -> String {
     file_path.cow_replace('\\', "/").into_owned()
 }
 
+#[expect(clippy::missing_errors_doc)]
 pub fn validate_component_path(file_path: &str) -> Result<(), RariError> {
     let normalized = normalize_component_path(file_path);
 

--- a/crates/rari/src/server/handlers/mod.rs
+++ b/crates/rari/src/server/handlers/mod.rs
@@ -1,3 +1,4 @@
+#![expect(clippy::missing_errors_doc, clippy::too_many_lines)]
 pub mod actions;
 pub mod api;
 pub mod app;

--- a/crates/rari/src/server/image/mod.rs
+++ b/crates/rari/src/server/image/mod.rs
@@ -23,6 +23,7 @@ pub struct ImageState {
     pub optimizer: Arc<ImageOptimizer>,
 }
 
+#[expect(clippy::missing_errors_doc)]
 pub async fn handle_image_request(
     State(state): State<ImageState>,
     Query(params): Query<OptimizeParams>,

--- a/crates/rari/src/server/image/mod.rs
+++ b/crates/rari/src/server/image/mod.rs
@@ -81,12 +81,12 @@ pub enum ImageError {
 impl IntoResponse for ImageError {
     fn into_response(self) -> Response {
         let (status, message) = match self {
-            ImageError::InvalidUrl(_) | ImageError::InvalidParams(_) => {
+            Self::InvalidUrl(_) | Self::InvalidParams(_) => {
                 (StatusCode::BAD_REQUEST, self.to_string())
             }
-            ImageError::UnauthorizedDomain(_) => (StatusCode::FORBIDDEN, self.to_string()),
-            ImageError::FetchError(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
-            ImageError::ProcessingError(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+            Self::UnauthorizedDomain(_) => (StatusCode::FORBIDDEN, self.to_string()),
+            Self::FetchError(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
+            Self::ProcessingError(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };
 
         (status, message).into_response()

--- a/crates/rari/src/server/image/optimizer.rs
+++ b/crates/rari/src/server/image/optimizer.rs
@@ -1,3 +1,4 @@
+#![expect(clippy::missing_errors_doc, clippy::too_many_lines)]
 use std::{
     path::{Path, PathBuf},
     sync::{

--- a/crates/rari/src/server/image/types.rs
+++ b/crates/rari/src/server/image/types.rs
@@ -20,11 +20,11 @@ impl<'de> Deserialize<'de> for ImageFormat {
     {
         let s = String::deserialize(deserializer)?;
         match s.cow_to_lowercase().as_ref() {
-            "avif" => Ok(ImageFormat::Avif),
-            "webp" => Ok(ImageFormat::WebP),
-            "jpeg" | "jpg" => Ok(ImageFormat::Jpeg),
-            "png" => Ok(ImageFormat::Png),
-            "gif" => Ok(ImageFormat::Gif),
+            "avif" => Ok(Self::Avif),
+            "webp" => Ok(Self::WebP),
+            "jpeg" | "jpg" => Ok(Self::Jpeg),
+            "png" => Ok(Self::Png),
+            "gif" => Ok(Self::Gif),
             _ => Err(Error::unknown_variant(&s, &["avif", "webp", "jpeg", "jpg", "png", "gif"])),
         }
     }
@@ -33,22 +33,22 @@ impl<'de> Deserialize<'de> for ImageFormat {
 impl ImageFormat {
     pub fn from_mime(mime: &str) -> Option<Self> {
         match mime {
-            "image/avif" => Some(ImageFormat::Avif),
-            "image/webp" => Some(ImageFormat::WebP),
-            "image/jpeg" | "image/jpg" => Some(ImageFormat::Jpeg),
-            "image/png" => Some(ImageFormat::Png),
-            "image/gif" => Some(ImageFormat::Gif),
+            "image/avif" => Some(Self::Avif),
+            "image/webp" => Some(Self::WebP),
+            "image/jpeg" | "image/jpg" => Some(Self::Jpeg),
+            "image/png" => Some(Self::Png),
+            "image/gif" => Some(Self::Gif),
             _ => None,
         }
     }
 
     pub fn extension(&self) -> &'static str {
         match self {
-            ImageFormat::Avif => "avif",
-            ImageFormat::WebP => "webp",
-            ImageFormat::Jpeg => "jpg",
-            ImageFormat::Png => "png",
-            ImageFormat::Gif => "gif",
+            Self::Avif => "avif",
+            Self::WebP => "webp",
+            Self::Jpeg => "jpg",
+            Self::Png => "png",
+            Self::Gif => "gif",
         }
     }
 }

--- a/crates/rari/src/server/loaders/cache.rs
+++ b/crates/rari/src/server/loaders/cache.rs
@@ -12,6 +12,7 @@ use crate::server::ServerState;
 pub struct CacheLoader;
 
 impl CacheLoader {
+    #[expect(clippy::missing_errors_doc)]
     pub async fn load_page_cache_configs(state: &ServerState) -> Result<(), RariError> {
         let pages_dir = Path::new("src/pages");
         if !pages_dir.exists() {

--- a/crates/rari/src/server/loaders/component.rs
+++ b/crates/rari/src/server/loaders/component.rs
@@ -1,3 +1,4 @@
+#![expect(clippy::missing_errors_doc, clippy::too_many_lines)]
 use std::{fs, future::Future, path::Path, pin::Pin, sync::Arc};
 
 use cow_utils::CowUtils;

--- a/crates/rari/src/server/middleware/proxy.rs
+++ b/crates/rari/src/server/middleware/proxy.rs
@@ -242,6 +242,7 @@ fn resolve_rari_package_dir() -> Option<PathBuf> {
     }
 }
 
+#[expect(clippy::missing_errors_doc)]
 pub async fn initialize_proxy(state: &ServerState) -> Result<(), Box<dyn Error>> {
     if !is_proxy_enabled() {
         return Ok(());

--- a/crates/rari/src/server/middleware/request_context.rs
+++ b/crates/rari/src/server/middleware/request_context.rs
@@ -187,6 +187,7 @@ impl RequestContext {
         }
     }
 
+    #[expect(clippy::missing_errors_doc)]
     pub async fn fetch_with_cache(
         &self,
         url: &str,

--- a/crates/rari/src/server/mod.rs
+++ b/crates/rari/src/server/mod.rs
@@ -1,5 +1,3 @@
-#![expect(clippy::missing_errors_doc, clippy::too_many_lines)]
-
 pub mod cache;
 pub mod compression;
 pub mod config;

--- a/crates/rari/src/server/og/cache.rs
+++ b/crates/rari/src/server/og/cache.rs
@@ -86,6 +86,7 @@ impl OgImageCache {
         None
     }
 
+    #[expect(clippy::missing_errors_doc)]
     pub async fn insert(&self, key: String, value: Vec<u8>) -> Result<(), Box<dyn Error>> {
         self.ensure_cache_dir().await;
 
@@ -96,6 +97,7 @@ impl OgImageCache {
         Ok(())
     }
 
+    #[expect(clippy::missing_errors_doc)]
     pub async fn remove(&self, key: &str) -> Result<Option<Vec<u8>>, CacheError> {
         let prev = match self.handler.get(&Self::ns(key)).await {
             Ok(Some(bytes)) => Some(bytes),
@@ -118,6 +120,7 @@ impl OgImageCache {
         }
     }
 
+    #[expect(clippy::missing_errors_doc)]
     pub async fn clear(&self) -> Result<(), CacheError> {
         self.handler.clear_prefix(KEY_PREFIX).await?;
 

--- a/crates/rari/src/server/og/generator.rs
+++ b/crates/rari/src/server/og/generator.rs
@@ -71,6 +71,7 @@ impl OgImageGenerator {
         }
     }
 
+    #[expect(clippy::missing_errors_doc)]
     pub async fn load_manifest(&self, manifest_path: &str) -> Result<(), OgImageError> {
         let content = fs::read_to_string(manifest_path)
             .await
@@ -125,6 +126,7 @@ impl OgImageGenerator {
         Self::find_matching_entry(&manifest, route_path).map(|(entry, _)| entry.clone())
     }
 
+    #[expect(clippy::missing_errors_doc)]
     pub async fn generate(&self, route_path: &str) -> Result<(Vec<u8>, bool), OgImageError> {
         const MAX_OG_WIDTH: u32 = 2400;
         const MAX_OG_HEIGHT: u32 = 1260;
@@ -401,6 +403,7 @@ impl OgImageGenerator {
         self.cache.clear().await.expect("clear");
     }
 
+    #[expect(clippy::missing_errors_doc)]
     pub async fn invalidate(&self, route_path: &str) -> Result<(), CacheError> {
         self.cache.remove(route_path).await.map(|_| ())
     }

--- a/crates/rari/src/server/og/layout/mod.rs
+++ b/crates/rari/src/server/og/layout/mod.rs
@@ -681,5 +681,5 @@ pub struct ComputedLayout {
     pub padding: taffy::Rect<f32>,
     pub element: JsxElement,
     pub style: FxHashMap<String, String>,
-    pub children: Vec<ComputedLayout>,
+    pub children: Vec<Self>,
 }

--- a/crates/rari/src/server/og/layout/style/gradient.rs
+++ b/crates/rari/src/server/og/layout/style/gradient.rs
@@ -12,9 +12,9 @@ pub enum StopPosition {
 impl StopPosition {
     pub fn to_px(self, axis_length: f32) -> f32 {
         match self {
-            StopPosition::Percentage(pct) => (pct / 100.0) * axis_length,
-            StopPosition::Px(px) => px,
-            StopPosition::Normalized(n) => n * axis_length,
+            Self::Percentage(pct) => (pct / 100.0) * axis_length,
+            Self::Px(px) => px,
+            Self::Normalized(n) => n * axis_length,
         }
     }
 }
@@ -66,7 +66,7 @@ impl LinearGradient {
             return None;
         }
 
-        Some(LinearGradient { angle_deg, stops })
+        Some(Self { angle_deg, stops })
     }
 
     fn split_gradient_parts(s: &str) -> Vec<String> {

--- a/crates/rari/src/server/og/mod.rs
+++ b/crates/rari/src/server/og/mod.rs
@@ -69,19 +69,19 @@ pub enum OgImageError {
 
 impl From<RariError> for OgImageError {
     fn from(err: RariError) -> Self {
-        OgImageError::InternalError(err.to_string())
+        Self::InternalError(err.to_string())
     }
 }
 
 impl IntoResponse for OgImageError {
     fn into_response(self) -> Response {
         let (status, message) = match self {
-            OgImageError::ComponentNotFound(_) => (StatusCode::NOT_FOUND, self.to_string()),
-            OgImageError::InvalidParams(_) => (StatusCode::BAD_REQUEST, self.to_string()),
-            OgImageError::ExecutionError(_) | OgImageError::GenerationError(_) => {
+            Self::ComponentNotFound(_) => (StatusCode::NOT_FOUND, self.to_string()),
+            Self::InvalidParams(_) => (StatusCode::BAD_REQUEST, self.to_string()),
+            Self::ExecutionError(_) | Self::GenerationError(_) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, self.to_string())
             }
-            OgImageError::InternalError(_) => {
+            Self::InternalError(_) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error".to_string())
             }
         };

--- a/crates/rari/src/server/og/mod.rs
+++ b/crates/rari/src/server/og/mod.rs
@@ -19,6 +19,7 @@ pub use generator::OgImageGenerator;
 use rari_error::RariError;
 pub use types::{OgImageParams, OgImageResult};
 
+#[expect(clippy::missing_errors_doc)]
 pub async fn handle_og_image_request(
     State(generator): State<Arc<OgImageGenerator>>,
     Path(route_path): Path<String>,

--- a/crates/rari/src/server/og/rendering/border.rs
+++ b/crates/rari/src/server/og/rendering/border.rs
@@ -25,8 +25,8 @@ pub(super) struct BorderRadius {
 }
 
 impl BorderRadius {
-    pub fn inset_by(&self, border: &BorderWidth) -> BorderRadius {
-        BorderRadius {
+    pub fn inset_by(&self, border: &BorderWidth) -> Self {
+        Self {
             top_left: (self.top_left - border.top.max(border.left)).max(0.0),
             top_right: (self.top_right - border.top.max(border.right)).max(0.0),
             bottom_right: (self.bottom_right - border.bottom.max(border.right)).max(0.0),

--- a/crates/rari/src/server/og/rendering/image.rs
+++ b/crates/rari/src/server/og/rendering/image.rs
@@ -62,6 +62,7 @@ impl ImageRenderer {
         Ok(())
     }
 
+    #[expect(clippy::too_many_lines)]
     fn process_object_fit(
         source_image: RgbaImage,
         target_width: u32,

--- a/crates/rari/src/server/rendering/metadata_injection.rs
+++ b/crates/rari/src/server/rendering/metadata_injection.rs
@@ -8,6 +8,7 @@ use crate::{
     server::image::ImageOptimizer,
 };
 
+#[expect(clippy::too_many_lines)]
 pub fn inject_metadata(
     html: &str,
     metadata: &PageMetadata,

--- a/crates/rari/src/server/rendering/utils.rs
+++ b/crates/rari/src/server/rendering/utils.rs
@@ -179,6 +179,7 @@ pub async fn extract_body_scripts_from_index_html() -> Option<String> {
     None
 }
 
+#[expect(clippy::missing_errors_doc)]
 pub async fn inject_assets_into_html(html: &str, config: &Config) -> Result<String, StatusCode> {
     let has_root_before = html.contains(r#"id="root""#);
     let is_complete_document = is_complete_html_document(html);
@@ -224,6 +225,7 @@ fn is_complete_html_document(html: &str) -> bool {
     has_doctype_or_html && has_body
 }
 
+#[expect(clippy::too_many_lines)]
 async fn inject_assets_into_complete_document(
     html: &str,
     config: &Config,

--- a/crates/rari/src/server/routing/api_error.rs
+++ b/crates/rari/src/server/routing/api_error.rs
@@ -134,27 +134,27 @@ impl From<ApiRouteError> for RariError {
     fn from(error: ApiRouteError) -> Self {
         match error {
             ApiRouteError::NotFound { message, .. } => {
-                RariError::not_found(message).with_property("error_type", "api_route_not_found")
+                Self::not_found(message).with_property("error_type", "api_route_not_found")
             }
             ApiRouteError::MethodNotAllowed { message, allowed_methods, .. } => {
-                RariError::bad_request(message)
+                Self::bad_request(message)
                     .with_property("error_type", "method_not_allowed")
                     .with_property("allowed_methods", &allowed_methods.join(","))
             }
             ApiRouteError::HandlerError { message, .. } => {
-                RariError::js_execution(message).with_property("error_type", "handler_error")
+                Self::js_execution(message).with_property("error_type", "handler_error")
             }
             ApiRouteError::InvalidResponse { message, .. } => {
-                RariError::internal(message).with_property("error_type", "invalid_response")
+                Self::internal(message).with_property("error_type", "invalid_response")
             }
             ApiRouteError::HandlerFileNotFound { message, .. } => {
-                RariError::not_found(message).with_property("error_type", "handler_file_not_found")
+                Self::not_found(message).with_property("error_type", "handler_file_not_found")
             }
             ApiRouteError::HandlerLoadError { message, .. } => {
-                RariError::internal(message).with_property("error_type", "handler_load_error")
+                Self::internal(message).with_property("error_type", "handler_load_error")
             }
             ApiRouteError::BodyParseError { message, .. } => {
-                RariError::bad_request(message).with_property("error_type", "body_parse_error")
+                Self::bad_request(message).with_property("error_type", "body_parse_error")
             }
         }
     }

--- a/crates/rari/src/server/routing/api_routes.rs
+++ b/crates/rari/src/server/routing/api_routes.rs
@@ -78,6 +78,7 @@ impl ApiRouteHandler {
         Self { runtime, manifest: Arc::new(manifest), handler_cache: Arc::new(DashMap::new()) }
     }
 
+    #[expect(clippy::missing_errors_doc)]
     pub async fn from_file(
         runtime: Arc<JsExecutionRuntime>,
         manifest_path: &str,
@@ -134,6 +135,7 @@ impl ApiRouteHandler {
         None
     }
 
+    #[expect(clippy::missing_errors_doc)]
     pub fn match_route(&self, path: &str, method: &str) -> Result<ApiRouteMatch, RariError> {
         let normalized_path = Self::normalize_path(path);
 
@@ -378,6 +380,7 @@ impl ApiRouteHandler {
         Ok(dist_path)
     }
 
+    #[expect(clippy::missing_errors_doc, clippy::too_many_lines)]
     pub async fn execute_handler(
         &self,
         route_match: &ApiRouteMatch,

--- a/crates/rari/src/server/routing/app_router.rs
+++ b/crates/rari/src/server/routing/app_router.rs
@@ -147,6 +147,7 @@ impl AppRouter {
         Self { manifest: Arc::new(manifest) }
     }
 
+    #[expect(clippy::missing_errors_doc)]
     pub async fn from_file(path: &str) -> Result<Self, RariError> {
         let content = fs::read_to_string(path)
             .await
@@ -158,6 +159,7 @@ impl AppRouter {
         Ok(Self::new(manifest))
     }
 
+    #[expect(clippy::missing_errors_doc)]
     pub fn match_route(&self, path: &str) -> Result<AppRouteMatch, RariError> {
         let normalized_path = Self::normalize_path(path);
 

--- a/crates/rari/src/server/routing/types.rs
+++ b/crates/rari/src/server/routing/types.rs
@@ -33,8 +33,8 @@ pub enum ParamValue {
 impl fmt::Display for ParamValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ParamValue::Single(s) => write!(f, "{s}"),
-            ParamValue::Multiple(v) => write!(f, "{}", v.join("/")),
+            Self::Single(s) => write!(f, "{s}"),
+            Self::Multiple(v) => write!(f, "{}", v.join("/")),
         }
     }
 }
@@ -43,16 +43,16 @@ impl ParamValue {
     #[cfg(test)]
     pub fn as_string(&self) -> Option<&String> {
         match self {
-            ParamValue::Single(s) => Some(s),
-            ParamValue::Multiple(_) => None,
+            Self::Single(s) => Some(s),
+            Self::Multiple(_) => None,
         }
     }
 
     #[cfg(test)]
     pub fn as_vec(&self) -> Option<&Vec<String>> {
         match self {
-            ParamValue::Single(_) => None,
-            ParamValue::Multiple(v) => Some(v),
+            Self::Single(_) => None,
+            Self::Multiple(v) => Some(v),
         }
     }
 }

--- a/crates/rari/src/server/vite.rs
+++ b/crates/rari/src/server/vite.rs
@@ -331,6 +331,7 @@ fn create_error_response(status: StatusCode, message: &str) -> Response<Body> {
         })
 }
 
+#[expect(clippy::missing_errors_doc)]
 pub async fn check_vite_server_health() -> Result<(), RariError> {
     let config = Config::get().ok_or_else(|| {
         RariError::configuration("Global configuration not available".to_string())


### PR DESCRIPTION
- Replace explicit type names with Self in enum constructors and implementations
- Move workspace.dependencies section before workspace.lints in Cargo.toml for better organization
- Add use_self = "warn" to workspace clippy lints to enforce this pattern going forward
- Update RscElement, RSCTree, Error, and RariError implementations to use Self consistently
- Apply Self in From trait implementations across error handling modules
- Standardize Self usage in type constructors throughout runtime and server modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved escaping for generated stylesheet link `href` attributes to reduce malformed HTML risk.
  * Kept image and OG error responses consistent while tightening internal error handling.
  * Updated global config access and route-matching helpers for more consistent behavior.

* **Refactor**
  * Standardized internal initialization and self-references across runtime extensions.
  * Simplified recursive type definitions and variant construction patterns across RSC/RSC tree types and related helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->