### PR TITLE
refactor: simplify extension trait implementations across runtime modules

### DIFF
--- a/crates/rari-rsc/src/flight/serializer.rs
+++ b/crates/rari-rsc/src/flight/serializer.rs
@@ -12,13 +12,12 @@ use base64::{Engine, engine::general_purpose::STANDARD};
 use cow_utils::CowUtils;
 use rari_error::RariError;
 use rustc_hash::{FxHashMap, FxHashSet};
-use serde_json::{Map, Value, json};
+use serde_json::{Map, Value};
 use smallvec::SmallVec;
-use tracing::error;
 
 use crate::{
     core::{RscFlightTag, ServerComponentExecutor},
-    flight::escape::escape_rsc_value,
+    flight::escape,
     types::{RSCTree, ReactElement},
 };
 
@@ -394,7 +393,7 @@ impl RscSerializer {
 
                 let props_value =
                     Value::Object(error_props.into_iter().collect::<Map<String, Value>>());
-                let escaped_props = escape_rsc_value(&props_value);
+                let escaped_props = escape::escape_rsc_value(&props_value);
                 let props_json =
                     serde_json::to_string(&escaped_props).unwrap_or_else(|_| "{}".to_string());
                 format!(r#"["$","div",{key_json},{props_json}]"#)
@@ -438,7 +437,7 @@ impl RscSerializer {
 
         let props_value =
             Value::Object(processed_props.into_iter().collect::<Map<String, Value>>());
-        let escaped_props = escape_rsc_value(&props_value);
+        let escaped_props = escape::escape_rsc_value(&props_value);
         let props_json = serde_json::to_string(&escaped_props).unwrap_or_else(|_| "{}".to_string());
 
         format!(r#"["$","{module_ref}",{key_json},{props_json}]"#)
@@ -541,7 +540,7 @@ impl RscSerializer {
         };
 
         let props_value = Value::Object(element_props.into_iter().collect::<Map<String, Value>>());
-        let escaped_props = escape_rsc_value(&props_value);
+        let escaped_props = escape::escape_rsc_value(&props_value);
         let props_json = serde_json::to_string(&escaped_props).unwrap_or_else(|_| "{}".to_string());
 
         format!(r#"["$","{tag}",{key_json},{props_json}]"#)
@@ -575,7 +574,7 @@ impl RscSerializer {
         let error_id = self.get_next_row_id();
 
         let digest = Self::generate_error_digest(component_name, message);
-        let error_data = json!({
+        let error_data = serde_json::json!({
             "digest": digest,
             "message": message
         });
@@ -618,7 +617,7 @@ impl RscSerializer {
 
         let chunk_name = module_ref.path.clone();
 
-        let module_data = json!([module_ref.path, [chunk_name], export_name]);
+        let module_data = serde_json::json!([module_ref.path, [chunk_name], export_name]);
 
         let import_line =
             RscFlightTag::ModuleImport.format_row(module_id, &module_data.to_string());
@@ -861,7 +860,9 @@ impl RscSerializer {
                     result.insert(key.clone(), validated_value);
                 }
                 Err(_) => {
-                    error!("[rari] RSC: Prop validation error for '{key}': {validation_errors:?}");
+                    tracing::error!(
+                        "[rari] RSC: Prop validation error for '{key}': {validation_errors:?}"
+                    );
                     result.insert(key.clone(), Value::Null);
                 }
             }
@@ -869,12 +870,16 @@ impl RscSerializer {
         }
 
         if !validation_errors.is_empty() {
-            error!(
+            tracing::error!(
                 "[rari] RSC: Props validation completed with {} errors",
                 validation_errors.len()
             );
             for error in &validation_errors {
-                error!("[rari] RSC: Validation error: {} - {}", error.field_path, error.message);
+                tracing::error!(
+                    "[rari] RSC: Validation error: {} - {}",
+                    error.field_path,
+                    error.message
+                );
             }
         }
 
@@ -1114,7 +1119,7 @@ impl RscSerializer {
                 data_array.iter().filter_map(|v| v.as_u64().map(|n| n as u8)).collect();
 
             let base64_data = base64_encode(&bytes);
-            let blob_model = json!([blob_type, base64_data]);
+            let blob_model = serde_json::json!([blob_type, base64_data]);
             let blob_json = serde_json::to_string(&blob_model).unwrap_or_else(|_| "[]".to_string());
             let chunk_line = format!("{chunk_id:x}:{blob_json}");
             self.output_lines.push(chunk_line);
@@ -1272,7 +1277,7 @@ impl RscSerializer {
     ) -> String {
         let boundary_row_id = self.get_next_row_id();
 
-        let boundary_data = json!([
+        let boundary_data = serde_json::json!([
             "$",
             "$Sreact.suspense",
             null,
@@ -1360,7 +1365,7 @@ impl RscSerializer {
     ) -> Result<String, RariError> {
         let boundary_row_id = self.get_next_row_id();
 
-        let boundary_data = json!([
+        let boundary_data = serde_json::json!([
             "$",
             "$Sreact.suspense",
             null,
@@ -1460,8 +1465,8 @@ mod tests {
         let mut serializer = RscSerializer::new();
 
         let mut props = FxHashMap::default();
-        props.insert("className".to_string(), json!("test-class"));
-        props.insert("children".to_string(), json!("Hello World"));
+        props.insert("className".to_string(), serde_json::json!("test-class"));
+        props.insert("children".to_string(), serde_json::json!("Hello World"));
 
         let element = SerializedReactElement::create_html_element("div", Some(props));
         let result = serializer.serialize_to_rsc_format(&element);
@@ -1477,8 +1482,8 @@ mod tests {
         serializer.register_client_component("Button", "./components/Button.client.js", "default");
 
         let mut props = FxHashMap::default();
-        props.insert("onClick".to_string(), json!("handleClick"));
-        props.insert("children".to_string(), json!("Click me"));
+        props.insert("onClick".to_string(), serde_json::json!("handleClick"));
+        props.insert("children".to_string(), serde_json::json!("Click me"));
 
         let element = SerializedReactElement::create_client_component("Button", Some(props));
         let result = serializer.serialize_to_rsc_format(&element);
@@ -1505,7 +1510,7 @@ mod tests {
         let mut serializer = RscSerializer::new();
 
         let mut props = FxHashMap::default();
-        props.insert("userId".to_string(), json!(123));
+        props.insert("userId".to_string(), serde_json::json!(123));
 
         let element = SerializedReactElement::create_server_component("UserProfile", Some(props));
         let result = serializer.serialize_to_rsc_format(&element);
@@ -1517,7 +1522,7 @@ mod tests {
     fn test_serialize_fragment() {
         let mut serializer = RscSerializer::new();
 
-        let children = vec![json!("First child"), json!("Second child")];
+        let children = vec![serde_json::json!("First child"), serde_json::json!("Second child")];
 
         let element = SerializedReactElement::create_fragment(Some(children));
         let result = serializer.serialize_to_rsc_format(&element);
@@ -1551,7 +1556,7 @@ mod tests {
         serializer.register_client_component("Button", "./components/Button.client.js", "default");
 
         let mut div_props = FxHashMap::default();
-        div_props.insert("className".to_string(), json!("container"));
+        div_props.insert("className".to_string(), serde_json::json!("container"));
 
         let div_element = SerializedReactElement::create_html_element("div", Some(div_props));
 
@@ -1587,18 +1592,18 @@ mod tests {
         let mut serializer = RscSerializer::new();
 
         let mut complex_props = FxHashMap::default();
-        complex_props.insert("valid_string".to_string(), json!("Hello"));
-        complex_props.insert("valid_number".to_string(), json!(42));
-        complex_props.insert("valid_boolean".to_string(), json!(true));
-        complex_props.insert("valid_null".to_string(), json!(null));
+        complex_props.insert("valid_string".to_string(), serde_json::json!("Hello"));
+        complex_props.insert("valid_number".to_string(), serde_json::json!(42));
+        complex_props.insert("valid_boolean".to_string(), serde_json::json!(true));
+        complex_props.insert("valid_null".to_string(), serde_json::json!(null));
         complex_props.insert(
             "nested_object".to_string(),
-            json!({
+            serde_json::json!({
                 "inner": "value",
                 "count": 10
             }),
         );
-        complex_props.insert("array_prop".to_string(), json!([1, 2, 3]));
+        complex_props.insert("array_prop".to_string(), serde_json::json!([1, 2, 3]));
 
         let element = SerializedReactElement::create_html_element("div", Some(complex_props));
         let result = serializer.serialize_to_rsc_format(&element);
@@ -1615,9 +1620,11 @@ mod tests {
         let mut serializer = RscSerializer::new();
 
         let mut props_with_function = FxHashMap::default();
-        props_with_function
-            .insert("onClick".to_string(), json!("function handleClick() { return true; }"));
-        props_with_function.insert("valid_prop".to_string(), json!("valid value"));
+        props_with_function.insert(
+            "onClick".to_string(),
+            serde_json::json!("function handleClick() { return true; }"),
+        );
+        props_with_function.insert("valid_prop".to_string(), serde_json::json!("valid value"));
 
         let element =
             SerializedReactElement::create_html_element("button", Some(props_with_function));
@@ -1633,11 +1640,11 @@ mod tests {
         let mut serializer = RscSerializer::new();
 
         let mut props = FxHashMap::default();
-        props.insert("safe_prop".to_string(), json!("safe"));
+        props.insert("safe_prop".to_string(), serde_json::json!("safe"));
 
         props.insert(
             "nested".to_string(),
-            json!({
+            serde_json::json!({
                 "level1": {
                     "level2": {
                         "data": "deep value"
@@ -1658,9 +1665,9 @@ mod tests {
         let mut serializer = RscSerializer::new();
 
         let mut props = FxHashMap::default();
-        props.insert("symbol_prop".to_string(), json!("Symbol(test)"));
-        props.insert("object_prop".to_string(), json!("Object [object Object]"));
-        props.insert("valid_prop".to_string(), json!("normal string"));
+        props.insert("symbol_prop".to_string(), serde_json::json!("Symbol(test)"));
+        props.insert("object_prop".to_string(), serde_json::json!("Object [object Object]"));
+        props.insert("valid_prop".to_string(), serde_json::json!("normal string"));
 
         let element = SerializedReactElement::create_html_element("div", Some(props));
         let result = serializer.serialize_to_rsc_format(&element);
@@ -1679,15 +1686,15 @@ mod tests {
             _props: Option<&FxHashMap<String, Value>>,
         ) -> Result<Value, RariError> {
             match component_name {
-                "SuccessfulComponent" => {
-                    Ok(json!(["$", "h1", null, {"children": "Server rendered content"}]))
-                }
-                "HTMLComponent" => Ok(json!("<p>HTML from server</p>")),
+                "SuccessfulComponent" => Ok(
+                    serde_json::json!(["$", "h1", null, {"children": "Server rendered content"}]),
+                ),
+                "HTMLComponent" => Ok(serde_json::json!("<p>HTML from server</p>")),
                 "FailingComponent" => {
                     Err(RariError::js_execution("Component execution failed".to_string()))
                 }
                 _ => Ok(
-                    json!({"type": "div", "props": {"children": format!("Component: {}", component_name)}}),
+                    serde_json::json!({"type": "div", "props": {"children": format!("Component: {}", component_name)}}),
                 ),
             }
         }
@@ -1746,8 +1753,8 @@ mod tests {
         serializer.set_server_component_executor(Box::new(MockServerComponentExecutor));
 
         let mut props = FxHashMap::default();
-        props.insert("title".to_string(), json!("Test Title"));
-        props.insert("count".to_string(), json!(5));
+        props.insert("title".to_string(), serde_json::json!("Test Title"));
+        props.insert("count".to_string(), serde_json::json!(5));
 
         let element =
             SerializedReactElement::create_server_component("GenericComponent", Some(props));
@@ -1762,17 +1769,17 @@ mod tests {
         let mut serializer = RscSerializer::new();
 
         let mut fallback_props = FxHashMap::default();
-        fallback_props.insert("children".to_string(), json!("Loading..."));
+        fallback_props.insert("children".to_string(), serde_json::json!("Loading..."));
         let fallback = LoadingReactElement::with_props("div", fallback_props);
 
         let mut children_props = FxHashMap::default();
-        children_props.insert("children".to_string(), json!("Content loaded"));
+        children_props.insert("children".to_string(), serde_json::json!("Content loaded"));
         let children = LoadingReactElement::with_props("div", children_props);
 
         let mut suspense_props = FxHashMap::default();
         suspense_props.insert("fallback".to_string(), serde_json::to_value(&fallback).unwrap());
         suspense_props.insert("children".to_string(), serde_json::to_value(&children).unwrap());
-        suspense_props.insert("~boundaryId".to_string(), json!("test-boundary"));
+        suspense_props.insert("~boundaryId".to_string(), serde_json::json!("test-boundary"));
 
         let suspense = LoadingReactElement::with_props("react.suspense", suspense_props);
 
@@ -1792,8 +1799,8 @@ mod tests {
         let mut serializer = RscSerializer::new();
 
         let mut props = FxHashMap::default();
-        props.insert("className".to_string(), json!("test-class"));
-        props.insert("children".to_string(), json!("Hello World"));
+        props.insert("className".to_string(), serde_json::json!("test-class"));
+        props.insert("children".to_string(), serde_json::json!("Hello World"));
 
         let element = LoadingReactElement::with_props("div", props).with_key("test-key");
 
@@ -1817,7 +1824,7 @@ mod tests {
         }
 
         let mut props = FxHashMap::default();
-        props.insert("children".to_string(), json!("Test Content"));
+        props.insert("children".to_string(), serde_json::json!("Test Content"));
 
         let element = LoadingReactElement::with_props("span", props);
 
@@ -1859,10 +1866,8 @@ mod tests {
 
     #[test]
     fn test_serialize_map_object() {
-        use serde_json::json;
-
         let mut serializer = RscSerializer::new();
-        let value = json!({"$map": [["key1", "value1"], ["key2", "value2"]]});
+        let value = serde_json::json!({"$map": [["key1", "value1"], ["key2", "value2"]]});
         let processed = serializer.process_special_values_with_outlining(&value);
 
         assert!(
@@ -1887,10 +1892,8 @@ mod tests {
 
     #[test]
     fn test_serialize_set_object() {
-        use serde_json::json;
-
         let mut serializer = RscSerializer::new();
-        let value = json!({"$set": ["value1", "value2", "value3"]});
+        let value = serde_json::json!({"$set": ["value1", "value2", "value3"]});
         let processed = serializer.process_special_values_with_outlining(&value);
 
         assert!(processed.as_str().unwrap().starts_with("$W"));
@@ -1908,10 +1911,8 @@ mod tests {
 
     #[test]
     fn test_serialize_formdata_object() {
-        use serde_json::json;
-
         let mut serializer = RscSerializer::new();
-        let value = json!({"$formdata": [["field1", "value1"], ["field2", "value2"]]});
+        let value = serde_json::json!({"$formdata": [["field1", "value1"], ["field2", "value2"]]});
         let processed = serializer.process_special_values_with_outlining(&value);
 
         assert!(processed.as_str().unwrap().starts_with("$K"));
@@ -1930,10 +1931,8 @@ mod tests {
 
     #[test]
     fn test_serialize_nested_collections() {
-        use serde_json::json;
-
         let mut serializer = RscSerializer::new();
-        let value = json!({
+        let value = serde_json::json!({
             "map": {"$map": [["key1", "value1"]]},
             "set": {"$set": ["item1", "item2"]},
             "nested": {
@@ -1952,10 +1951,8 @@ mod tests {
 
     #[test]
     fn test_serialize_map_with_special_values() {
-        use serde_json::json;
-
         let mut serializer = RscSerializer::new();
-        let value = json!({
+        let value = serde_json::json!({
             "$map": [
                 ["date", {"$date": "2025-12-09T18:00:00.000Z"}],
                 ["bigint", {"$bigint": "123"}],
@@ -1977,10 +1974,8 @@ mod tests {
 
     #[test]
     fn test_serialize_multiple_maps_unique_ids() {
-        use serde_json::json;
-
         let mut serializer = RscSerializer::new();
-        let value = json!({
+        let value = serde_json::json!({
             "map1": {"$map": [["a", "1"]]},
             "map2": {"$map": [["b", "2"]]},
             "map3": {"$map": [["c", "3"]]}
@@ -2005,10 +2000,8 @@ mod tests {
 
     #[test]
     fn test_serialize_promise_object() {
-        use serde_json::json;
-
         let mut serializer = RscSerializer::new();
-        let value = json!({"$promise": {"status": "pending", "value": null}});
+        let value = serde_json::json!({"$promise": {"status": "pending", "value": null}});
         let processed = serializer.process_special_values_with_outlining(&value);
 
         assert!(processed.as_str().unwrap().starts_with("$@"));
@@ -2024,10 +2017,8 @@ mod tests {
 
     #[test]
     fn test_serialize_server_function() {
-        use serde_json::json;
-
         let mut serializer = RscSerializer::new();
-        let value = json!({
+        let value = serde_json::json!({
             "$function": {
                 "id": "actions/todo-actions#addTodo",
                 "bound": null
@@ -2045,10 +2036,8 @@ mod tests {
 
     #[test]
     fn test_serialize_temporary_reference() {
-        use serde_json::json;
-
         let mut serializer = RscSerializer::new();
-        let value = json!({"$temp": "ref_123"});
+        let value = serde_json::json!({"$temp": "ref_123"});
         let processed = serializer.process_special_values_with_outlining(&value);
 
         assert_eq!(processed, "$Tref_123");
@@ -2058,10 +2047,8 @@ mod tests {
 
     #[test]
     fn test_serialize_symbol_reference() {
-        use serde_json::json;
-
         let mut serializer = RscSerializer::new();
-        let value = json!({"$symbol": "iterator"});
+        let value = serde_json::json!({"$symbol": "iterator"});
         let processed = serializer.process_special_values_with_outlining(&value);
 
         assert_eq!(processed, "$Siterator");
@@ -2071,10 +2058,8 @@ mod tests {
 
     #[test]
     fn test_serialize_deferred_object() {
-        use serde_json::json;
-
         let mut serializer = RscSerializer::new();
-        let value = json!({"$deferred": {"type": "debug", "data": "some data"}});
+        let value = serde_json::json!({"$deferred": {"type": "debug", "data": "some data"}});
         let processed = serializer.process_special_values_with_outlining(&value);
 
         assert!(processed.as_str().unwrap().starts_with("$Y"));
@@ -2087,10 +2072,8 @@ mod tests {
 
     #[test]
     fn test_serialize_iterator_object() {
-        use serde_json::json;
-
         let mut serializer = RscSerializer::new();
-        let value = json!({"$iterator": ["value1", "value2", "value3"]});
+        let value = serde_json::json!({"$iterator": ["value1", "value2", "value3"]});
         let processed = serializer.process_special_values_with_outlining(&value);
 
         assert!(processed.as_str().unwrap().starts_with("$i"));
@@ -2104,10 +2087,8 @@ mod tests {
 
     #[test]
     fn test_serialize_mixed_advanced_markers() {
-        use serde_json::json;
-
         let mut serializer = RscSerializer::new();
-        let value = json!({
+        let value = serde_json::json!({
             "promise": {"$promise": {"status": "fulfilled", "value": 42}},
             "function": {"$function": {"id": "myAction"}},
             "temp": {"$temp": "temp_ref"},
@@ -2130,10 +2111,8 @@ mod tests {
 
     #[test]
     fn test_serialize_nested_advanced_markers() {
-        use serde_json::json;
-
         let mut serializer = RscSerializer::new();
-        let value = json!({
+        let value = serde_json::json!({
             "$promise": {
                 "status": "fulfilled",
                 "value": {
@@ -2165,15 +2144,15 @@ mod tests {
 
         let fallback = LoadingReactElement::with_props("div", {
             let mut props = FxHashMap::default();
-            props.insert("className".to_string(), json!("loading-spinner"));
-            props.insert("children".to_string(), json!("Loading..."));
+            props.insert("className".to_string(), serde_json::json!("loading-spinner"));
+            props.insert("children".to_string(), serde_json::json!("Loading..."));
             props
         });
 
         let children = LoadingReactElement::with_props("article", {
             let mut props = FxHashMap::default();
-            props.insert("className".to_string(), json!("content"));
-            props.insert("children".to_string(), json!("Article content"));
+            props.insert("className".to_string(), serde_json::json!("content"));
+            props.insert("children".to_string(), serde_json::json!("Article content"));
             props
         });
 
@@ -2181,7 +2160,7 @@ mod tests {
             let mut props = FxHashMap::default();
             props.insert("fallback".to_string(), serde_json::to_value(&fallback).unwrap());
             props.insert("children".to_string(), serde_json::to_value(&children).unwrap());
-            props.insert("~boundaryId".to_string(), json!("article-boundary"));
+            props.insert("~boundaryId".to_string(), serde_json::json!("article-boundary"));
             props
         });
 
@@ -2209,8 +2188,8 @@ mod tests {
         let mut serializer = RscSerializer::new();
 
         let mut props = FxHashMap::default();
-        props.insert("children".to_string(), json!({"tag": "div", "props": {}}));
-        props.insert("~boundaryId".to_string(), json!("test"));
+        props.insert("children".to_string(), serde_json::json!({"tag": "div", "props": {}}));
+        props.insert("~boundaryId".to_string(), serde_json::json!("test"));
 
         let suspense = LoadingReactElement::with_props("react.suspense", props);
 
@@ -2227,8 +2206,8 @@ mod tests {
         let mut serializer = RscSerializer::new();
 
         let mut props = FxHashMap::default();
-        props.insert("fallback".to_string(), json!({"tag": "div", "props": {}}));
-        props.insert("~boundaryId".to_string(), json!("test"));
+        props.insert("fallback".to_string(), serde_json::json!({"tag": "div", "props": {}}));
+        props.insert("~boundaryId".to_string(), serde_json::json!("test"));
 
         let suspense = LoadingReactElement::with_props("react.suspense", props);
 
@@ -2247,7 +2226,7 @@ mod tests {
         let mut props = FxHashMap::default();
         props.insert(
             "buffer".to_string(),
-            json!({
+            serde_json::json!({
                 "$typedarray": {
                     "type": "Uint8Array",
                     "data": [1, 2, 3, 4, 5]
@@ -2270,7 +2249,7 @@ mod tests {
         let mut props = FxHashMap::default();
         props.insert(
             "data".to_string(),
-            json!({
+            serde_json::json!({
                 "$typedarray": {
                     "type": "Int32Array",
                     "data": [100, 200, 300]
@@ -2293,7 +2272,7 @@ mod tests {
         let mut props = FxHashMap::default();
         props.insert(
             "floats".to_string(),
-            json!({
+            serde_json::json!({
                 "$typedarray": {
                     "type": "Float64Array",
                     "data": [1, 2, 3]
@@ -2316,7 +2295,7 @@ mod tests {
         let mut props = FxHashMap::default();
         props.insert(
             "file".to_string(),
-            json!({
+            serde_json::json!({
                 "$blob": {
                     "type": "image/png",
                     "data": [137, 80, 78, 71]
@@ -2339,7 +2318,7 @@ mod tests {
         let mut props = FxHashMap::default();
         props.insert(
             "data".to_string(),
-            json!({
+            serde_json::json!({
                 "$blob": {
                     "data": [1, 2, 3, 4]
                 }
@@ -2361,7 +2340,7 @@ mod tests {
         let mut props = FxHashMap::default();
         props.insert(
             "stream".to_string(),
-            json!({
+            serde_json::json!({
                 "$stream": {
                     "chunks": [
                         [1, 2, 3],
@@ -2393,7 +2372,7 @@ mod tests {
         let mut props = FxHashMap::default();
         props.insert(
             "byteStream".to_string(),
-            json!({
+            serde_json::json!({
                 "$stream": {
                     "byteStream": true,
                     "chunks": [
@@ -2421,7 +2400,7 @@ mod tests {
         let mut props = FxHashMap::default();
         props.insert(
             "data".to_string(),
-            json!({
+            serde_json::json!({
                 "buffer": {
                     "$typedarray": {
                         "type": "Uint8Array",
@@ -2470,7 +2449,7 @@ mod tests {
             let mut props = FxHashMap::default();
             props.insert(
                 "data".to_string(),
-                json!({
+                serde_json::json!({
                     "$typedarray": {
                         "type": type_name,
                         "data": [1, 2, 3]
@@ -2497,7 +2476,7 @@ mod tests {
         let mut props = FxHashMap::default();
         props.insert(
             "stream".to_string(),
-            json!({
+            serde_json::json!({
                 "$stream": {
                     "chunks": []
                 }
@@ -2518,7 +2497,7 @@ mod tests {
         let mut props = FxHashMap::default();
         props.insert(
             "mixed".to_string(),
-            json!({
+            serde_json::json!({
                 "nan": "$NaN",
                 "buffer": {
                     "$typedarray": {
@@ -2547,13 +2526,13 @@ mod tests {
         let mut props = FxHashMap::default();
         props.insert(
             "data".to_string(),
-            json!({
+            serde_json::json!({
                 "map": {"$map": [["key1", "value1"], ["key2", "value2"]]},
                 "set": {"$set": ["a", "b", "c"]},
                 "promise": {"$promise": {"status": "pending", "value": null}}
             }),
         );
-        props.insert("className".to_string(), json!("container"));
+        props.insert("className".to_string(), serde_json::json!("container"));
 
         let parent_element = SerializedReactElement::create_html_element("div", Some(props));
 

--- a/crates/rari-rsc/src/flight/serializer.rs
+++ b/crates/rari-rsc/src/flight/serializer.rs
@@ -1826,7 +1826,7 @@ mod tests {
         assert_eq!(result, "$La", "Reference should use hexadecimal format");
 
         let output = serializer.output_lines.join("\n");
-        assert!(output.contains("a:["), "Wire format row should use hex ID 'a'");
+        assert!(output.contains("a:["), "Flight protocol row should use hex ID 'a'");
         assert!(output.contains("Test Content"), "Should contain the element content");
 
         let element2 = LoadingReactElement::with_props("div", FxHashMap::default());
@@ -2160,7 +2160,7 @@ mod tests {
     }
 
     #[test]
-    fn test_suspense_wire_format_structure() {
+    fn test_suspense_flight_protocol_structure() {
         let mut serializer = RscSerializer::new();
 
         let fallback = LoadingReactElement::with_props("div", {
@@ -2190,7 +2190,7 @@ mod tests {
         let output = serializer.output_lines.join("\n");
 
         let lines: Vec<&str> = output.lines().collect();
-        assert_eq!(lines.len(), 3, "Should have 3 rows in wire format");
+        assert_eq!(lines.len(), 3, "Should have 3 rows in Flight protocol");
 
         assert!(lines[0].contains(r#"["$","div""#), "First row should be fallback div");
         assert!(lines[0].contains("loading-spinner"), "Should contain fallback className");

--- a/crates/rari-utils/src/lib.rs
+++ b/crates/rari-utils/src/lib.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use cow_utils::CowUtils;
+use url::Url;
 
 fn normalize_path(path: &Path) -> PathBuf {
     let mut components = Vec::new();
@@ -43,7 +44,7 @@ pub fn path_to_file_url(path: &Path) -> String {
         normalize_path(&joined)
     };
 
-    url::Url::from_file_path(&absolute_path).map(|url| url.to_string()).unwrap_or_else(|()| {
+    Url::from_file_path(&absolute_path).map(|url| url.to_string()).unwrap_or_else(|()| {
         let path_str = absolute_path.to_string_lossy().cow_replace('\\', "/").into_owned();
         if path_str.starts_with('/') {
             format!("file://{path_str}")

--- a/crates/rari/src/main.rs
+++ b/crates/rari/src/main.rs
@@ -1,6 +1,6 @@
 use std::{env, error};
 
-use clap::{Arg, ArgAction::SetTrue, Command};
+use clap::{Arg, ArgAction, Command};
 use rari::server::{
     Server,
     config::{Config, Mode},
@@ -9,7 +9,6 @@ use rari::server::{
 use rari_error::RariError;
 use rustls::crypto::{CryptoProvider, aws_lc_rs};
 use tokio::{fs, signal};
-use tracing::error;
 use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
@@ -27,13 +26,13 @@ async fn main() -> Result<(), Box<dyn error::Error + Send + Sync>> {
                         .short('v')
                         .long("verbose")
                         .help("Enable verbose logging")
-                        .action(SetTrue),
+                        .action(ArgAction::SetTrue),
                 )
                 .arg(
                     Arg::new("dry-run")
                         .long("dry-run")
                         .help("Preview images that would be optimized without performing writes")
-                        .action(SetTrue),
+                        .action(ArgAction::SetTrue),
                 ),
         )
         .arg(
@@ -67,9 +66,15 @@ async fn main() -> Result<(), Box<dyn error::Error + Send + Sync>> {
                 .short('v')
                 .long("verbose")
                 .help("Enable verbose logging")
-                .action(SetTrue),
+                .action(ArgAction::SetTrue),
         )
-        .arg(Arg::new("quiet").short('q').long("quiet").help("Reduce log output").action(SetTrue))
+        .arg(
+            Arg::new("quiet")
+                .short('q')
+                .long("quiet")
+                .help("Reduce log output")
+                .action(ArgAction::SetTrue),
+        )
         .get_matches();
 
     if let Some(("optimize-images", sub_matches)) = matches.subcommand() {
@@ -88,7 +93,7 @@ async fn main() -> Result<(), Box<dyn error::Error + Send + Sync>> {
     let config = load_configuration(&matches)?;
 
     let server = Server::new(config).await.map_err(|e| {
-        error!("Failed to create server: {}", e);
+        tracing::error!("Failed to create server: {}", e);
         e
     })?;
 
@@ -99,7 +104,7 @@ async fn main() -> Result<(), Box<dyn error::Error + Send + Sync>> {
             match result {
                 Ok(()) => {}
                 Err(e) => {
-                    error!("Server error: {}", e);
+                    tracing::error!("Server error: {}", e);
                     return Err(e.into());
                 }
             }

--- a/crates/rari/src/rendering/base/renderer.rs
+++ b/crates/rari/src/rendering/base/renderer.rs
@@ -16,12 +16,11 @@ use parking_lot::Mutex;
 use rari_error::RariError;
 use rari_rsc::{
     components::ComponentRegistry,
-    utils::{self, extract_dependencies, hash_string},
+    utils::{self},
 };
 use rustc_hash::FxHashSet;
 use serde_json::Value;
-use tokio::{fs, time, time::timeout};
-use tracing::error;
+use tokio::{fs, time};
 
 use super::{
     constants::{
@@ -143,8 +142,11 @@ impl RscRenderer {
         let timeout_duration =
             Duration::from_millis(self.resource_limits.max_script_execution_time_ms);
 
-        match timeout(timeout_duration, self.runtime.execute_script(script_name.clone(), script))
-            .await
+        match time::timeout(
+            timeout_duration,
+            self.runtime.execute_script(script_name.clone(), script),
+        )
+        .await
         {
             Ok(result) => result,
             Err(_) => {
@@ -342,12 +344,12 @@ globalThis['~errors'].batch.push({{
             )
             .await?;
 
-        let dependencies = extract_dependencies(component_code);
+        let dependencies = utils::extract_dependencies(component_code);
 
         for dep in &dependencies {
             let dep_owned = dep.clone();
             if let Err(e) = self.register_dependency_if_needed(dep_owned).await {
-                error!(
+                tracing::error!(
                     "[rari] RSC: Failed to register dependency '{dep}' for component '{component_id}': {e}"
                 );
             }
@@ -492,7 +494,7 @@ globalThis['~errors'].batch.push({{
                         };
 
                         if !already_registered && Self::is_react_component_file(&content) {
-                            let sub_dependencies = extract_dependencies(&content);
+                            let sub_dependencies = utils::extract_dependencies(&content);
                             for sub_dep in sub_dependencies {
                                 stack.push(sub_dep);
                             }
@@ -515,7 +517,7 @@ globalThis['~errors'].batch.push({{
     ) -> Result<(), RariError> {
         let transformed_module_code = component_code.to_string();
 
-        let dependencies = extract_dependencies(component_code);
+        let dependencies = utils::extract_dependencies(component_code);
 
         {
             let mut registry = self.component_registry.lock();
@@ -631,7 +633,7 @@ globalThis['~errors'].batch.push({{
     }
 
     fn create_component_verification_script(component_id: &str) -> String {
-        let hashed_component_id = format!("Component_{}", hash_string(component_id));
+        let hashed_component_id = format!("Component_{}", utils::hash_string(component_id));
         RscJsLoader::create_component_verification_script(component_id, &hashed_component_id)
     }
 
@@ -771,7 +773,7 @@ globalThis['~errors'].batch.push({{
             return Err(RariError::not_found(format!("Component not found: {component_id}")));
         }
 
-        let component_hash = hash_string(component_id);
+        let component_hash = utils::hash_string(component_id);
         let props_json = props.filter(|p| !p.trim().is_empty()).unwrap_or("{}");
 
         let clear_environment_script = self
@@ -1306,9 +1308,10 @@ globalThis['~rsc'].functions['{component_id}'] = {component_id};
                 .await;
 
             if let Err(e) = execution_result {
-                error!(
+                tracing::error!(
                     "HMR wrapper script execution failed for component '{}': {:?}",
-                    component_id, e
+                    component_id,
+                    e
                 );
                 return Err(e);
             }

--- a/crates/rari/src/rendering/base/renderer.rs
+++ b/crates/rari/src/rendering/base/renderer.rs
@@ -845,12 +845,12 @@ globalThis['~errors'].batch.push({{
             ))
         })?;
 
-        if let Some(wire_format) = rsc_data.as_str() {
-            return Ok(wire_format.to_string());
+        if let Some(flight_protocol) = rsc_data.as_str() {
+            return Ok(flight_protocol.to_string());
         }
 
         Err(RariError::js_execution(format!(
-            "RSC data for component '{component_id}' is not a wire format string"
+            "RSC data for component '{component_id}' is not a Flight protocol string"
         )))
     }
 

--- a/crates/rari/src/rendering/layout/core.rs
+++ b/crates/rari/src/rendering/layout/core.rs
@@ -5,13 +5,11 @@ use std::{env, sync::Arc};
 use base64::{Engine, engine::general_purpose::STANDARD};
 use cow_utils::CowUtils;
 use rari_error::RariError;
-use rari_utils::path_to_file_url;
 use serde_json::Value;
 use tokio::{
     sync::{Mutex, mpsc},
     task,
 };
-use tracing::{debug, error};
 
 use super::{
     error_messages,
@@ -117,14 +115,14 @@ impl LayoutHtmlCache {
             Ok(Some(b)) => b,
             Ok(None) => return None,
             Err(e) => {
-                debug!(key = %ns_key, error = %e, "layout cache get failed");
+                tracing::debug!(key = %ns_key, error = %e, "layout cache get failed");
                 return None;
             }
         };
         match String::from_utf8(bytes) {
             Ok(s) => Some(s),
             Err(e) => {
-                debug!(key = %ns_key, error = %e, "layout cache value not valid utf-8");
+                tracing::debug!(key = %ns_key, error = %e, "layout cache value not valid utf-8");
                 None
             }
         }
@@ -200,7 +198,7 @@ impl LayoutRenderer {
             return Ok(false);
         }
 
-        let page_path = path_to_file_url(&page_file_path);
+        let page_path = rari_utils::path_to_file_url(&page_file_path);
 
         let check_script = format!(
             r#"
@@ -1030,7 +1028,11 @@ impl LayoutRenderer {
         defer_rsc: bool,
     ) -> Result<String, RariError> {
         let page_props = utils::create_page_props(route_match, context).map_err(|e| {
-            error!("Failed to create page props for route '{}': {}", route_match.route.path, e);
+            tracing::error!(
+                "Failed to create page props for route '{}': {}",
+                route_match.route.path,
+                e
+            );
             RariError::internal(format!(
                 "Failed to create page props for route '{}' (component: {}): {}",
                 route_match.route.path, route_match.route.file_path, e
@@ -1038,7 +1040,11 @@ impl LayoutRenderer {
         })?;
 
         let page_props_json = serde_json::to_string(&page_props).map_err(|e| {
-            error!("Failed to serialize page props for route '{}': {}", route_match.route.path, e);
+            tracing::error!(
+                "Failed to serialize page props for route '{}': {}",
+                route_match.route.path,
+                e
+            );
             RariError::internal(format!(
                 "Failed to serialize page props for route '{}' (component: {}): {}",
                 route_match.route.path, route_match.route.file_path, e

--- a/crates/rari/src/rendering/layout/core.rs
+++ b/crates/rari/src/rendering/layout/core.rs
@@ -766,26 +766,10 @@ impl LayoutRenderer {
                         r#"<script id="__RARI_RSC_PAYLOAD__" type="application/octet-stream" data-encoding="base64">{b64}</script>"#
                     )
                 } else {
-                    let rsc_payload = if rsc_flight_protocol.ends_with('\n') {
-                        rsc_flight_protocol.clone()
-                    } else {
-                        format!("{rsc_flight_protocol}\n")
-                    };
-                    let escaped_payload = rsc_payload.cow_replace("</", "<\\/");
-                    format!(
-                        r#"<script id="__RARI_RSC_PAYLOAD__" type="text/x-component">{escaped_payload}</script>"#
-                    )
+                    Self::build_text_payload_script(&rsc_flight_protocol)
                 }
             } else {
-                let rsc_payload = if rsc_flight_protocol.ends_with('\n') {
-                    rsc_flight_protocol.clone()
-                } else {
-                    format!("{rsc_flight_protocol}\n")
-                };
-                let escaped_payload = rsc_payload.cow_replace("</", "<\\/");
-                format!(
-                    r#"<script id="__RARI_RSC_PAYLOAD__" type="text/x-component">{escaped_payload}</script>"#
-                )
+                Self::build_text_payload_script(&rsc_flight_protocol)
             };
             let completion_script = r"<script>if(!window['~rari'])window['~rari']={};window['~rari'].streaming={complete:true}</script>";
 
@@ -946,6 +930,18 @@ impl LayoutRenderer {
             "RSC render did not produce a Flight protocol string. The renderer may not be loaded."
                 .to_string(),
         ))
+    }
+
+    fn build_text_payload_script(rsc_flight_protocol: &str) -> String {
+        let rsc_payload = if rsc_flight_protocol.ends_with('\n') {
+            rsc_flight_protocol.to_string()
+        } else {
+            format!("{rsc_flight_protocol}\n")
+        };
+        let escaped_payload = rsc_payload.cow_replace("</", "<\\/");
+        format!(
+            r#"<script id="__RARI_RSC_PAYLOAD__" type="text/x-component">{escaped_payload}</script>"#
+        )
     }
 
     fn validate_rsc_flight_protocol(rsc_data: &str) -> Result<(), RariError> {

--- a/crates/rari/src/rendering/layout/core.rs
+++ b/crates/rari/src/rendering/layout/core.rs
@@ -269,7 +269,7 @@ impl LayoutRenderer {
 
         let renderer = self.renderer.lock().await;
 
-        let wire_result: Result<String, RariError> = async {
+        let flight_result: Result<String, RariError> = async {
             let rsc_flight_protocol =
                 Self::execute_composition_and_serialize(&renderer, composition_script).await?;
             Self::validate_rsc_flight_protocol(&rsc_flight_protocol)?;
@@ -279,7 +279,7 @@ impl LayoutRenderer {
 
         drop(request_context);
 
-        wire_result
+        flight_result
     }
 
     async fn render_route_with_mode_internal(
@@ -711,7 +711,7 @@ impl LayoutRenderer {
                 }
             };
 
-            let (rsc_wire_format, html) = match render_result {
+            let (rsc_flight_protocol, html) = match render_result {
                 Ok(v) => v,
                 Err(e) if needs_streaming => {
                     tracing::warn!("Fizz render failed for streaming route: {e}");
@@ -725,7 +725,7 @@ impl LayoutRenderer {
                 }
             };
 
-            let has_binary_rows = rsc_wire_format.lines().any(|line| {
+            let has_binary_rows = rsc_flight_protocol.lines().any(|line| {
                 let trimmed = line.trim();
                 if let Some(colon_pos) = trimmed.find(':') {
                     let header = &trimmed[..colon_pos];
@@ -766,10 +766,10 @@ impl LayoutRenderer {
                         r#"<script id="__RARI_RSC_PAYLOAD__" type="application/octet-stream" data-encoding="base64">{b64}</script>"#
                     )
                 } else {
-                    let rsc_payload = if rsc_wire_format.ends_with('\n') {
-                        rsc_wire_format.clone()
+                    let rsc_payload = if rsc_flight_protocol.ends_with('\n') {
+                        rsc_flight_protocol.clone()
                     } else {
-                        format!("{rsc_wire_format}\n")
+                        format!("{rsc_flight_protocol}\n")
                     };
                     let escaped_payload = rsc_payload.cow_replace("</", "<\\/");
                     format!(
@@ -777,10 +777,10 @@ impl LayoutRenderer {
                     )
                 }
             } else {
-                let rsc_payload = if rsc_wire_format.ends_with('\n') {
-                    rsc_wire_format.clone()
+                let rsc_payload = if rsc_flight_protocol.ends_with('\n') {
+                    rsc_flight_protocol.clone()
                 } else {
-                    format!("{rsc_wire_format}\n")
+                    format!("{rsc_flight_protocol}\n")
                 };
                 let escaped_payload = rsc_payload.cow_replace("</", "<\\/");
                 format!(
@@ -938,12 +938,12 @@ impl LayoutRenderer {
             RariError::internal("No RSC data in render result")
         })?;
 
-        if let Some(wire_format_str) = rsc_data.as_str() {
-            return Ok(wire_format_str.to_string());
+        if let Some(flight_protocol_str) = rsc_data.as_str() {
+            return Ok(flight_protocol_str.to_string());
         }
 
         Err(RariError::internal(
-            "RSC render did not produce a wire format string. The renderer may not be loaded."
+            "RSC render did not produce a Flight protocol string. The renderer may not be loaded."
                 .to_string(),
         ))
     }
@@ -963,7 +963,7 @@ impl LayoutRenderer {
 
         if !looks_like_flight {
             return Err(RariError::internal(
-                "RSC output does not look like a valid Flight wire format".to_string(),
+                "RSC output does not look like a valid Flight protocol".to_string(),
             ));
         }
 
@@ -1330,10 +1330,7 @@ mod tests {
         let result = LayoutRenderer::validate_rsc_flight_protocol("Error: composition failed");
         assert!(result.is_err());
         assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("does not look like a valid Flight wire format")
+            result.unwrap_err().to_string().contains("does not look like a valid Flight protocol")
         );
     }
 }

--- a/crates/rari/src/rendering/layout/js/flight_render.ts
+++ b/crates/rari/src/rendering/layout/js/flight_render.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../types.d.ts" />
 
-async function renderWireToHtml(wireFormat: string): Promise<string> {
+async function renderFlightToHtml(flightProtocol: string): Promise<string> {
   const React = g.React
   const ReactDOMServer = g['~reactServer']
   const FlightClient = g['~flightClient']
@@ -15,10 +15,10 @@ async function renderWireToHtml(wireFormat: string): Promise<string> {
   // Use the raw binary if available (avoids text re-encoding overhead
   // and preserves T row framing). Falls back to text splitting.
   const rawBinary = g['~rari']?.lastRscBinary
-  let wireStream: ReadableStream
+  let flightStream: ReadableStream
 
   if (rawBinary && rawBinary.byteLength > 0) {
-    wireStream = new ReadableStream({
+    flightStream = new ReadableStream({
       start(controller) {
         controller.enqueue(rawBinary)
         controller.close()
@@ -26,8 +26,8 @@ async function renderWireToHtml(wireFormat: string): Promise<string> {
     })
   }
   else {
-    const lines = wireFormat.split('\n').filter(line => line.trim().length > 0)
-    wireStream = new ReadableStream({
+    const lines = flightProtocol.split('\n').filter(line => line.trim().length > 0)
+    flightStream = new ReadableStream({
       start(controller) {
         for (const line of lines) {
           controller.enqueue(new TextEncoder().encode(`${line}\n`))
@@ -39,7 +39,7 @@ async function renderWireToHtml(wireFormat: string): Promise<string> {
 
   let rootElement
   try {
-    rootElement = await FlightClient.createFromReadableStream(wireStream, {
+    rootElement = await FlightClient.createFromReadableStream(flightStream, {
       ssrManifest: {
         moduleMap: g['~rari']?.ssrModules || {},
         moduleLoading: null,
@@ -72,4 +72,4 @@ async function renderWireToHtml(wireFormat: string): Promise<string> {
 
 if (!g['~rari'])
   g['~rari'] = {}
-g['~rari'].renderWireToHtml = renderWireToHtml
+g['~rari'].renderFlightToHtml = renderFlightToHtml

--- a/crates/rari/src/rendering/static.rs
+++ b/crates/rari/src/rendering/static.rs
@@ -14,12 +14,11 @@ use std::{
 
 use cow_utils::CowUtils;
 use rari_error::{RariError, StreamingError};
-use rari_rsc::flight::escape::unescape_rsc_value;
+use rari_rsc::flight::escape;
 use regex::Regex;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde_json::Value;
 use tokio::{fs, time};
-use tracing::error;
 
 use crate::{
     RscElement,
@@ -115,7 +114,7 @@ pub fn test_is_valid_attribute_name(name: &str) -> bool {
 }
 
 #[expect(clippy::too_many_lines)]
-fn serialize_style_object(style_obj: &serde_json::Map<String, serde_json::Value>) -> String {
+fn serialize_style_object(style_obj: &serde_json::Map<String, Value>) -> String {
     const UNITLESS_PROPERTIES: &[&str] = &[
         "animation-iteration-count",
         "border-image-outset",
@@ -276,11 +275,11 @@ impl RscHtmlRenderer {
         }
     }
 
-    fn value_looks_like_rsc(value: &serde_json::Value) -> bool {
+    fn value_looks_like_rsc(value: &Value) -> bool {
         match value {
-            serde_json::Value::String(s) => Self::string_looks_like_rsc(s),
-            serde_json::Value::Array(arr) => arr.iter().any(Self::value_looks_like_rsc),
-            serde_json::Value::Object(obj) => obj.values().any(Self::value_looks_like_rsc),
+            Value::String(s) => Self::string_looks_like_rsc(s),
+            Value::Array(arr) => arr.iter().any(Self::value_looks_like_rsc),
+            Value::Object(obj) => obj.values().any(Self::value_looks_like_rsc),
             _ => false,
         }
     }
@@ -586,7 +585,7 @@ impl RscHtmlRenderer {
             .map_err(|e| RariError::internal(format!("Invalid row ID '{id_str}': {e}")))?;
 
         if let Some(json_str) = data_str.strip_prefix('I') {
-            if let Ok(import_data) = serde_json::from_str::<serde_json::Value>(json_str) {
+            if let Ok(import_data) = serde_json::from_str::<Value>(json_str) {
                 let module_path =
                     import_data.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string();
                 let export_name = import_data
@@ -733,7 +732,7 @@ impl RscHtmlRenderer {
         let result =
             self.runtime.execute_script("render_flight_to_fizz".to_string(), script).await?;
 
-        let ok = result.get("ok").and_then(serde_json::Value::as_bool).unwrap_or(false);
+        let ok = result.get("ok").and_then(Value::as_bool).unwrap_or(false);
         if !ok {
             let err = result.get("error").and_then(|v| v.as_str()).unwrap_or("unknown");
             return Err(RariError::js_execution(format!("Fizz reviver failed: {err}")));
@@ -993,9 +992,8 @@ impl RscHtmlRenderer {
                 }
 
                 RscElement::Component { tag, key: _, props } => {
-                    let props_value = serde_json::Value::Object(
-                        props.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
-                    );
+                    let props_value =
+                        Value::Object(props.iter().map(|(k, v)| (k.clone(), v.clone())).collect());
                     self.render_component_to_html(tag, &props_value, row_map, row_cache).await
                 }
 
@@ -1048,7 +1046,7 @@ impl RscHtmlRenderer {
     fn render_component_to_html<'a>(
         &'a self,
         tag: &'a str,
-        props: &'a serde_json::Value,
+        props: &'a Value,
         row_map: &'a FxHashMap<u32, &RscElement>,
         row_cache: &'a mut FxHashMap<u32, String>,
     ) -> Pin<Box<dyn Future<Output = Result<String, RariError>> + Send + 'a>> {
@@ -1180,7 +1178,7 @@ impl RscHtmlRenderer {
 
     fn render_json_to_html<'a>(
         &'a self,
-        json: &'a serde_json::Value,
+        json: &'a Value,
         row_map: &'a FxHashMap<u32, &RscElement>,
         row_cache: &'a mut FxHashMap<u32, String>,
     ) -> Pin<Box<dyn Future<Output = Result<String, RariError>> + Send + 'a>> {
@@ -1366,7 +1364,7 @@ impl RscToHtmlConverter {
                 if parts.len() == 2
                     && let Ok(row_id) = u32::from_str_radix(parts[0], 16)
                     && let Some(i_data) = parts[1].trim().strip_prefix('I')
-                    && let Ok(import_data) = serde_json::from_str::<serde_json::Value>(i_data)
+                    && let Ok(import_data) = serde_json::from_str::<Value>(i_data)
                 {
                     let module_path =
                         import_data.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string();
@@ -1386,7 +1384,7 @@ impl RscToHtmlConverter {
                     match self.parse_and_render_rsc(&chunk.data, chunk.row_id).await {
                         Ok(rsc_html) => rsc_html,
                         Err(e) => {
-                            error!("Error parsing RSC: {}", e);
+                            tracing::error!("Error parsing RSC: {}", e);
                             Vec::new()
                         }
                     }
@@ -1399,7 +1397,7 @@ impl RscToHtmlConverter {
                             output.extend(rsc_html);
                         }
                         Err(e) => {
-                            error!("Error parsing initial RSC shell: {}", e);
+                            tracing::error!("Error parsing initial RSC shell: {}", e);
                         }
                     }
 
@@ -1427,7 +1425,7 @@ impl RscToHtmlConverter {
                         Ok(html)
                     }
                     Err(e) => {
-                        error!("Error generating boundary replacement: {}", e);
+                        tracing::error!("Error generating boundary replacement: {}", e);
                         Ok(html)
                     }
                 }
@@ -1446,7 +1444,7 @@ impl RscToHtmlConverter {
                     let parts: Vec<&str> = rsc_line.trim().splitn(2, ':').collect();
                     let error_msg = if parts.len() == 2 {
                         let json_part = parts[1].strip_prefix('E').unwrap_or(parts[1]);
-                        serde_json::from_str::<serde_json::Value>(json_part)
+                        serde_json::from_str::<Value>(json_part)
                             .ok()
                             .and_then(|error_data| {
                                 error_data["error"].as_str().map(ToString::to_string)
@@ -1488,7 +1486,7 @@ impl RscToHtmlConverter {
         };
 
         if let Err(ref e) = result {
-            error!("Chunk conversion error for {:?}: {}", chunk.chunk_type, e);
+            tracing::error!("Chunk conversion error for {:?}: {}", chunk.chunk_type, e);
             return Err(StreamingError::ChunkConversionError {
                 message: e.to_string(),
                 chunk_type: Some(chunk_type_str),
@@ -1661,7 +1659,7 @@ if (typeof window !== 'undefined') {{
         }
 
         if let Some(i_data) = json_str.strip_prefix('I') {
-            if let Ok(import_data) = serde_json::from_str::<serde_json::Value>(i_data) {
+            if let Ok(import_data) = serde_json::from_str::<Value>(i_data) {
                 let module_path =
                     import_data.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string();
                 let export_name = import_data
@@ -1683,7 +1681,7 @@ if (typeof window !== 'undefined') {{
         }
 
         if json_str.starts_with('"')
-            && let Ok(serde_json::Value::String(s)) = serde_json::from_str(json_str)
+            && let Ok(Value::String(s)) = serde_json::from_str(json_str)
             && RscHtmlRenderer::is_rsc_payload(&s)
         {
             return Ok(Vec::new());
@@ -1693,7 +1691,7 @@ if (typeof window !== 'undefined') {{
             return Ok(Vec::new());
         }
 
-        let rsc_data: serde_json::Value = serde_json::from_str(json_str)
+        let rsc_data: Value = serde_json::from_str(json_str)
             .map_err(|e| RariError::internal(format!("Invalid RSC JSON: {e}")))?;
 
         let html = self.rsc_element_to_html(&rsc_data).await?;
@@ -1706,7 +1704,7 @@ if (typeof window !== 'undefined') {{
     #[expect(clippy::too_many_lines)]
     fn rsc_element_to_html<'a>(
         &'a self,
-        element: &'a serde_json::Value,
+        element: &'a Value,
     ) -> Pin<Box<dyn Future<Output = Result<String, RariError>> + Send + 'a>> {
         Box::pin(async move {
             if let Some(s) = element.as_str() {
@@ -1742,7 +1740,7 @@ if (typeof window !== 'undefined') {{
                     let after_colon = &s[colon_pos + 1..];
                     if !after_colon.is_empty()
                         && (after_colon.starts_with('[') || after_colon.starts_with('{'))
-                        && serde_json::from_str::<serde_json::Value>(after_colon).is_ok()
+                        && serde_json::from_str::<Value>(after_colon).is_ok()
                     {
                         return Ok(String::new());
                     }
@@ -1845,7 +1843,7 @@ if (typeof window !== 'undefined') {{
     async fn render_client_component_placeholder(
         &self,
         component_ref: &str,
-        props: Option<&serde_json::Map<String, serde_json::Value>>,
+        props: Option<&serde_json::Map<String, Value>>,
     ) -> Result<String, RariError> {
         let props_are_rsc =
             props.is_some_and(|p| p.values().any(RscHtmlRenderer::value_looks_like_rsc));
@@ -1857,7 +1855,7 @@ if (typeof window !== 'undefined') {{
             && let Some((module_path, export_name)) = self.module_imports.get(&module_row_id)
         {
             let props_json = if let Some(p) = props {
-                serde_json::to_string(&unescape_rsc_value(&serde_json::Value::Object(p.clone())))
+                serde_json::to_string(&escape::unescape_rsc_value(&Value::Object(p.clone())))
                     .unwrap_or_default()
             } else {
                 "{}".to_string()
@@ -1883,7 +1881,7 @@ if (typeof window !== 'undefined') {{
     async fn render_suspense_boundary(
         &self,
         _element_type: &str,
-        props: Option<&serde_json::Map<String, serde_json::Value>>,
+        props: Option<&serde_json::Map<String, Value>>,
     ) -> Result<String, RariError> {
         if let Some(props) = props {
             let rari_boundary_id =
@@ -1950,7 +1948,7 @@ if (typeof window !== 'undefined') {{
     async fn render_html_element(
         &self,
         tag: &str,
-        props: Option<&serde_json::Map<String, serde_json::Value>>,
+        props: Option<&serde_json::Map<String, Value>>,
     ) -> Result<String, RariError> {
         if tag == "$Sreact.suspense" || tag == "react.suspense" || tag == "suspense" {
             return self.render_suspense_boundary(tag, props).await;
@@ -2081,7 +2079,7 @@ if (typeof window !== 'undefined') {{
         let parts: Vec<&str> = line_for_parsing.splitn(2, ':').collect();
 
         if parts.len() != 2 {
-            error!("Invalid boundary update format: {}", rsc_line);
+            tracing::error!("Invalid boundary update format: {}", rsc_line);
             return Ok(Vec::new());
         }
 
@@ -2101,7 +2099,7 @@ if (typeof window !== 'undefined') {{
             let rendered_html = if let Some(text) = content_json.strip_prefix('T') {
                 escape_html(text)
             } else {
-                match serde_json::from_str::<serde_json::Value>(content_json) {
+                match serde_json::from_str::<Value>(content_json) {
                     Ok(content) => match self.rsc_element_to_html(&content).await {
                         Ok(html) if !html.is_empty() => html,
                         _ => String::new(),
@@ -2144,10 +2142,10 @@ if (typeof window !== 'undefined') {{
 
         let json_part = parts[1].strip_prefix('E').unwrap_or(parts[1]);
 
-        let error_data = match serde_json::from_str::<serde_json::Value>(json_part) {
+        let error_data = match serde_json::from_str::<Value>(json_part) {
             Ok(data) => data,
             Err(e) => {
-                error!("Failed to parse error data from stream, using fallback: {}", e);
+                tracing::error!("Failed to parse error data from stream, using fallback: {}", e);
                 return Self::generate_fallback_error_html();
             }
         };

--- a/crates/rari/src/rendering/static.rs
+++ b/crates/rari/src/rendering/static.rs
@@ -705,24 +705,24 @@ impl RscHtmlRenderer {
         let is_dev_mode = config.is_development();
         let css_links = Self::css_links_for_route(route_match);
 
-        let html_content = self.render_wire_to_fizz_html(rsc_flight_protocol).await?;
+        let html_content = self.render_flight_to_fizz_html(rsc_flight_protocol).await?;
 
         self.assemble_document(html_content, cache_template, is_dev_mode, &css_links).await
     }
 
-    async fn render_wire_to_fizz_html(
+    async fn render_flight_to_fizz_html(
         &self,
         rsc_flight_protocol: &str,
     ) -> Result<String, RariError> {
-        let wire_json =
+        let flight_json =
             serde_json::to_string(rsc_flight_protocol).unwrap_or_else(|_| "\"\"".to_string());
 
         let script = format!(
             r"(async function() {{
-                const fn = globalThis['~rari'] && globalThis['~rari'].renderWireToHtml;
-                if (!fn) return {{ ok: false, error: 'renderWireToHtml unavailable' }};
+                const fn = globalThis['~rari'] && globalThis['~rari'].renderFlightToHtml;
+                if (!fn) return {{ ok: false, error: 'renderFlightToHtml unavailable' }};
                 try {{
-                    const html = await fn({wire_json});
+                    const html = await fn({flight_json});
                     return {{ ok: true, html: html }};
                 }} catch (e) {{
                     return {{ ok: false, error: String((e && e.message) || e) }};
@@ -730,7 +730,8 @@ impl RscHtmlRenderer {
             }})()",
         );
 
-        let result = self.runtime.execute_script("render_wire_to_fizz".to_string(), script).await?;
+        let result =
+            self.runtime.execute_script("render_flight_to_fizz".to_string(), script).await?;
 
         let ok = result.get("ok").and_then(serde_json::Value::as_bool).unwrap_or(false);
         if !ok {
@@ -804,12 +805,12 @@ impl RscHtmlRenderer {
 
         let render_future = async {
             tracing::info!(
-                "RSC->HTML: Starting wire format parsing, length: {}",
+                "RSC->HTML: Starting Flight protocol parsing, length: {}",
                 rsc_flight_protocol.len()
             );
             let rsc_rows = self.parse_rsc_flight_protocol(rsc_flight_protocol).map_err(|e| {
-                tracing::error!("RSC->HTML: Failed to parse wire format: {}", e);
-                RariError::internal(format!("Failed to parse RSC wire format: {e}"))
+                tracing::error!("RSC->HTML: Failed to parse Flight protocol: {}", e);
+                RariError::internal(format!("Failed to parse RSC Flight protocol: {e}"))
             })?;
 
             tracing::info!("RSC->HTML: Parsed {} rows", rsc_rows.len());

--- a/crates/rari/src/rendering/streaming/js/rsc_renderer.ts
+++ b/crates/rari/src/rendering/streaming/js/rsc_renderer.ts
@@ -47,7 +47,7 @@ async function renderToRsc(element: unknown): Promise<string> {
     g['~rari'] = {}
   g['~rari'].lastRscBinary = fullBuffer
 
-  // Return text version for Rust-side wire format validation and
+  // Return text version for Rust-side Flight protocol validation and
   // for the Fizz path (which re-encodes to binary via its own stream).
   // Note: this text is NOT valid for direct client consumption if it
   // contains T rows. The binary should be used instead.

--- a/crates/rari/src/runtime/ext/cache/mod.rs
+++ b/crates/rari/src/runtime/ext/cache/mod.rs
@@ -1,3 +1,4 @@
+use deno_cache::deno_cache;
 use deno_core::{Extension, extension};
 
 use super::ExtensionTrait;
@@ -14,12 +15,12 @@ impl ExtensionTrait<()> for init_cache {
     }
 }
 
-impl ExtensionTrait<()> for deno_cache::deno_cache {
+impl ExtensionTrait<()> for deno_cache {
     fn init((): ()) -> Extension {
         Self::init(None)
     }
 }
 
 pub fn extensions(_options: Option<()>, is_snapshot: bool) -> Vec<Extension> {
-    vec![deno_cache::deno_cache::build((), is_snapshot), init_cache::build((), is_snapshot)]
+    vec![deno_cache::build((), is_snapshot), init_cache::build((), is_snapshot)]
 }

--- a/crates/rari/src/runtime/ext/cron/mod.rs
+++ b/crates/rari/src/runtime/ext/cron/mod.rs
@@ -1,5 +1,6 @@
+use ::deno_cron::local::LocalCronHandler;
 use deno_core::{Extension, extension};
-use deno_cron::local::LocalCronHandler;
+use deno_cron::deno_cron;
 
 use super::ExtensionTrait;
 
@@ -14,12 +15,12 @@ impl ExtensionTrait<()> for init_cron {
         Self::init()
     }
 }
-impl ExtensionTrait<()> for deno_cron::deno_cron {
+impl ExtensionTrait<()> for deno_cron {
     fn init((): ()) -> Extension {
         Self::init(Box::new(LocalCronHandler::new()))
     }
 }
 
 pub fn extensions(is_snapshot: bool) -> Vec<Extension> {
-    vec![deno_cron::deno_cron::build((), is_snapshot), init_cron::build((), is_snapshot)]
+    vec![deno_cron::build((), is_snapshot), init_cron::build((), is_snapshot)]
 }

--- a/crates/rari/src/runtime/ext/crypto/mod.rs
+++ b/crates/rari/src/runtime/ext/crypto/mod.rs
@@ -1,4 +1,5 @@
 use deno_core::{Extension, extension};
+use deno_crypto::deno_crypto;
 
 use super::ExtensionTrait;
 
@@ -13,12 +14,12 @@ impl ExtensionTrait<()> for init_crypto {
         Self::init()
     }
 }
-impl ExtensionTrait<Option<u64>> for deno_crypto::deno_crypto {
+impl ExtensionTrait<Option<u64>> for deno_crypto {
     fn init(seed: Option<u64>) -> Extension {
         Self::init(seed)
     }
 }
 
 pub fn extensions(seed: Option<u64>, is_snapshot: bool) -> Vec<Extension> {
-    vec![deno_crypto::deno_crypto::build(seed, is_snapshot), init_crypto::build((), is_snapshot)]
+    vec![deno_crypto::build(seed, is_snapshot), init_crypto::build((), is_snapshot)]
 }

--- a/crates/rari/src/runtime/ext/ffi/mod.rs
+++ b/crates/rari/src/runtime/ext/ffi/mod.rs
@@ -1,4 +1,5 @@
 use deno_core::{Extension, extension};
+use deno_ffi::deno_ffi;
 
 use super::ExtensionTrait;
 
@@ -13,12 +14,12 @@ impl ExtensionTrait<()> for init_ffi {
         Self::init()
     }
 }
-impl ExtensionTrait<()> for deno_ffi::deno_ffi {
+impl ExtensionTrait<()> for deno_ffi {
     fn init((): ()) -> Extension {
         Self::init(None)
     }
 }
 
 pub fn extensions(is_snapshot: bool) -> Vec<Extension> {
-    vec![deno_ffi::deno_ffi::build((), is_snapshot), init_ffi::build((), is_snapshot)]
+    vec![deno_ffi::build((), is_snapshot), init_ffi::build((), is_snapshot)]
 }

--- a/crates/rari/src/runtime/ext/fs/mod.rs
+++ b/crates/rari/src/runtime/ext/fs/mod.rs
@@ -1,5 +1,6 @@
+use ::deno_fs::FileSystemRc;
 use deno_core::{Extension, extension};
-use deno_fs::FileSystemRc;
+use deno_fs::deno_fs;
 
 use super::ExtensionTrait;
 
@@ -16,12 +17,12 @@ impl ExtensionTrait<()> for init_fs {
     }
 }
 
-impl ExtensionTrait<FileSystemRc> for deno_fs::deno_fs {
+impl ExtensionTrait<FileSystemRc> for deno_fs {
     fn init(fs: FileSystemRc) -> Extension {
         Self::init(fs)
     }
 }
 
 pub fn extensions(fs: FileSystemRc, is_snapshot: bool) -> Vec<Extension> {
-    vec![deno_fs::deno_fs::build(fs, is_snapshot), init_fs::build((), is_snapshot)]
+    vec![deno_fs::build(fs, is_snapshot), init_fs::build((), is_snapshot)]
 }

--- a/crates/rari/src/runtime/ext/http/mod.rs
+++ b/crates/rari/src/runtime/ext/http/mod.rs
@@ -1,9 +1,12 @@
+use ::deno_http::Options;
 use deno_core::{Extension, extension};
+use deno_http::deno_http;
 
 use super::ExtensionTrait;
 
 mod runtime;
 use runtime::deno_http_runtime;
+
 impl ExtensionTrait<()> for deno_http_runtime {
     fn init((): ()) -> Extension {
         Self::init()
@@ -21,9 +24,9 @@ impl ExtensionTrait<()> for init_http {
         Self::init()
     }
 }
-impl ExtensionTrait<()> for deno_http::deno_http {
+impl ExtensionTrait<()> for deno_http {
     fn init((): ()) -> Extension {
-        Self::init(deno_http::Options {
+        Self::init(Options {
             http2_builder_hook: None,
             no_legacy_abort: false,
             automatic_compression: false,
@@ -34,7 +37,7 @@ impl ExtensionTrait<()> for deno_http::deno_http {
 pub fn extensions((): (), is_snapshot: bool) -> Vec<Extension> {
     vec![
         deno_http_runtime::build((), is_snapshot),
-        deno_http::deno_http::build((), is_snapshot),
+        deno_http::build((), is_snapshot),
         init_http::build((), is_snapshot),
     ]
 }

--- a/crates/rari/src/runtime/ext/http/runtime.rs
+++ b/crates/rari/src/runtime/ext/http/runtime.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use deno_core::{OpState, ResourceId, error::ResourceError, extension, op2};
+use deno_error::JsError;
 use deno_http::http_create_conn_resource;
 #[cfg(unix)]
 use deno_net::io::UnixStreamResource;
@@ -18,7 +19,7 @@ use tokio::net::unix;
 
 extension!(deno_http_runtime, ops = [op_http_start]);
 
-#[derive(Debug, deno_error::JsError)]
+#[derive(Debug, JsError)]
 pub enum HttpStartError {
     #[class("Busy")]
     TcpStreamInUse,

--- a/crates/rari/src/runtime/ext/io/mod.rs
+++ b/crates/rari/src/runtime/ext/io/mod.rs
@@ -1,4 +1,7 @@
+use ::deno_io::Stdio;
 use deno_core::{Extension, extension};
+use deno_io::deno_io;
+use tty::deno_tty;
 
 use super::ExtensionTrait;
 
@@ -23,21 +26,21 @@ impl ExtensionTrait<()> for init_io {
         Self::init()
     }
 }
-impl ExtensionTrait<Option<deno_io::Stdio>> for deno_io::deno_io {
-    fn init(pipes: Option<deno_io::Stdio>) -> Extension {
+impl ExtensionTrait<Option<Stdio>> for deno_io {
+    fn init(pipes: Option<Stdio>) -> Extension {
         Self::init(pipes)
     }
 }
-impl ExtensionTrait<()> for tty::deno_tty {
+impl ExtensionTrait<()> for deno_tty {
     fn init((): ()) -> Extension {
         Self::init()
     }
 }
 
-pub fn extensions(pipes: Option<deno_io::Stdio>, is_snapshot: bool) -> Vec<Extension> {
+pub fn extensions(pipes: Option<Stdio>, is_snapshot: bool) -> Vec<Extension> {
     vec![
-        deno_io::deno_io::build(pipes, is_snapshot),
-        tty::deno_tty::build((), is_snapshot),
+        deno_io::build(pipes, is_snapshot),
+        deno_tty::build((), is_snapshot),
         init_io::build((), is_snapshot),
     ]
 }

--- a/crates/rari/src/runtime/ext/kv/mod.rs
+++ b/crates/rari/src/runtime/ext/kv/mod.rs
@@ -1,11 +1,13 @@
 use std::path::PathBuf;
 
-use deno_core::{Extension, extension};
-use deno_kv::{
+use ::deno_kv::{
+    KvConfig as DenoKvConfig, KvConfigBuilder,
     dynamic::MultiBackendDbHandler,
     remote::{HttpOptions, RemoteDbHandler},
     sqlite::SqliteDbHandler,
 };
+use deno_core::{Extension, extension};
+use deno_kv::deno_kv;
 
 use super::ExtensionTrait;
 
@@ -15,19 +17,21 @@ extension!(
     esm_entry_point = "ext:init_kv/init_kv.ts",
     esm = [ dir "src/runtime/ext/kv", "init_kv.ts" ],
 );
+
 impl ExtensionTrait<()> for init_kv {
     fn init((): ()) -> Extension {
         Self::init()
     }
 }
-impl ExtensionTrait<KvStore> for deno_kv::deno_kv {
+
+impl ExtensionTrait<KvStore> for deno_kv {
     fn init(store: KvStore) -> Extension {
         Self::init(Box::new(store.handler()), store.config())
     }
 }
 
 pub fn extensions(store: KvStore, is_snapshot: bool) -> Vec<Extension> {
-    vec![deno_kv::deno_kv::build(store, is_snapshot), init_kv::build((), is_snapshot)]
+    vec![deno_kv::build(store, is_snapshot), init_kv::build((), is_snapshot)]
 }
 
 #[derive(Clone)]
@@ -49,9 +53,10 @@ pub struct KvConfig {
     pub max_total_mutation_size_bytes: usize,
     pub max_total_key_size_bytes: usize,
 }
-impl From<KvConfig> for deno_kv::KvConfig {
+
+impl From<KvConfig> for DenoKvConfig {
     fn from(value: KvConfig) -> Self {
-        deno_kv::KvConfigBuilder::default()
+        KvConfigBuilder::default()
             .max_write_key_size_bytes(value.max_write_key_size_bytes)
             .max_value_size_bytes(value.max_value_size_bytes)
             .max_read_ranges(value.max_read_ranges)
@@ -64,6 +69,7 @@ impl From<KvConfig> for deno_kv::KvConfig {
             .build()
     }
 }
+
 impl Default for KvConfig {
     fn default() -> Self {
         const MAX_WRITE_KEY_SIZE_BYTES: usize = 2048;
@@ -115,10 +121,11 @@ impl KvStore {
         }
     }
 
-    pub fn config(&self) -> deno_kv::KvConfig {
+    pub fn config(&self) -> DenoKvConfig {
         self.1.into()
     }
 }
+
 impl Default for KvStore {
     fn default() -> Self {
         Self::new_local(None, None, KvConfig::default())

--- a/crates/rari/src/runtime/ext/mod.rs
+++ b/crates/rari/src/runtime/ext/mod.rs
@@ -1,8 +1,13 @@
 use std::{borrow::Cow::Borrowed, option::Option::None, path::PathBuf, sync::Arc};
 
+use deno_bundle_runtime::deno_bundle_runtime;
 use deno_core::Extension;
-use deno_fs::{FileSystemRc, sync::MaybeArc};
+use deno_fs::{FileSystemRc, RealFs, sync::MaybeArc};
+use deno_io::Stdio;
 use deno_runtime::deno_canvas::deno_canvas;
+use deno_web::InMemoryBroadcastChannel;
+
+use crate::runtime::ext::{kv::KvStore, node::resolvers::Resolver, web::WebOptions};
 
 pub trait ExtensionTrait<A> {
     fn init(options: A) -> Extension;
@@ -46,29 +51,29 @@ mod webstorage;
 #[derive(Clone)]
 #[non_exhaustive]
 pub struct ExtensionOptions {
-    pub web: web::WebOptions,
-    pub io_pipes: Option<deno_io::Stdio>,
+    pub web: WebOptions,
+    pub io_pipes: Option<Stdio>,
     pub cache: Option<()>,
     pub filesystem: FileSystemRc,
     pub crypto_seed: Option<u64>,
-    pub node_resolver: Arc<node::resolvers::Resolver>,
-    pub broadcast_channel: deno_web::InMemoryBroadcastChannel,
+    pub node_resolver: Arc<Resolver>,
+    pub broadcast_channel: InMemoryBroadcastChannel,
     pub webstorage_origin_storage_dir: Option<PathBuf>,
-    pub kv_store: kv::KvStore,
+    pub kv_store: KvStore,
 }
 
 impl Default for ExtensionOptions {
     fn default() -> Self {
         Self {
-            web: web::WebOptions::default(),
-            io_pipes: Some(deno_io::Stdio::default()),
-            filesystem: MaybeArc::new(deno_fs::RealFs),
+            web: WebOptions::default(),
+            io_pipes: Some(Stdio::default()),
+            filesystem: MaybeArc::new(RealFs),
             cache: Some(()),
             crypto_seed: None,
-            node_resolver: Arc::new(node::resolvers::Resolver::default()),
-            broadcast_channel: deno_web::InMemoryBroadcastChannel::default(),
+            node_resolver: Arc::new(Resolver::default()),
+            broadcast_channel: InMemoryBroadcastChannel::default(),
             webstorage_origin_storage_dir: None,
-            kv_store: kv::KvStore::default(),
+            kv_store: KvStore::default(),
         }
     }
 }
@@ -108,7 +113,7 @@ pub fn extensions(options: &ExtensionOptions, is_snapshot: bool) -> Vec<Extensio
     extensions.extend(node_sqlite::extensions(is_snapshot));
     extensions.extend(node::extensions(Arc::clone(&options.node_resolver), is_snapshot));
     {
-        let mut bundle_ext = deno_bundle_runtime::deno_bundle_runtime::init(None);
+        let mut bundle_ext = deno_bundle_runtime::init(None);
         bundle_ext.esm_files = Borrowed(&[]);
         bundle_ext.esm_entry_point = None;
         extensions.push(bundle_ext);

--- a/crates/rari/src/runtime/ext/napi/mod.rs
+++ b/crates/rari/src/runtime/ext/napi/mod.rs
@@ -1,13 +1,14 @@
 use deno_core::Extension;
+use deno_napi::deno_napi;
 
 use super::ExtensionTrait;
 
-impl ExtensionTrait<()> for deno_napi::deno_napi {
+impl ExtensionTrait<()> for deno_napi {
     fn init((): ()) -> Extension {
         Self::init(None)
     }
 }
 
 pub fn extensions(is_snapshot: bool) -> Vec<Extension> {
-    vec![deno_napi::deno_napi::build((), is_snapshot)]
+    vec![deno_napi::build((), is_snapshot)]
 }

--- a/crates/rari/src/runtime/ext/node/cjs_translator.rs
+++ b/crates/rari/src/runtime/ext/node/cjs_translator.rs
@@ -2,9 +2,11 @@
 
 use std::{borrow::Cow, cell::RefCell, sync::Arc};
 
-use deno_ast::{MediaType, ModuleExportsAndReExports, ModuleSpecifier};
+use deno_ast::{MediaType, ModuleExportsAndReExports, ModuleSpecifier, ParseParams};
 use deno_core::unsync;
 use deno_error::JsErrorBox;
+use deno_fs::FileSystemRc;
+use deno_permissions::CheckedPathBuf;
 use deno_resolver::npm::DenoInNpmPackageChecker;
 use deno_runtime::deno_fs;
 use node_resolver::{
@@ -52,13 +54,13 @@ impl From<ExtNodeCjsAnalysis<'_>> for CjsAnalysis {
 }
 
 pub struct CjsCodeAnalyzer {
-    fs: deno_fs::FileSystemRc,
+    fs: FileSystemRc,
     cache: RefCell<FxHashMap<String, CjsAnalysis>>,
     cjs_tracker: Arc<Resolver>,
 }
 
 impl CjsCodeAnalyzer {
-    pub fn new(fs: deno_fs::FileSystemRc, cjs_tracker: Arc<Resolver>) -> Self {
+    pub fn new(fs: FileSystemRc, cjs_tracker: Arc<Resolver>) -> Self {
         Self { fs, cache: RefCell::new(FxHashMap::default()), cjs_tracker }
     }
 
@@ -76,7 +78,7 @@ impl CjsCodeAnalyzer {
         let media_type = MediaType::from_specifier(specifier);
 
         if media_type == MediaType::Json {
-            return Ok(CjsAnalysis::Cjs(deno_ast::ModuleExportsAndReExports::default()));
+            return Ok(CjsAnalysis::Cjs(ModuleExportsAndReExports::default()));
         }
 
         let cjs_tracker = Arc::clone(&self.cjs_tracker);
@@ -86,7 +88,7 @@ impl CjsCodeAnalyzer {
         let analysis = unsync::spawn_blocking({
             let source: Arc<str> = source.into();
             move || -> Result<CjsAnalysis, JsErrorBox> {
-                let parsed_source = deno_ast::parse_program(deno_ast::ParseParams {
+                let parsed_source = deno_ast::parse_program(ParseParams {
                     specifier: specifier_clone.clone(),
                     text: source,
                     media_type,
@@ -166,12 +168,8 @@ impl analyze::CjsCodeAnalyzer for CjsCodeAnalyzer {
             Some(source) => source,
             None => {
                 if let Ok(path) = specifier.to_file_path() {
-                    if let Ok(source_from_file) = self
-                        .fs
-                        .read_text_file_lossy_async(deno_permissions::CheckedPathBuf::unsafe_new(
-                            path,
-                        ))
-                        .await
+                    if let Ok(source_from_file) =
+                        self.fs.read_text_file_lossy_async(CheckedPathBuf::unsafe_new(path)).await
                     {
                         source_from_file
                     } else {

--- a/crates/rari/src/runtime/ext/node/mod.rs
+++ b/crates/rari/src/runtime/ext/node/mod.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use deno_core::{Extension, extension};
+use deno_node::deno_node;
 use deno_resolver::npm::DenoInNpmPackageChecker;
 use resolvers::{NpmPackageFolderResolverImpl, Resolver};
 use sys_traits::impls::RealSys;
@@ -23,7 +24,7 @@ impl ExtensionTrait<()> for init_node {
     }
 }
 
-impl ExtensionTrait<Arc<Resolver>> for deno_node::deno_node {
+impl ExtensionTrait<Arc<Resolver>> for deno_node {
     fn init(resolver: Arc<Resolver>) -> Extension {
         let services = resolver.init_services();
 
@@ -37,7 +38,7 @@ impl ExtensionTrait<Arc<Resolver>> for deno_node::deno_node {
 }
 
 pub fn extensions(resolver: Arc<Resolver>, is_snapshot: bool) -> Vec<Extension> {
-    let node_ext = deno_node::deno_node::build(resolver, is_snapshot);
+    let node_ext = deno_node::build(resolver, is_snapshot);
 
     let init_ext = init_node::build((), is_snapshot);
 

--- a/crates/rari/src/runtime/ext/node/resolvers.rs
+++ b/crates/rari/src/runtime/ext/node/resolvers.rs
@@ -8,20 +8,22 @@ use std::{
 };
 
 use deno_ast::{MediaType, ModuleSpecifier};
+use deno_core::FastString;
 use deno_error::JsErrorBox;
 use deno_fs::{FileSystem, RealFs};
 use deno_node::{NodeExtInitServices, NodeRequireLoader, NodeResolver};
-use deno_package_json::{PackageJsonCache, PackageJsonRc};
+use deno_package_json::{PackageJsonCache, PackageJsonCacheResult, PackageJsonRc};
+use deno_permissions::{CheckedPath, PermissionsContainer};
 use deno_process::NpmProcessStateProvider;
 use deno_resolver::npm::{
     ByonmInNpmPackageChecker, ByonmNpmResolver, ByonmNpmResolverCreateOptions,
     DenoInNpmPackageChecker,
 };
-use deno_semver::package::PackageReq;
+use deno_semver::{Version, package::PackageReq};
 use node_resolver::{
     DenoIsBuiltInNodeModuleChecker, InNpmPackageChecker, NodeConditionOptions, NodeResolutionCache,
-    NpmPackageFolderResolver, PackageJsonResolver, UrlOrPath, UrlOrPathRef,
-    analyze::NodeCodeTranslatorMode::ModuleLoader,
+    NodeResolverOptions, NpmPackageFolderResolver, PackageJsonResolver, UrlOrPath, UrlOrPathRef,
+    analyze::{CjsModuleExportAnalyzer, NodeCodeTranslatorMode::ModuleLoader},
     cache::NodeResolutionSys,
     errors::{
         PackageFolderResolveError, PackageFolderResolveErrorKind, PackageJsonLoadError,
@@ -30,7 +32,9 @@ use node_resolver::{
 };
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use sys_traits::impls::RealSys;
+use sys_traits::{FileType, impls::RealSys};
+
+use crate::runtime::ext::node::cjs_translator::CjsCodeAnalyzer;
 
 const NODE_MODULES_DIR: &str = "node_modules";
 const TYPESCRIPT_VERSION: &str = "5.8.3";
@@ -75,7 +79,7 @@ impl Resolver {
             self.folder_resolver.clone(),
             self.folder_resolver.pjson_resolver(),
             NodeResolutionSys::new(RealSys, Some(self.folder_resolver.resolution_cache())),
-            node_resolver::NodeResolverOptions {
+            NodeResolverOptions {
                 conditions: NodeConditionOptions::default(),
                 is_browser_platform: false,
                 bundle_mode: false,
@@ -84,7 +88,7 @@ impl Resolver {
                         clippy::expect_used,
                         reason = "Infallible operation with valid inputs"
                     )]
-                    deno_semver::Version::parse_standard(TYPESCRIPT_VERSION)
+                    Version::parse_standard(TYPESCRIPT_VERSION)
                         .expect("failed to parse typescript version"),
                 ),
             },
@@ -98,10 +102,6 @@ impl Resolver {
             NodeResolver<DenoInNpmPackageChecker, NpmPackageFolderResolverImpl, RealSys>,
         >,
     ) -> super::cjs_translator::NodeCodeTranslator {
-        use node_resolver::analyze::CjsModuleExportAnalyzer;
-
-        use super::cjs_translator::CjsCodeAnalyzer;
-
         let cjs = CjsCodeAnalyzer::new(self.filesystem(), Arc::clone(self));
 
         let module_export_analyzer = CjsModuleExportAnalyzer::new(
@@ -221,7 +221,7 @@ impl Resolver {
 
     pub fn has_node_modules_dir(&self) -> bool {
         self.folder_resolver.base_dir().as_ref().is_some_and(|d| {
-            let checked_path = deno_permissions::CheckedPath::unsafe_new(Cow::Borrowed(d));
+            let checked_path = CheckedPath::unsafe_new(Cow::Borrowed(d));
             self.fs.exists_sync(&checked_path) && self.fs.is_dir_sync(&checked_path)
         })
     }
@@ -333,7 +333,7 @@ impl NpmPackageFolderResolver for NpmPackageFolderResolverImpl {
     fn resolve_types_package_folder(
         &self,
         _package_name: &str,
-        _version: Option<&deno_semver::Version>,
+        _version: Option<&Version>,
         _referrer: Option<&UrlOrPathRef<'_>>,
     ) -> Option<PathBuf> {
         None
@@ -348,8 +348,7 @@ impl PackageJsonCacheImpl {
     }
 }
 impl PackageJsonCache for PackageJsonCacheImpl {
-    fn get(&self, path: &Path) -> deno_package_json::PackageJsonCacheResult {
-        use deno_package_json::PackageJsonCacheResult;
+    fn get(&self, path: &Path) -> PackageJsonCacheResult {
         match self.0.read().ok().and_then(|i| i.get(path)) {
             Some(pkg) => PackageJsonCacheResult::Hit(Some(pkg)),
             None => PackageJsonCacheResult::NotCached,
@@ -397,11 +396,11 @@ impl NodeResolutionCache for NodeResolutionCacheImpl {
         }
     }
 
-    fn get_file_type(&self, path: &Path) -> Option<Option<sys_traits::FileType>> {
+    fn get_file_type(&self, path: &Path) -> Option<Option<FileType>> {
         self.inner.read().ok().and_then(|i| i.get_file_type(path))
     }
 
-    fn set_file_type(&self, path: PathBuf, value: Option<sys_traits::FileType>) {
+    fn set_file_type(&self, path: PathBuf, value: Option<FileType>) {
         if let Ok(mut i) = self.inner.write() {
             i.set_file_type(path, value);
         }
@@ -409,7 +408,7 @@ impl NodeResolutionCache for NodeResolutionCacheImpl {
 }
 #[derive(Debug, Default, Clone)]
 pub struct NodeResolutionCacheInner {
-    cache: FxHashMap<PathBuf, (Option<PathBuf>, Option<sys_traits::FileType>)>,
+    cache: FxHashMap<PathBuf, (Option<PathBuf>, Option<FileType>)>,
 }
 impl NodeResolutionCacheInner {
     fn get_canonicalized(&self, path: &Path) -> Option<Result<PathBuf, io::Error>> {
@@ -433,11 +432,11 @@ impl NodeResolutionCacheInner {
     }
 
     #[expect(clippy::option_option)]
-    fn get_file_type(&self, path: &Path) -> Option<Option<sys_traits::FileType>> {
+    fn get_file_type(&self, path: &Path) -> Option<Option<FileType>> {
         self.cache.get(path).map(|(_, t)| *t)
     }
 
-    fn set_file_type(&mut self, path: PathBuf, value: Option<sys_traits::FileType>) {
+    fn set_file_type(&mut self, path: PathBuf, value: Option<FileType>) {
         if let Some((_, t)) = self.cache.get_mut(&path) {
             *t = value;
         } else {
@@ -471,14 +470,14 @@ impl NpmProcessStateProvider for Resolver {
 struct RequireLoader(Arc<dyn FileSystem + Send + Sync>);
 impl NodeRequireLoader for RequireLoader {
     fn load_text_file_lossy(&self, path: &Path) -> Result<deno_core::FastString, JsErrorBox> {
-        let path_checked = deno_permissions::CheckedPath::unsafe_new(Cow::Borrowed(path));
+        let path_checked = CheckedPath::unsafe_new(Cow::Borrowed(path));
         let text = self.0.read_text_file_lossy_sync(&path_checked).map_err(JsErrorBox::from_err)?;
-        Ok(deno_core::FastString::from(text.into_owned()))
+        Ok(FastString::from(text.into_owned()))
     }
 
     fn ensure_read_permission<'a>(
         &self,
-        _permissions: &mut deno_permissions::PermissionsContainer,
+        _permissions: &mut PermissionsContainer,
         path: Cow<'a, Path>,
     ) -> Result<Cow<'a, Path>, JsErrorBox> {
         Ok(path)

--- a/crates/rari/src/runtime/ext/node/resolvers.rs
+++ b/crates/rari/src/runtime/ext/node/resolvers.rs
@@ -469,7 +469,7 @@ impl NpmProcessStateProvider for Resolver {
 #[derive(Debug)]
 struct RequireLoader(Arc<dyn FileSystem + Send + Sync>);
 impl NodeRequireLoader for RequireLoader {
-    fn load_text_file_lossy(&self, path: &Path) -> Result<deno_core::FastString, JsErrorBox> {
+    fn load_text_file_lossy(&self, path: &Path) -> Result<FastString, JsErrorBox> {
         let path_checked = CheckedPath::unsafe_new(Cow::Borrowed(path));
         let text = self.0.read_text_file_lossy_sync(&path_checked).map_err(JsErrorBox::from_err)?;
         Ok(FastString::from(text.into_owned()))

--- a/crates/rari/src/runtime/ext/node_crypto/mod.rs
+++ b/crates/rari/src/runtime/ext/node_crypto/mod.rs
@@ -1,13 +1,14 @@
 use deno_core::Extension;
+use deno_node_crypto::deno_node_crypto;
 
 use super::ExtensionTrait;
 
-impl ExtensionTrait<()> for deno_node_crypto::deno_node_crypto {
+impl ExtensionTrait<()> for deno_node_crypto {
     fn init((): ()) -> Extension {
         Self::init()
     }
 }
 
 pub fn extensions(is_snapshot: bool) -> Vec<Extension> {
-    vec![deno_node_crypto::deno_node_crypto::build((), is_snapshot)]
+    vec![deno_node_crypto::build((), is_snapshot)]
 }

--- a/crates/rari/src/runtime/ext/node_sqlite/mod.rs
+++ b/crates/rari/src/runtime/ext/node_sqlite/mod.rs
@@ -1,13 +1,14 @@
 use deno_core::Extension;
+use deno_node_sqlite::deno_node_sqlite;
 
 use super::ExtensionTrait;
 
-impl ExtensionTrait<()> for deno_node_sqlite::deno_node_sqlite {
+impl ExtensionTrait<()> for deno_node_sqlite {
     fn init((): ()) -> Extension {
         Self::init()
     }
 }
 
 pub fn extensions(is_snapshot: bool) -> Vec<Extension> {
-    vec![deno_node_sqlite::deno_node_sqlite::build((), is_snapshot)]
+    vec![deno_node_sqlite::build((), is_snapshot)]
 }

--- a/crates/rari/src/runtime/ext/rari/core/types.d.ts
+++ b/crates/rari/src/runtime/ext/rari/core/types.d.ts
@@ -131,7 +131,7 @@ declare global {
       readStream?: (stream: ReadableStream) => Promise<string>
       ssrModules?: Record<string, { default?: unknown, [key: string]: unknown }>
       ssrRenderComponent?: (modulePath: string, exportName: string, props: unknown) => Promise<string>
-      renderWireToHtml?: (wireFormat: string) => Promise<string>
+      renderFlightToHtml?: (flightProtocol: string) => Promise<string>
       clientReferenceManifest?: Record<string, { id: string, chunks: string, name: string }>
       lastRscBinary?: Uint8Array
       capturedElement?: unknown

--- a/crates/rari/src/runtime/ext/runtime/mod.rs
+++ b/crates/rari/src/runtime/ext/runtime/mod.rs
@@ -45,7 +45,7 @@ fn build_permissions(permissions_container: &WebPermissionsContainer) -> DenoPer
     let permissions =
         permissions_container.0.to_deno_permissions(parser.as_ref()).unwrap_or_else(|err| {
             tracing::warn!("Failed to derive Deno permissions from web permissions: {err}");
-            Permissions::allow_all()
+            Permissions::none_without_prompt()
         });
     DenoPermissionsContainer::new(parser, permissions)
 }

--- a/crates/rari/src/runtime/ext/runtime/mod.rs
+++ b/crates/rari/src/runtime/ext/runtime/mod.rs
@@ -1,6 +1,6 @@
 use std::{num::NonZero, rc::Rc, sync::Arc, thread};
 
-use ::deno_permissions::{Permissions, PermissionsContainer};
+use ::deno_permissions::{Permissions, PermissionsContainer as DenoPermissionsContainer};
 use deno_core::{
     CrossIsolateStore, Extension,
     error::JsError,
@@ -30,16 +30,19 @@ use deno_tls::RootCertStoreProvider;
 use deno_web::{BlobStore, InMemoryBroadcastChannel};
 use sys_traits::impls::RealSys;
 
-use super::{ExtensionOptions, ExtensionTrait, node::resolvers::Resolver};
+use super::{
+    ExtensionOptions, ExtensionTrait, node::resolvers::Resolver,
+    web::PermissionsContainer as WebPermissionsContainer,
+};
 use crate::runtime::module_loader::RariModuleLoader;
 
 fn format_js_error(error: &JsError) -> String {
     deno_format_js_error(error, None)
 }
 
-fn build_permissions(_permissions_container: &PermissionsContainer) -> PermissionsContainer {
+fn build_permissions(_permissions_container: &WebPermissionsContainer) -> DenoPermissionsContainer {
     let parser = Arc::new(RuntimePermissionDescriptorParser::<RealSys>::new(RealSys));
-    PermissionsContainer::new(parser, Permissions::allow_all())
+    DenoPermissionsContainer::new(parser, Permissions::allow_all())
 }
 
 extension!(
@@ -62,7 +65,7 @@ extension!(
         };
         state.put(options);
 
-        let container = state.borrow::<PermissionsContainer>();
+        let container = state.borrow::<WebPermissionsContainer>();
         let permissions = build_permissions(container);
         state.put(permissions);
     },

--- a/crates/rari/src/runtime/ext/runtime/mod.rs
+++ b/crates/rari/src/runtime/ext/runtime/mod.rs
@@ -1,15 +1,16 @@
 use std::{num::NonZero, rc::Rc, sync::Arc, thread};
 
-use ::deno_permissions::Permissions;
+use ::deno_permissions::{Permissions, PermissionsContainer};
 use deno_core::{
     CrossIsolateStore, Extension,
     error::JsError,
     extension,
     v8::{BackingStore, SharedRef, icu},
 };
+use deno_io::Stdio;
 use deno_process::deno_process;
 use deno_runtime::{
-    BootstrapOptions, WorkerExecutionMode, WorkerLogLevel, colors,
+    BootstrapOptions, FeatureChecker, WorkerExecutionMode, WorkerLogLevel, colors,
     deno_inspector_server::MainInspectorSessionChannel,
     deno_os::{ExitCode, deno_os},
     fmt_errors::format_js_error as deno_format_js_error,
@@ -21,25 +22,24 @@ use deno_runtime::{
         worker_host::{CreateWebWorkerCb, deno_worker_host},
     },
     permissions::RuntimePermissionDescriptorParser,
+    runtime,
     web_worker::{WebWorker, WebWorkerOptions, WebWorkerServiceOptions},
 };
 use deno_telemetry::OtelConfig;
+use deno_tls::RootCertStoreProvider;
+use deno_web::{BlobStore, InMemoryBroadcastChannel};
 use sys_traits::impls::RealSys;
 
-use super::{
-    ExtensionOptions, ExtensionTrait, node::resolvers::Resolver, web::PermissionsContainer,
-};
+use super::{ExtensionOptions, ExtensionTrait, node::resolvers::Resolver};
 use crate::runtime::module_loader::RariModuleLoader;
 
 fn format_js_error(error: &JsError) -> String {
     deno_format_js_error(error, None)
 }
 
-fn build_permissions(
-    _permissions_container: &PermissionsContainer,
-) -> ::deno_permissions::PermissionsContainer {
+fn build_permissions(_permissions_container: &PermissionsContainer) -> PermissionsContainer {
     let parser = Arc::new(RuntimePermissionDescriptorParser::<RealSys>::new(RealSys));
-    ::deno_permissions::PermissionsContainer::new(parser, Permissions::allow_all())
+    PermissionsContainer::new(parser, Permissions::allow_all())
 }
 
 extension!(
@@ -81,7 +81,7 @@ impl ExtensionTrait<()> for init_runtime {
     }
 }
 
-impl ExtensionTrait<()> for deno_runtime::runtime {
+impl ExtensionTrait<()> for runtime {
     fn init((): ()) -> Extension {
         let mut ext = Self::init();
 
@@ -165,7 +165,7 @@ pub fn extensions(
         deno_web_worker::build((), is_snapshot),
         deno_worker_host::build((options, shared_array_buffer_store), is_snapshot),
         deno_permissions::build((), is_snapshot),
-        deno_runtime::runtime::build((), is_snapshot),
+        runtime::build((), is_snapshot),
         init_console::build((), is_snapshot),
         init_runtime::build((), is_snapshot),
     ]
@@ -175,12 +175,12 @@ pub fn extensions(
 pub struct WebWorkerCallbackOptions {
     shared_array_buffer_store: Option<CrossIsolateStore<SharedRef<BackingStore>>>,
     node_resolver: Arc<Resolver>,
-    root_cert_store_provider: Option<Arc<dyn deno_tls::RootCertStoreProvider>>,
-    broadcast_channel: deno_web::InMemoryBroadcastChannel,
+    root_cert_store_provider: Option<Arc<dyn RootCertStoreProvider>>,
+    broadcast_channel: InMemoryBroadcastChannel,
     unsafely_ignore_certificate_errors: Option<Vec<String>>,
     seed: Option<u64>,
-    stdio: deno_io::Stdio,
-    blob_store: Arc<deno_web::BlobStore>,
+    stdio: Stdio,
+    blob_store: Arc<BlobStore>,
 }
 
 impl WebWorkerCallbackOptions {
@@ -211,7 +211,7 @@ fn create_web_worker_callback(options: WebWorkerCallbackOptions) -> Arc<CreateWe
 
         let create_web_worker_cb = create_web_worker_callback(options.clone());
 
-        let mut feature_checker = deno_features::FeatureChecker::default();
+        let mut feature_checker = FeatureChecker::default();
         feature_checker.set_exit_cb(Box::new(|_, _| {}));
 
         let services = WebWorkerServiceOptions {

--- a/crates/rari/src/runtime/ext/runtime/mod.rs
+++ b/crates/rari/src/runtime/ext/runtime/mod.rs
@@ -40,9 +40,14 @@ fn format_js_error(error: &JsError) -> String {
     deno_format_js_error(error, None)
 }
 
-fn build_permissions(_permissions_container: &WebPermissionsContainer) -> DenoPermissionsContainer {
+fn build_permissions(permissions_container: &WebPermissionsContainer) -> DenoPermissionsContainer {
     let parser = Arc::new(RuntimePermissionDescriptorParser::<RealSys>::new(RealSys));
-    DenoPermissionsContainer::new(parser, Permissions::allow_all())
+    let permissions =
+        permissions_container.0.to_deno_permissions(parser.as_ref()).unwrap_or_else(|err| {
+            tracing::warn!("Failed to derive Deno permissions from web permissions: {err}");
+            Permissions::allow_all()
+        });
+    DenoPermissionsContainer::new(parser, permissions)
 }
 
 extension!(

--- a/crates/rari/src/runtime/ext/web/mod.rs
+++ b/crates/rari/src/runtime/ext/web/mod.rs
@@ -1,6 +1,12 @@
 use std::{rc::Rc, sync::Arc};
 
+use ::deno_fetch::Options;
 use deno_core::{Extension, extension};
+use deno_fetch::deno_fetch;
+use deno_net::deno_net;
+use deno_telemetry::deno_telemetry;
+use deno_tls::deno_tls;
+use deno_web::deno_web;
 
 use super::ExtensionTrait;
 
@@ -22,9 +28,9 @@ impl ExtensionTrait<WebOptions> for init_fetch {
         Self::init()
     }
 }
-impl ExtensionTrait<WebOptions> for deno_fetch::deno_fetch {
+impl ExtensionTrait<WebOptions> for deno_fetch {
     fn init(options: WebOptions) -> Extension {
-        let options = deno_fetch::Options {
+        let options = Options {
             user_agent: options.user_agent.clone(),
             root_cert_store_provider: options.root_cert_store_provider.clone(),
             proxy: options.proxy.clone(),
@@ -52,7 +58,7 @@ impl ExtensionTrait<WebOptions> for init_net {
         Self::init()
     }
 }
-impl ExtensionTrait<WebOptions> for deno_net::deno_net {
+impl ExtensionTrait<WebOptions> for deno_net {
     fn init(options: WebOptions) -> Extension {
         Self::init(
             options.root_cert_store_provider.clone(),
@@ -73,7 +79,7 @@ impl ExtensionTrait<()> for init_telemetry {
     }
 }
 
-impl ExtensionTrait<()> for deno_telemetry::deno_telemetry {
+impl ExtensionTrait<()> for deno_telemetry {
     fn init((): ()) -> Extension {
         Self::init()
     }
@@ -95,13 +101,13 @@ impl ExtensionTrait<WebOptions> for init_web {
     }
 }
 
-impl ExtensionTrait<WebOptions> for deno_web::deno_web {
+impl ExtensionTrait<WebOptions> for deno_web {
     fn init(options: WebOptions) -> Extension {
         Self::init(options.blob_store, options.base_url, false, options.broadcast_channel)
     }
 }
 
-impl ExtensionTrait<()> for deno_tls::deno_tls {
+impl ExtensionTrait<()> for deno_tls {
     fn init((): ()) -> Extension {
         Self::init()
     }
@@ -115,11 +121,11 @@ pub fn extensions(options: WebOptions, is_snapshot: bool) -> Vec<Extension> {
     // applyToGlobal side effects on top of V8-built-in globals).
     let fetch_is_snapshot = false;
     vec![
-        deno_web::deno_web::build(options.clone(), is_snapshot),
-        deno_telemetry::deno_telemetry::build((), is_snapshot),
-        deno_net::deno_net::build(options.clone(), is_snapshot),
-        deno_fetch::deno_fetch::build(options.clone(), is_snapshot),
-        deno_tls::deno_tls::build((), is_snapshot),
+        deno_web::build(options.clone(), is_snapshot),
+        deno_telemetry::build((), is_snapshot),
+        deno_net::build(options.clone(), is_snapshot),
+        deno_fetch::build(options.clone(), is_snapshot),
+        deno_tls::build((), is_snapshot),
         init_web::build(options.clone(), is_snapshot),
         init_telemetry::build((), is_snapshot),
         init_net::build(options.clone(), is_snapshot),

--- a/crates/rari/src/runtime/ext/web/options.rs
+++ b/crates/rari/src/runtime/ext/web/options.rs
@@ -5,30 +5,35 @@
 
 use std::{rc::Rc, sync::Arc};
 
-use deno_fetch::dns::Resolver;
+use deno_core::ModuleSpecifier;
+use deno_error::JsErrorBox;
+use deno_fetch::{DefaultFileFetchHandler, FetchHandler, ReqBody, dns::Resolver};
+use deno_telemetry::OtelConfig;
+use deno_tls::{Proxy, RootCertStoreProvider, TlsKeys};
+use deno_web::{BlobStore, InMemoryBroadcastChannel};
+use http::{HeaderValue, Request, header::ACCEPT_ENCODING};
 use hyper_util::client::legacy::Builder;
 
 use super::{DefaultWebPermissions, WebPermissions};
 
-type RequestBuilderHook =
-    fn(&mut http::Request<deno_fetch::ReqBody>) -> Result<(), deno_error::JsErrorBox>;
+type RequestBuilderHook = fn(&mut Request<ReqBody>) -> Result<(), JsErrorBox>;
 
 #[derive(Clone)]
 pub struct WebOptions {
-    pub base_url: Option<deno_core::ModuleSpecifier>,
+    pub base_url: Option<ModuleSpecifier>,
     pub user_agent: String,
-    pub root_cert_store_provider: Option<Arc<dyn deno_tls::RootCertStoreProvider>>,
-    pub proxy: Option<deno_tls::Proxy>,
+    pub root_cert_store_provider: Option<Arc<dyn RootCertStoreProvider>>,
+    pub proxy: Option<Proxy>,
     pub request_builder_hook: Option<RequestBuilderHook>,
     pub unsafely_ignore_certificate_errors: Option<Vec<String>>,
-    pub client_cert_chain_and_key: deno_tls::TlsKeys,
-    pub file_fetch_handler: Rc<dyn deno_fetch::FetchHandler>,
+    pub client_cert_chain_and_key: TlsKeys,
+    pub file_fetch_handler: Rc<dyn FetchHandler>,
     pub permissions: Arc<dyn WebPermissions>,
-    pub blob_store: Arc<deno_web::BlobStore>,
-    pub broadcast_channel: deno_web::InMemoryBroadcastChannel,
+    pub blob_store: Arc<BlobStore>,
+    pub broadcast_channel: InMemoryBroadcastChannel,
     pub client_builder_hook: Option<fn(Builder) -> Builder>,
     pub resolver: Resolver,
-    pub telemetry_config: deno_telemetry::OtelConfig,
+    pub telemetry_config: OtelConfig,
 }
 
 impl Default for WebOptions {
@@ -40,28 +45,24 @@ impl Default for WebOptions {
             proxy: None,
             request_builder_hook: Some(fix_accept_encoding_for_deno),
             unsafely_ignore_certificate_errors: None,
-            client_cert_chain_and_key: deno_tls::TlsKeys::Null,
-            file_fetch_handler: Rc::new(deno_fetch::DefaultFileFetchHandler),
+            client_cert_chain_and_key: TlsKeys::Null,
+            file_fetch_handler: Rc::new(DefaultFileFetchHandler),
             permissions: Arc::new(DefaultWebPermissions),
-            blob_store: Arc::new(deno_web::BlobStore::default()),
-            broadcast_channel: deno_web::InMemoryBroadcastChannel::default(),
+            blob_store: Arc::new(BlobStore::default()),
+            broadcast_channel: InMemoryBroadcastChannel::default(),
             client_builder_hook: None,
             resolver: Resolver::default(),
-            telemetry_config: deno_telemetry::OtelConfig::default(),
+            telemetry_config: OtelConfig::default(),
         }
     }
 }
 
 /// Deno's fetch only supports gzip and deflate, not zstd or brotli.
 /// This prevents issues where servers return zstd-compressed responses that Deno can't handle.
-fn fix_accept_encoding_for_deno(
-    req: &mut http::Request<deno_fetch::ReqBody>,
-) -> Result<(), deno_error::JsErrorBox> {
-    use http::header::{ACCEPT_ENCODING, HeaderValue};
+fn fix_accept_encoding_for_deno(req: &mut Request<ReqBody>) -> Result<(), JsErrorBox> {
     if !req.headers().contains_key(ACCEPT_ENCODING) {
         req.headers_mut().insert(ACCEPT_ENCODING, HeaderValue::from_static("gzip, deflate"));
     }
-
     Ok(())
 }
 

--- a/crates/rari/src/runtime/ext/web/permissions.rs
+++ b/crates/rari/src/runtime/ext/web/permissions.rs
@@ -170,7 +170,7 @@ impl AllowlistWebPermissions {
             allow_env: (!inst.envs.is_empty()).then(|| inst.envs.iter().cloned().collect()),
             allow_sys: (!inst.sys.is_empty())
                 .then(|| inst.sys.iter().map(|kind| kind.as_str().to_string()).collect()),
-            allow_ffi: inst.exec.then(|| vec!["all".to_string()]),
+            allow_ffi: inst.exec.then(Vec::new),
             prompt: false,
             ..PermissionsOptions::default()
         }

--- a/crates/rari/src/runtime/ext/web/permissions.rs
+++ b/crates/rari/src/runtime/ext/web/permissions.rs
@@ -9,7 +9,10 @@ use std::{
 
 use deno_core::url::Url;
 use deno_fs::FsError;
-use deno_permissions::{PermissionCheckError, PermissionDeniedError, PermissionState};
+use deno_permissions::{
+    PermissionCheckError, PermissionDeniedError, PermissionDescriptorParser, PermissionState,
+    Permissions, PermissionsFromOptionsError, PermissionsOptions,
+};
 use parking_lot::{RwLock, RwLockReadGuard};
 use rustc_hash::FxHashSet;
 
@@ -147,6 +150,21 @@ impl AllowlistWebPermissions {
     fn borrow(&self) -> RwLockReadGuard<'_, AllowlistWebPermissionsSet> {
         self.0.read()
     }
+
+    fn to_deno_permissions_options(&self) -> PermissionsOptions {
+        let inst = self.borrow();
+        PermissionsOptions {
+            allow_read: inst.read_all.then(|| inst.read_paths.iter().cloned().collect()),
+            allow_write: inst.write_all.then(|| inst.write_paths.iter().cloned().collect()),
+            allow_net: (!inst.hosts.is_empty()).then(|| inst.hosts.iter().cloned().collect()),
+            allow_env: (!inst.envs.is_empty()).then(|| inst.envs.iter().cloned().collect()),
+            allow_sys: (!inst.sys.is_empty())
+                .then(|| inst.sys.iter().map(|kind| kind.as_str().to_string()).collect()),
+            allow_ffi: inst.exec.then(|| vec!["all".to_string()]),
+            prompt: false,
+            ..PermissionsOptions::default()
+        }
+    }
 }
 
 impl WebPermissions for AllowlistWebPermissions {
@@ -266,6 +284,13 @@ impl WebPermissions for AllowlistWebPermissions {
     fn check_exec(&self) -> Result<(), PermissionDeniedError> {
         if self.borrow().exec { Ok(()) } else { oops("ffi")? }
     }
+
+    fn to_deno_permissions(
+        &self,
+        parser: &dyn PermissionDescriptorParser,
+    ) -> Result<Permissions, PermissionsFromOptionsError> {
+        Permissions::from_options(parser, &self.to_deno_permissions_options())
+    }
 }
 
 pub trait WebPermissions: Debug + Send + Sync {
@@ -334,6 +359,14 @@ pub trait WebPermissions: Debug + Send + Sync {
     fn check_env(&self, var: &str) -> Result<(), PermissionDeniedError>;
 
     fn check_exec(&self) -> Result<(), PermissionDeniedError>;
+
+    fn to_deno_permissions(
+        &self,
+        parser: &dyn PermissionDescriptorParser,
+    ) -> Result<Permissions, PermissionsFromOptionsError> {
+        let _ = parser;
+        Ok(Permissions::allow_all())
+    }
 }
 
 macro_rules! impl_sys_permission_kinds {

--- a/crates/rari/src/runtime/ext/web/permissions.rs
+++ b/crates/rari/src/runtime/ext/web/permissions.rs
@@ -9,9 +9,8 @@ use std::{
 
 use deno_core::url::Url;
 use deno_fs::FsError;
-use deno_permissions::PermissionCheckError;
-pub use deno_permissions::PermissionDeniedError;
-use parking_lot::RwLock;
+use deno_permissions::{PermissionCheckError, PermissionDeniedError, PermissionState};
+use parking_lot::{RwLock, RwLockReadGuard};
 use rustc_hash::FxHashSet;
 
 fn to_io_err(err: &PermissionDeniedError) -> Error {
@@ -19,12 +18,11 @@ fn to_io_err(err: &PermissionDeniedError) -> Error {
 }
 
 pub fn oops<T>(msg: impl Display) -> Result<T, PermissionDeniedError> {
-    use deno_permissions::PermissionDeniedError;
     Err(PermissionDeniedError {
         access: msg.to_string(),
         name: "oops",
         custom_message: None,
-        state: deno_permissions::PermissionState::Denied,
+        state: PermissionState::Denied,
     })
 }
 
@@ -146,7 +144,7 @@ struct AllowlistWebPermissionsSet {
 #[derive(Clone, Default, Debug)]
 pub struct AllowlistWebPermissions(Arc<RwLock<AllowlistWebPermissionsSet>>);
 impl AllowlistWebPermissions {
-    fn borrow(&self) -> parking_lot::RwLockReadGuard<'_, AllowlistWebPermissionsSet> {
+    fn borrow(&self) -> RwLockReadGuard<'_, AllowlistWebPermissionsSet> {
         self.0.read()
     }
 }

--- a/crates/rari/src/runtime/ext/web/permissions.rs
+++ b/crates/rari/src/runtime/ext/web/permissions.rs
@@ -125,6 +125,14 @@ impl WebPermissions for DefaultWebPermissions {
     fn check_exec(&self) -> Result<(), PermissionDeniedError> {
         Ok(())
     }
+
+    fn to_deno_permissions(
+        &self,
+        parser: &dyn PermissionDescriptorParser,
+    ) -> Result<Permissions, PermissionsFromOptionsError> {
+        let _ = parser;
+        Ok(Permissions::allow_all())
+    }
 }
 
 #[derive(Clone, Default, Debug)]
@@ -154,8 +162,10 @@ impl AllowlistWebPermissions {
     fn to_deno_permissions_options(&self) -> PermissionsOptions {
         let inst = self.borrow();
         PermissionsOptions {
-            allow_read: inst.read_all.then(|| inst.read_paths.iter().cloned().collect()),
-            allow_write: inst.write_all.then(|| inst.write_paths.iter().cloned().collect()),
+            allow_read: (inst.read_all && !inst.read_paths.is_empty())
+                .then(|| inst.read_paths.iter().cloned().collect()),
+            allow_write: (inst.write_all && !inst.write_paths.is_empty())
+                .then(|| inst.write_paths.iter().cloned().collect()),
             allow_net: (!inst.hosts.is_empty()).then(|| inst.hosts.iter().cloned().collect()),
             allow_env: (!inst.envs.is_empty()).then(|| inst.envs.iter().cloned().collect()),
             allow_sys: (!inst.sys.is_empty())
@@ -363,10 +373,7 @@ pub trait WebPermissions: Debug + Send + Sync {
     fn to_deno_permissions(
         &self,
         parser: &dyn PermissionDescriptorParser,
-    ) -> Result<Permissions, PermissionsFromOptionsError> {
-        let _ = parser;
-        Ok(Permissions::allow_all())
-    }
+    ) -> Result<Permissions, PermissionsFromOptionsError>;
 }
 
 macro_rules! impl_sys_permission_kinds {

--- a/crates/rari/src/runtime/ext/webgpu/mod.rs
+++ b/crates/rari/src/runtime/ext/webgpu/mod.rs
@@ -1,13 +1,14 @@
 use deno_core::Extension;
+use deno_webgpu::deno_webgpu;
 
 use super::ExtensionTrait;
 
-impl ExtensionTrait<()> for deno_webgpu::deno_webgpu {
+impl ExtensionTrait<()> for deno_webgpu {
     fn init((): ()) -> Extension {
         Self::init()
     }
 }
 
 pub fn extensions(is_snapshot: bool) -> Vec<Extension> {
-    vec![deno_webgpu::deno_webgpu::build((), is_snapshot)]
+    vec![deno_webgpu::build((), is_snapshot)]
 }

--- a/crates/rari/src/runtime/ext/webidl/mod.rs
+++ b/crates/rari/src/runtime/ext/webidl/mod.rs
@@ -1,4 +1,5 @@
 use deno_core::{Extension, extension};
+use deno_webidl::deno_webidl;
 
 use super::ExtensionTrait;
 
@@ -16,5 +17,5 @@ impl ExtensionTrait<()> for init_webidl {
 }
 
 pub fn extensions(is_snapshot: bool) -> Vec<Extension> {
-    vec![deno_webidl::deno_webidl::init(), init_webidl::build((), is_snapshot)]
+    vec![deno_webidl::init(), init_webidl::build((), is_snapshot)]
 }

--- a/crates/rari/src/runtime/ext/websocket/mod.rs
+++ b/crates/rari/src/runtime/ext/websocket/mod.rs
@@ -1,4 +1,5 @@
 use deno_core::{Extension, extension};
+use deno_websocket::deno_websocket;
 
 use super::{ExtensionTrait, web::WebOptions};
 
@@ -13,15 +14,12 @@ impl ExtensionTrait<()> for init_websocket {
         Self::init()
     }
 }
-impl ExtensionTrait<WebOptions> for deno_websocket::deno_websocket {
+impl ExtensionTrait<WebOptions> for deno_websocket {
     fn init(_options: WebOptions) -> Extension {
         Self::init()
     }
 }
 
 pub fn extensions(options: WebOptions, is_snapshot: bool) -> Vec<Extension> {
-    vec![
-        deno_websocket::deno_websocket::build(options, is_snapshot),
-        init_websocket::build((), is_snapshot),
-    ]
+    vec![deno_websocket::build(options, is_snapshot), init_websocket::build((), is_snapshot)]
 }

--- a/crates/rari/src/runtime/ext/webstorage/mod.rs
+++ b/crates/rari/src/runtime/ext/webstorage/mod.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use deno_core::{Extension, extension};
+use deno_webstorage::deno_webstorage;
 
 use super::ExtensionTrait;
 
@@ -15,7 +16,7 @@ impl ExtensionTrait<()> for init_webstorage {
         Self::init()
     }
 }
-impl ExtensionTrait<Option<PathBuf>> for deno_webstorage::deno_webstorage {
+impl ExtensionTrait<Option<PathBuf>> for deno_webstorage {
     fn init(origin_storage_dir: Option<PathBuf>) -> Extension {
         Self::init(origin_storage_dir)
     }
@@ -23,7 +24,7 @@ impl ExtensionTrait<Option<PathBuf>> for deno_webstorage::deno_webstorage {
 
 pub fn extensions(origin_storage_dir: Option<PathBuf>, is_snapshot: bool) -> Vec<Extension> {
     vec![
-        deno_webstorage::deno_webstorage::build(origin_storage_dir, is_snapshot),
+        deno_webstorage::build(origin_storage_dir, is_snapshot),
         init_webstorage::build((), is_snapshot),
     ]
 }

--- a/crates/rari/src/runtime/factory/executor.rs
+++ b/crates/rari/src/runtime/factory/executor.rs
@@ -3,8 +3,7 @@ use std::{env, rc::Rc, string::ToString, time::Duration};
 use deno_core::{JsRuntime, error::AnyError, v8};
 use rari_error::RariError;
 use serde_json::Value;
-use tokio::{sync::mpsc, time::timeout};
-use tracing::error;
+use tokio::{sync::mpsc, time};
 
 use crate::{
     runtime::{
@@ -126,7 +125,7 @@ async fn execute_as_module(
 
     match eval_result {
         Ok(()) => {
-            match timeout(
+            match time::timeout(
                 Duration::from_millis(10),
                 run_event_loop_with_error_handling(
                     runtime,
@@ -233,7 +232,7 @@ async fn handle_promise_result(
         let context = scope.get_current_context();
         let global = context.global(scope);
         let Some(key) = v8::String::new(scope, "__temp_promise_ref__") else {
-            error!("Failed to create V8 string for __temp_promise_ref__");
+            tracing::error!("Failed to create V8 string for __temp_promise_ref__");
             return Err(RariError::internal("Failed to create V8 string".to_string()));
         };
         global.set(scope, key.into(), local_v8_val);

--- a/crates/rari/src/runtime/mod.rs
+++ b/crates/rari/src/runtime/mod.rs
@@ -9,12 +9,11 @@ use deno_core::ModuleId;
 use rari_error::RariError;
 use regex::Regex;
 use rustc_hash::FxHashMap;
-use serde_json::{Value, json};
+use serde_json::Value;
 use tokio::{
     sync::mpsc::{Sender, UnboundedReceiver},
     time,
 };
-use tracing::error;
 
 pub mod ext;
 pub mod factory;
@@ -27,8 +26,7 @@ use factory::JsRuntimeInterface;
 use crate::{
     runtime::factory::RariRuntime,
     server::{
-        middleware::request_context::RequestContext,
-        rendering::metadata::{finalize_metadata, merge_metadata},
+        middleware::request_context::RequestContext, rendering::metadata,
         routing::types::ParamValue,
     },
 };
@@ -120,7 +118,7 @@ impl JsExecutionRuntime {
         params: FxHashMap<String, ParamValue>,
         search_params: FxHashMap<String, Vec<String>>,
     ) -> Result<Value, RariError> {
-        let data = json!({
+        let data = serde_json::json!({
             "layoutPaths": layout_paths,
             "pagePath": page_path,
             "params": params,
@@ -148,12 +146,12 @@ impl JsExecutionRuntime {
             RariError::serialization("Expected metadata list to be an array".to_string())
         })?;
 
-        let mut merged_metadata = json!({});
+        let mut merged_metadata = serde_json::json!({});
         for metadata_item in metadata_array {
-            merged_metadata = merge_metadata(&merged_metadata, metadata_item);
+            merged_metadata = metadata::merge_metadata(&merged_metadata, metadata_item);
         }
 
-        finalize_metadata(&mut merged_metadata);
+        metadata::finalize_metadata(&mut merged_metadata);
 
         Ok(merged_metadata)
     }
@@ -555,11 +553,17 @@ impl JsExecutionRuntime {
         match (result, clear_result) {
             (Ok(value), Ok(())) => Ok(value),
             (Ok(value), Err(clear_err)) => {
-                error!("Failed to clear request context after successful operation: {}", clear_err);
+                tracing::error!(
+                    "Failed to clear request context after successful operation: {}",
+                    clear_err
+                );
                 Ok(value)
             }
             (Err(op_err), Err(clear_err)) => {
-                error!("Failed to clear request context after operation error: {}", clear_err);
+                tracing::error!(
+                    "Failed to clear request context after operation error: {}",
+                    clear_err
+                );
                 Err(op_err)
             }
             (Err(op_err), Ok(())) => Err(op_err),

--- a/crates/rari/src/runtime/mod.rs
+++ b/crates/rari/src/runtime/mod.rs
@@ -5,8 +5,10 @@ use std::{
 };
 
 use cow_utils::CowUtils;
+use deno_core::ModuleId;
 use rari_error::RariError;
 use regex::Regex;
+use rustc_hash::FxHashMap;
 use serde_json::{Value, json};
 use tokio::{
     sync::mpsc::{Sender, UnboundedReceiver},
@@ -22,14 +24,17 @@ pub mod transpile;
 
 use factory::JsRuntimeInterface;
 
-use crate::server::{
-    middleware::request_context::RequestContext,
-    rendering::metadata::{finalize_metadata, merge_metadata},
-    routing::types::ParamValue,
+use crate::{
+    runtime::factory::RariRuntime,
+    server::{
+        middleware::request_context::RequestContext,
+        rendering::metadata::{finalize_metadata, merge_metadata},
+        routing::types::ParamValue,
+    },
 };
 
 pub struct JsExecutionRuntime {
-    runtime: Arc<factory::RariRuntime>,
+    runtime: Arc<RariRuntime>,
     timeout_ms: u64,
 }
 
@@ -58,7 +63,7 @@ fn is_esm_code(code: &str) -> bool {
 
 #[expect(clippy::missing_errors_doc)]
 impl JsExecutionRuntime {
-    pub fn new(env_vars: Option<rustc_hash::FxHashMap<String, String>>) -> Self {
+    pub fn new(env_vars: Option<FxHashMap<String, String>>) -> Self {
         let runtime = if let Some(env_vars) = env_vars {
             factory::create_runtime_with_env(env_vars)
         } else {
@@ -112,8 +117,8 @@ impl JsExecutionRuntime {
         &self,
         layout_paths: Vec<String>,
         page_path: String,
-        params: rustc_hash::FxHashMap<String, ParamValue>,
-        search_params: rustc_hash::FxHashMap<String, Vec<String>>,
+        params: FxHashMap<String, ParamValue>,
+        search_params: FxHashMap<String, Vec<String>>,
     ) -> Result<Value, RariError> {
         let data = json!({
             "layoutPaths": layout_paths,
@@ -175,7 +180,7 @@ impl JsExecutionRuntime {
         }
     }
 
-    pub async fn load_es_module(&self, specifier: &str) -> Result<deno_core::ModuleId, RariError> {
+    pub async fn load_es_module(&self, specifier: &str) -> Result<ModuleId, RariError> {
         let runtime = Arc::clone(&self.runtime);
         let specifier = specifier.to_string();
 
@@ -193,10 +198,7 @@ impl JsExecutionRuntime {
         }
     }
 
-    pub async fn evaluate_module(
-        &self,
-        module_id: deno_core::ModuleId,
-    ) -> Result<Value, RariError> {
+    pub async fn evaluate_module(&self, module_id: ModuleId) -> Result<Value, RariError> {
         let runtime = Arc::clone(&self.runtime);
 
         match time::timeout(
@@ -253,10 +255,7 @@ impl JsExecutionRuntime {
         }
     }
 
-    pub async fn get_module_namespace(
-        &self,
-        module_id: deno_core::ModuleId,
-    ) -> Result<Value, RariError> {
+    pub async fn get_module_namespace(&self, module_id: ModuleId) -> Result<Value, RariError> {
         let runtime = Arc::clone(&self.runtime);
 
         match time::timeout(
@@ -455,8 +454,7 @@ impl JsExecutionRuntime {
                     RariError::js_execution(error_msg)
                 })?;
 
-            let success =
-                result.get("success").and_then(serde_json::Value::as_bool).unwrap_or(false);
+            let success = result.get("success").and_then(Value::as_bool).unwrap_or(false);
 
             if !success {
                 let error_msg =

--- a/crates/rari/src/runtime/module_loader/core.rs
+++ b/crates/rari/src/runtime/module_loader/core.rs
@@ -1,11 +1,12 @@
 use std::{
     borrow::Cow,
     env, fs,
-    io::{Error, ErrorKind::InvalidInput},
+    io::{Error, ErrorKind},
     path::{Path, PathBuf},
     rc::Rc,
     string::ToString,
     sync::{Arc, OnceLock},
+    time::Instant,
 };
 
 use cow_utils::CowUtils;
@@ -20,7 +21,6 @@ use rari_rsc::utils::{DependencyList, extract_dependencies};
 use rari_utils::path_to_file_url;
 use regex::Regex;
 use rustc_hash::FxHashMap;
-use tokio::time::Instant;
 
 use super::{
     cache::{DEFAULT_TTL_SECS, ModuleCaching},
@@ -314,7 +314,7 @@ export default {{}};
             match ModuleSpecifier::parse(specifier.as_str()) {
                 Ok(_) => transpile::maybe_transpile_source(&specifier, code),
                 Err(e) => Err(JsErrorBox::from_err(Box::new(Error::new(
-                    InvalidInput,
+                    ErrorKind::InvalidInput,
                     format!("Failed to parse module specifier '{specifier}': {e}"),
                 )))),
             }

--- a/crates/rari/src/runtime/ops.rs
+++ b/crates/rari/src/runtime/ops.rs
@@ -1,24 +1,16 @@
-use std::{
-    cell::RefCell,
-    cmp::Ordering::{Greater, Less},
-    collections::BTreeMap,
-    rc::Rc,
-    sync::Arc,
-    time::Duration,
-};
+use std::{cell::RefCell, cmp::Ordering, collections::BTreeMap, rc::Rc, sync::Arc, time::Duration};
 
 use axum::http::HeaderMap;
 use deno_core::{OpDecl, OpState, op2};
 use deno_error::JsErrorBox;
 use serde::Deserialize;
 use tokio::sync::mpsc;
-use tracing::error;
 
 use crate::{
-    rendering::base::sanitize_component_output,
+    rendering::base,
     server::{
-        core::utils::client::get_http_client,
-        handlers::actions::{is_valid_attr_value, is_valid_cookie_name, is_valid_cookie_value},
+        core::utils::client,
+        handlers::actions,
         middleware::request_context::{PendingCookie, PendingCookieKey, RequestContext},
     },
 };
@@ -76,12 +68,17 @@ impl StreamOpState {
 
 fn parse_hex_row_id(row_id: &str, context: &str) -> Result<u32, JsErrorBox> {
     if !row_id.chars().all(|c| c.is_ascii_hexdigit()) {
-        error!("op_send_chunk_to_rust: invalid row_id '{}' for {}", row_id, context);
+        tracing::error!("op_send_chunk_to_rust: invalid row_id '{}' for {}", row_id, context);
         return Err(JsErrorBox::generic(format!("Invalid row_id: {row_id}")));
     }
 
     u32::from_str_radix(row_id, 16).map_err(|e| {
-        error!("op_send_chunk_to_rust: invalid row_id '{}' for {}: {}", row_id, context, e);
+        tracing::error!(
+            "op_send_chunk_to_rust: invalid row_id '{}' for {}: {}",
+            row_id,
+            context,
+            e
+        );
         JsErrorBox::generic(format!("Invalid row_id: {row_id}"))
     })
 }
@@ -98,7 +95,7 @@ pub async fn op_send_chunk_to_rust(
                 "Invalid JSON for RSC operation: {e}. JSON length: {}",
                 operation_json.len()
             );
-            error!("{err_msg}");
+            tracing::error!("{err_msg}");
             return Err(JsErrorBox::generic(err_msg));
         }
     };
@@ -133,7 +130,7 @@ pub async fn op_send_chunk_to_rust(
             let rsc_row = format!("{row_id_num:x}:M{module_data}");
 
             if sender.send(Ok(rsc_row.into_bytes())).await.is_err() {
-                error!("op_send_chunk_to_rust: receiver dropped for module reference.");
+                tracing::error!("op_send_chunk_to_rust: receiver dropped for module reference.");
             }
         }
         (Some(sender), RscStreamOperation::ReactElement { row_id, element }) => {
@@ -141,7 +138,7 @@ pub async fn op_send_chunk_to_rust(
             let rsc_row = format!("{row_id_num:x}:J{element}");
 
             if sender.send(Ok(rsc_row.into_bytes())).await.is_err() {
-                error!("op_send_chunk_to_rust: receiver dropped for React element.");
+                tracing::error!("op_send_chunk_to_rust: receiver dropped for React element.");
             }
         }
         (Some(sender), RscStreamOperation::Symbol { row_id, symbol_ref }) => {
@@ -149,13 +146,13 @@ pub async fn op_send_chunk_to_rust(
             let rsc_row = format!("{row_id_num:x}:S\"{symbol_ref}\"");
 
             if sender.send(Ok(rsc_row.into_bytes())).await.is_err() {
-                error!("op_send_chunk_to_rust: receiver dropped for symbol reference.");
+                tracing::error!("op_send_chunk_to_rust: receiver dropped for symbol reference.");
             }
         }
         (Some(sender), RscStreamOperation::Error { row_id, message, stack, phase, digest }) => {
-            error!("Streaming error in row {row_id}: {message}");
+            tracing::error!("Streaming error in row {row_id}: {message}");
             if let Some(stack_trace) = &stack {
-                error!("Stack trace: {stack_trace}");
+                tracing::error!("Stack trace: {stack_trace}");
             }
 
             let error_data = serde_json::json!({
@@ -169,12 +166,12 @@ pub async fn op_send_chunk_to_rust(
             let rsc_row = format!("{row_id_num:x}:E{error_data}");
 
             if sender.send(Ok(rsc_row.into_bytes())).await.is_err() {
-                error!("op_send_chunk_to_rust: receiver dropped for error message.");
+                tracing::error!("op_send_chunk_to_rust: receiver dropped for error message.");
             }
         }
         (Some(_sender), RscStreamOperation::Complete { final_row_id: _ }) => {}
         (None, operation) => {
-            error!("No sender available for operation: {operation:?}");
+            tracing::error!("No sender available for operation: {operation:?}");
             return Err(JsErrorBox::generic("No chunk sender available"));
         }
     }
@@ -289,13 +286,13 @@ pub fn op_fizz_done(state: &mut OpState) {
 
 #[op2(fast)]
 pub fn op_internal_log(#[string] message: &str) {
-    error!("[rari] {message}");
+    tracing::error!("[rari] {message}");
 }
 
 #[op2]
 #[string]
 pub fn op_sanitize_html(#[string] html: &str, #[string] _component_id: &str) -> String {
-    sanitize_component_output(html)
+    base::sanitize_component_output(html)
 }
 
 fn http_status_text(status: u16) -> &'static str {
@@ -366,7 +363,7 @@ pub async fn op_fetch_with_cache(
                 }))
             }
             Err(e) => {
-                error!("Fetch failed for {}: {}", url, e);
+                tracing::error!("Fetch failed for {}: {}", url, e);
                 Ok(serde_json::json!({
                     "ok": false,
                     "status": 500,
@@ -389,7 +386,7 @@ pub async fn op_fetch_with_cache(
                 "tags": Vec::<String>::new()
             })),
             Err(e) => {
-                error!("Fetch failed for {}: {}", url, e);
+                tracing::error!("Fetch failed for {}: {}", url, e);
                 Ok(serde_json::json!({
                     "ok": false,
                     "status": 500,
@@ -407,7 +404,7 @@ async fn perform_simple_fetch(
     url: &str,
     options: &rustc_hash::FxHashMap<String, String>,
 ) -> Result<(u16, String, serde_json::Map<String, serde_json::Value>), String> {
-    let client = get_http_client()?;
+    let client = client::get_http_client()?;
     let mut request = client.get(url);
 
     if let Some(headers_str) = options.get("headers")
@@ -461,8 +458,8 @@ pub fn op_get_cookies(state: Rc<RefCell<OpState>>) -> String {
         let a_is_delete = a_cookie.max_age == Some(0);
         let b_is_delete = b_cookie.max_age == Some(0);
         match (a_is_delete, b_is_delete) {
-            (true, false) => Less,
-            (false, true) => Greater,
+            (true, false) => Ordering::Less,
+            (false, true) => Ordering::Greater,
             _ => {
                 let a_path_len = a_key.path.as_deref().unwrap_or("").len();
                 let b_path_len = b_key.path.as_deref().unwrap_or("").len();
@@ -512,11 +509,11 @@ pub fn op_set_cookie(
     state: Rc<RefCell<OpState>>,
     #[serde] args: SetCookieArgs,
 ) -> Result<(), JsErrorBox> {
-    if !is_valid_cookie_name(&args.name) {
+    if !actions::is_valid_cookie_name(&args.name) {
         return Err(JsErrorBox::type_error(format!("Invalid cookie name: '{}'", args.name)));
     }
 
-    if !is_valid_cookie_value(&args.value) {
+    if !actions::is_valid_cookie_value(&args.value) {
         return Err(JsErrorBox::type_error(format!(
             "Invalid cookie value for '{}': contains invalid characters",
             args.name
@@ -524,7 +521,7 @@ pub fn op_set_cookie(
     }
 
     if let Some(ref path) = args.path
-        && !is_valid_attr_value(path)
+        && !actions::is_valid_attr_value(path)
     {
         return Err(JsErrorBox::type_error(format!(
             "Invalid cookie path for '{}': '{}'",
@@ -533,7 +530,7 @@ pub fn op_set_cookie(
     }
 
     if let Some(ref domain) = args.domain
-        && !is_valid_attr_value(domain)
+        && !actions::is_valid_attr_value(domain)
     {
         return Err(JsErrorBox::type_error(format!(
             "Invalid cookie domain for '{}': '{}'",

--- a/crates/rari/src/server/cache/warmup.rs
+++ b/crates/rari/src/server/cache/warmup.rs
@@ -10,7 +10,6 @@ use axum::http::HeaderMap;
 use futures::stream::{self, StreamExt};
 use rustc_hash::FxHashMap;
 use tokio::sync::{Mutex, OnceCell};
-use tracing::{error, info};
 
 use crate::{
     rendering::layout::{LayoutRenderContext, LayoutRenderer, types::RenderResult},
@@ -37,18 +36,18 @@ async fn warmup_render_lock() -> &'static Mutex<()> {
 
 pub async fn warm_cache(state: &ServerState) {
     let Some(app_router) = &state.app_router else {
-        info!("[rari] Cache warmup: No app router available, skipping");
+        tracing::info!("[rari] Cache warmup: No app router available, skipping");
         return;
     };
 
     let paths = app_router.warmup_paths();
 
     if paths.is_empty() {
-        info!("[rari] Cache warmup: No routes to warm");
+        tracing::info!("[rari] Cache warmup: No routes to warm");
         return;
     }
 
-    info!("[rari] Cache warmup: Pre-rendering {} routes...", paths.len());
+    tracing::info!("[rari] Cache warmup: Pre-rendering {} routes...", paths.len());
     let start = Instant::now();
 
     let success_count = Arc::new(AtomicUsize::new(0));
@@ -64,7 +63,7 @@ pub async fn warm_cache(state: &ServerState) {
                         success_count.fetch_add(1, Ordering::Relaxed);
                     }
                     Err(e) => {
-                        error!("[rari] Cache warmup: Failed to warm '{}': {}", path, e);
+                        tracing::error!("[rari] Cache warmup: Failed to warm '{}': {}", path, e);
                         error_count.fetch_add(1, Ordering::Relaxed);
                     }
                 }
@@ -73,7 +72,7 @@ pub async fn warm_cache(state: &ServerState) {
         .await;
 
     let elapsed = start.elapsed();
-    info!(
+    tracing::info!(
         "[rari] Cache warmup: Completed in {:.1}ms ({} succeeded, {} failed)",
         elapsed.as_secs_f64() * 1000.0,
         success_count.load(Ordering::Relaxed),

--- a/crates/rari/src/server/compression/stream.rs
+++ b/crates/rari/src/server/compression/stream.rs
@@ -4,7 +4,6 @@ use async_compression::tokio::write::{BrotliEncoder, GzipEncoder, ZstdEncoder};
 use bytes::Bytes;
 use futures::stream::{self, Stream, StreamExt};
 use tokio::io::AsyncWriteExt;
-use tracing::error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
@@ -66,7 +65,7 @@ where
                                     Some((Ok(compressed_chunk), (input, Some(comp), false)))
                                 }
                                 Err(e) => {
-                                    error!("Zstd compression error: {}", e);
+                                    tracing::error!("Zstd compression error: {}", e);
                                     Some((Err(e), (input, None, true)))
                                 }
                             }
@@ -77,7 +76,7 @@ where
                                 match comp.finish().await {
                                     Ok(final_chunk) => Some((Ok(final_chunk), (input, None, true))),
                                     Err(e) => {
-                                        error!("Zstd finalization error: {}", e);
+                                        tracing::error!("Zstd finalization error: {}", e);
                                         Some((Err(e), (input, None, true)))
                                     }
                                 }
@@ -107,7 +106,7 @@ where
                                     Some((Ok(compressed_chunk), (input, Some(comp), false)))
                                 }
                                 Err(e) => {
-                                    error!("Brotli compression error: {}", e);
+                                    tracing::error!("Brotli compression error: {}", e);
                                     Some((Err(e), (input, None, true)))
                                 }
                             }
@@ -118,7 +117,7 @@ where
                                 match comp.finish().await {
                                     Ok(final_chunk) => Some((Ok(final_chunk), (input, None, true))),
                                     Err(e) => {
-                                        error!("Brotli finalization error: {}", e);
+                                        tracing::error!("Brotli finalization error: {}", e);
                                         Some((Err(e), (input, None, true)))
                                     }
                                 }
@@ -148,7 +147,7 @@ where
                                     Some((Ok(compressed_chunk), (input, Some(comp), false)))
                                 }
                                 Err(e) => {
-                                    error!("Gzip compression error: {}", e);
+                                    tracing::error!("Gzip compression error: {}", e);
                                     Some((Err(e), (input, None, true)))
                                 }
                             }
@@ -159,7 +158,7 @@ where
                                 match comp.finish().await {
                                     Ok(final_chunk) => Some((Ok(final_chunk), (input, None, true))),
                                     Err(e) => {
-                                        error!("Gzip finalization error: {}", e);
+                                        tracing::error!("Gzip finalization error: {}", e);
                                         Some((Err(e), (input, None, true)))
                                     }
                                 }

--- a/crates/rari/src/server/core/mod.rs
+++ b/crates/rari/src/server/core/mod.rs
@@ -2,7 +2,7 @@ pub mod types;
 pub mod utils;
 
 use std::{
-    env, fs,
+    env,
     net::SocketAddr,
     path::PathBuf,
     sync::{Arc, atomic::AtomicU64},
@@ -21,6 +21,7 @@ use dashmap::DashMap;
 use rari_error::RariError;
 use rustc_hash::FxHashMap;
 use tokio::{
+    fs,
     net::TcpListener,
     sync::{Mutex, RwLock},
 };
@@ -230,7 +231,7 @@ impl Server {
         let mut config = config;
         let config_path = "dist/server/image.json";
 
-        if let Ok(image_config_str) = fs::read_to_string(config_path)
+        if let Ok(image_config_str) = fs::read_to_string(config_path).await
             && let Ok(image_config) = serde_json::from_str::<ImageConfig>(&image_config_str)
         {
             config.images = image_config;

--- a/crates/rari/src/server/core/mod.rs
+++ b/crates/rari/src/server/core/mod.rs
@@ -1,33 +1,33 @@
-use std::{env, fs, path::PathBuf};
-
-use axum::{body::HttpBody, routing};
-use tokio::sync::Mutex;
-
 pub mod types;
 pub mod utils;
 
 use std::{
+    env, fs,
     net::SocketAddr,
+    path::PathBuf,
     sync::{Arc, atomic::AtomicU64},
     time::Instant,
 };
 
 use axum::{
     Router,
+    body::HttpBody,
     extract::DefaultBodyLimit,
     middleware::{self},
-    routing::{any, get, post},
+    routing,
 };
 use colored::Colorize;
 use dashmap::DashMap;
 use rari_error::RariError;
 use rustc_hash::FxHashMap;
-use tokio::{net::TcpListener, sync::RwLock};
+use tokio::{
+    net::TcpListener,
+    sync::{Mutex, RwLock},
+};
 use tower_http::{
     compression::{CompressionLayer, Predicate},
     services::ServeDir,
 };
-use tracing::{debug, error};
 use types::ServerState;
 
 use crate::{
@@ -237,7 +237,7 @@ impl Server {
         }
 
         if let Err(e) = proxy::initialize_proxy(&state).await {
-            error!("Failed to initialize proxy: {}", e);
+            tracing::error!("Failed to initialize proxy: {}", e);
         }
 
         let router = Self::build_router(&config, state.clone()).await?;
@@ -275,27 +275,28 @@ impl Server {
         let image_state = ImageState { optimizer: image_optimizer };
 
         let revalidation_router = Router::new()
-            .route("/_rari/revalidate", post(revalidate_by_path))
+            .route("/_rari/revalidate", routing::post(revalidate_by_path))
             .layer(small_body_limit);
 
         let mut router = Router::new()
-            .route("/_rari/health", get(health_check))
+            .route("/_rari/health", routing::get(health_check))
             .layer(medium_body_limit)
-            .route("/_rari/route-info", post(get_route_info))
+            .route("/_rari/route-info", routing::post(get_route_info))
             .layer(small_body_limit)
-            .route("/_rari/action", post(handle_server_action))
-            .route("/_rari/form-action", post(handle_form_action))
+            .route("/_rari/action", routing::post(handle_server_action))
+            .route("/_rari/form-action", routing::post(handle_form_action))
             .layer(medium_body_limit)
             .merge(revalidation_router);
 
-        let image_router =
-            Router::new().route("/_rari/image", get(handle_image_request)).with_state(image_state);
+        let image_router = Router::new()
+            .route("/_rari/image", routing::get(handle_image_request))
+            .with_state(image_state);
 
         router = router.merge(image_router);
 
         let og_router = Router::new()
-            .route("/_rari/og/", get(og_image_handler_root))
-            .route("/_rari/og/{*path}", get(og_image_handler))
+            .route("/_rari/og/", routing::get(og_image_handler_root))
+            .route("/_rari/og/{*path}", routing::get(og_image_handler))
             .with_state(state.clone());
 
         router = router.merge(og_router);
@@ -305,19 +306,19 @@ impl Server {
             let large_body_limit = DefaultBodyLimit::max(50 * 1024 * 1024);
 
             router = router
-                .route("/_rari/register", post(register_component))
-                .route("/_rari/register-client", post(register_client_component))
+                .route("/_rari/register", routing::post(register_component))
+                .route("/_rari/register-client", routing::post(register_client_component))
                 .layer(large_body_limit)
-                .route("/_rari/hmr", post(handle_hmr_action))
+                .route("/_rari/hmr", routing::post(handle_hmr_action))
                 .route("/_rari/hmr", routing::options(cors_preflight_ok))
                 .layer(medium_body_limit)
-                .route("/vite-server", get(vite_websocket_proxy))
-                .route("/vite-server/", get(vite_websocket_proxy))
-                .route("/vite-server/{*path}", any(vite_reverse_proxy))
-                .route("/src/{*path}", any(vite_src_proxy));
+                .route("/vite-server", routing::get(vite_websocket_proxy))
+                .route("/vite-server/", routing::get(vite_websocket_proxy))
+                .route("/vite-server/{*path}", routing::any(vite_reverse_proxy))
+                .route("/src/{*path}", routing::any(vite_src_proxy));
 
             if let Err(e) = check_vite_server_health().await {
-                debug!("Vite server not yet available: {}", e);
+                tracing::debug!("Vite server not yet available: {}", e);
             }
         }
 
@@ -327,23 +328,24 @@ impl Server {
             let medium_body_limit = DefaultBodyLimit::max(1024 * 1024);
             router = router
                 .route("/api/{*path}", routing::options(api_cors_preflight))
-                .route("/api/{*path}", any(handle_api_route))
+                .route("/api/{*path}", routing::any(handle_api_route))
                 .layer(medium_body_limit);
         }
 
         if has_app_router {
             if config.is_production() {
-                router = router.route("/assets/{*path}", get(serve_static_asset));
+                router = router.route("/assets/{*path}", routing::get(serve_static_asset));
             }
 
             router = router
-                .route("/", get(handle_app_route))
+                .route("/", routing::get(handle_app_route))
                 .route("/", routing::options(cors_preflight_ok))
-                .route("/{*path}", get(handle_app_route))
+                .route("/{*path}", routing::get(handle_app_route))
                 .route("/{*path}", routing::options(cors_preflight_ok));
         } else if config.is_production() {
-            router =
-                router.route("/", get(root_handler)).route("/{*path}", get(static_or_spa_handler));
+            router = router
+                .route("/", routing::get(root_handler))
+                .route("/{*path}", routing::get(static_or_spa_handler));
         } else {
             let static_service =
                 ServeDir::new(config.public_dir()).append_index_html_on_directories(true);

--- a/crates/rari/src/server/core/utils/path_validation.rs
+++ b/crates/rari/src/server/core/utils/path_validation.rs
@@ -2,9 +2,10 @@ use std::path::{Path, PathBuf};
 
 use cow_utils::CowUtils;
 use rari_error::RariError;
+use tokio::fs;
 
 #[expect(clippy::missing_errors_doc)]
-pub fn validate_safe_path(base: &Path, requested: &str) -> Result<PathBuf, RariError> {
+pub async fn validate_safe_path(base: &Path, requested: &str) -> Result<PathBuf, RariError> {
     if requested.contains("..") {
         return Err(RariError::bad_request("Invalid path: contains '..' pattern"));
     }
@@ -39,13 +40,12 @@ pub fn validate_safe_path(base: &Path, requested: &str) -> Result<PathBuf, RariE
 
     let path = base.join(requested_clean);
 
-    let Ok(canonical_path) = path.canonicalize() else {
-        return Err(RariError::not_found("File not found"));
-    };
+    let canonical_path =
+        fs::canonicalize(&path).await.map_err(|_| RariError::not_found("File not found"))?;
 
-    let Ok(canonical_base) = base.canonicalize() else {
-        return Err(RariError::internal("Invalid base directory configuration"));
-    };
+    let canonical_base = fs::canonicalize(base)
+        .await
+        .map_err(|_| RariError::internal("Invalid base directory configuration"))?;
 
     if !canonical_path.starts_with(&canonical_base) {
         return Err(RariError::bad_request("Path traversal detected"));
@@ -119,67 +119,67 @@ mod tests {
         env::temp_dir().join(format!("rari-test-path-validation-{name}"))
     }
 
-    #[test]
-    fn test_rejects_parent_directory_traversal() {
+    #[tokio::test]
+    async fn test_rejects_parent_directory_traversal() {
         let base = test_temp_dir("parent-traversal");
         fs::create_dir_all(&base).unwrap();
 
-        let result = validate_safe_path(&base, "../etc/passwd");
+        let result = validate_safe_path(&base, "../etc/passwd").await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("'..'"));
     }
 
-    #[test]
-    fn test_rejects_multiple_parent_traversal() {
+    #[tokio::test]
+    async fn test_rejects_multiple_parent_traversal() {
         let base = test_temp_dir("multiple-parent");
         fs::create_dir_all(&base).unwrap();
 
-        let result = validate_safe_path(&base, "../../etc/passwd");
+        let result = validate_safe_path(&base, "../../etc/passwd").await;
         assert!(result.is_err());
     }
 
-    #[test]
-    fn test_rejects_hidden_traversal() {
+    #[tokio::test]
+    async fn test_rejects_hidden_traversal() {
         let base = test_temp_dir("hidden-traversal");
         fs::create_dir_all(&base).unwrap();
 
-        let result = validate_safe_path(&base, "foo/../../../etc/passwd");
+        let result = validate_safe_path(&base, "foo/../../../etc/passwd").await;
         assert!(result.is_err());
     }
 
-    #[test]
-    fn test_rejects_double_slash() {
+    #[tokio::test]
+    async fn test_rejects_double_slash() {
         let base = test_temp_dir("double-slash");
         fs::create_dir_all(&base).unwrap();
 
-        let result = validate_safe_path(&base, "foo//bar");
+        let result = validate_safe_path(&base, "foo//bar").await;
         assert!(result.is_err());
     }
 
-    #[test]
-    fn test_rejects_null_byte() {
+    #[tokio::test]
+    async fn test_rejects_null_byte() {
         let base = test_temp_dir("null-byte");
         fs::create_dir_all(&base).unwrap();
 
-        let result = validate_safe_path(&base, "foo\0bar");
+        let result = validate_safe_path(&base, "foo\0bar").await;
         assert!(result.is_err());
     }
 
-    #[test]
-    fn test_accepts_valid_path() {
+    #[tokio::test]
+    async fn test_accepts_valid_path() {
         let base = test_temp_dir("valid-path");
         fs::create_dir_all(&base).unwrap();
 
         let test_file = base.join("test.txt");
         fs::write(&test_file, "test content").unwrap();
 
-        let result = validate_safe_path(&base, "test.txt");
+        let result = validate_safe_path(&base, "test.txt").await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), test_file.canonicalize().unwrap());
     }
 
-    #[test]
-    fn test_accepts_nested_valid_path() {
+    #[tokio::test]
+    async fn test_accepts_nested_valid_path() {
         let base = test_temp_dir("nested-path");
         fs::create_dir_all(&base).unwrap();
 
@@ -188,14 +188,14 @@ mod tests {
         let test_file = nested_dir.join("test.txt");
         fs::write(&test_file, "test content").unwrap();
 
-        let result = validate_safe_path(&base, "foo/bar/test.txt");
+        let result = validate_safe_path(&base, "foo/bar/test.txt").await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), test_file.canonicalize().unwrap());
     }
 
     #[cfg(unix)]
-    #[test]
-    fn test_rejects_symlink_escape() {
+    #[tokio::test]
+    async fn test_rejects_symlink_escape() {
         let base = test_temp_dir("symlink-escape");
         let _ = fs::remove_dir_all(&base);
         fs::create_dir_all(&base).unwrap();
@@ -210,7 +210,7 @@ mod tests {
         let _ = fs::remove_file(&link_path);
         symlink(&outside_dir, &link_path).expect("Failed to create symlink for security test");
 
-        let result = validate_safe_path(&base, "escape/secret.txt");
+        let result = validate_safe_path(&base, "escape/secret.txt").await;
         assert!(result.is_err(), "Security failure: symlink escape was not rejected");
     }
 
@@ -232,24 +232,24 @@ mod tests {
         assert!(validate_component_path("app/page\0.tsx").is_err());
     }
 
-    #[test]
-    fn test_handles_leading_slash() {
+    #[tokio::test]
+    async fn test_handles_leading_slash() {
         let base = test_temp_dir("leading-slash");
         fs::create_dir_all(&base).unwrap();
 
         let test_file = base.join("test.txt");
         fs::write(&test_file, "test content").unwrap();
 
-        let result = validate_safe_path(&base, "/test.txt");
+        let result = validate_safe_path(&base, "/test.txt").await;
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_rejects_nonexistent_path() {
+    #[tokio::test]
+    async fn test_rejects_nonexistent_path() {
         let base = test_temp_dir("nonexistent");
         fs::create_dir_all(&base).unwrap();
 
-        let result = validate_safe_path(&base, "nonexistent.txt");
+        let result = validate_safe_path(&base, "nonexistent.txt").await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
     }

--- a/crates/rari/src/server/handlers/actions.rs
+++ b/crates/rari/src/server/handlers/actions.rs
@@ -11,7 +11,6 @@ use rari_error::RariError;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tracing::error;
 
 use crate::{
     server::{
@@ -123,7 +122,7 @@ fn normalize_origin(url: &url::Url) -> (String, String, u16) {
 fn check_origin(headers: &HeaderMap, allowed_origins: &[String]) -> Result<(), StatusCode> {
     if allowed_origins.is_empty() {
         let host = headers.get("host").and_then(|v| v.to_str().ok()).ok_or_else(|| {
-            error!("Missing host header in server action request");
+            tracing::error!("Missing host header in server action request");
             StatusCode::BAD_REQUEST
         })?;
 
@@ -140,7 +139,7 @@ fn check_origin(headers: &HeaderMap, allowed_origins: &[String]) -> Result<(), S
 
         let server_origin_str = format!("{scheme}://{host}");
         let server_origin_url = url::Url::parse(&server_origin_str).map_err(|e| {
-            error!("Failed to parse server origin: {}", e);
+            tracing::error!("Failed to parse server origin: {}", e);
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
         let server_origin_tuple = normalize_origin(&server_origin_url);
@@ -153,7 +152,11 @@ fn check_origin(headers: &HeaderMap, allowed_origins: &[String]) -> Result<(), S
                     return Ok(());
                 }
             }
-            error!("Origin mismatch: origin={}, server_origin={}", origin, server_origin_str);
+            tracing::error!(
+                "Origin mismatch: origin={}, server_origin={}",
+                origin,
+                server_origin_str
+            );
             return Err(StatusCode::FORBIDDEN);
         }
 
@@ -164,23 +167,26 @@ fn check_origin(headers: &HeaderMap, allowed_origins: &[String]) -> Result<(), S
                 if referer_tuple == server_origin_tuple {
                     return Ok(());
                 }
-                error!(
+                tracing::error!(
                     "Referer mismatch: referer_origin={}://{}:{}, server_origin={}",
-                    referer_tuple.0, referer_tuple.1, referer_tuple.2, server_origin_str
+                    referer_tuple.0,
+                    referer_tuple.1,
+                    referer_tuple.2,
+                    server_origin_str
                 );
             } else {
-                error!("Invalid referer header: failed to parse");
+                tracing::error!("Invalid referer header: failed to parse");
             }
             return Err(StatusCode::FORBIDDEN);
         }
 
-        error!("Missing origin and referer headers in server action request");
+        tracing::error!("Missing origin and referer headers in server action request");
         return Err(StatusCode::FORBIDDEN);
     }
 
     if let Some(origin) = headers.get("origin").and_then(|v| v.to_str().ok()) {
         if !is_origin_allowed(origin, allowed_origins) {
-            error!("Invalid origin: {}", origin);
+            tracing::error!("Invalid origin: {}", origin);
             return Err(StatusCode::FORBIDDEN);
         }
         return Ok(());
@@ -198,14 +204,14 @@ fn check_origin(headers: &HeaderMap, allowed_origins: &[String]) -> Result<(), S
             if is_origin_allowed(&referer_origin, allowed_origins) {
                 return Ok(());
             }
-            error!("Invalid referer origin: {}", referer_origin);
+            tracing::error!("Invalid referer origin: {}", referer_origin);
         } else {
-            error!("Invalid referer header: failed to parse origin");
+            tracing::error!("Invalid referer header: failed to parse origin");
         }
         return Err(StatusCode::FORBIDDEN);
     }
 
-    error!("Missing Origin and Referer headers with non-empty allowed_origins");
+    tracing::error!("Missing Origin and Referer headers with non-empty allowed_origins");
     Err(StatusCode::FORBIDDEN)
 }
 
@@ -229,7 +235,7 @@ pub async fn handle_server_action(
     let request: ServerActionRequest = match serde_json::from_slice(&body) {
         Ok(req) => req,
         Err(e) => {
-            error!("Failed to parse server action request: {}", e);
+            tracing::error!("Failed to parse server action request: {}", e);
             let mut response = Json(ServerActionResponse {
                 success: false,
                 result: None,
@@ -249,7 +255,11 @@ pub async fn handle_server_action(
     };
 
     if request.args.len() > MAX_BOUND_ARGS {
-        error!("Too many server function arguments: {} > {}", request.args.len(), MAX_BOUND_ARGS);
+        tracing::error!(
+            "Too many server function arguments: {} > {}",
+            request.args.len(),
+            MAX_BOUND_ARGS
+        );
         let mut response = Json(ServerActionResponse {
             success: false,
             result: None,
@@ -273,7 +283,7 @@ pub async fn handle_server_action(
     }
 
     if is_reserved_export_name(&request.export_name) {
-        error!("Attempted to call reserved export name: {}", request.export_name);
+        tracing::error!("Attempted to call reserved export name: {}", request.export_name);
         let mut response = Json(ServerActionResponse {
             success: false,
             result: None,
@@ -304,7 +314,7 @@ pub async fn handle_server_action(
     let sanitized_args = match validate_and_sanitize_args(&request.args, &validation_config) {
         Ok(args) => args,
         Err(e) => {
-            error!("Input validation failed: {}", e);
+            tracing::error!("Input validation failed: {}", e);
             let mut response = Json(ServerActionResponse {
                 success: false,
                 result: None,
@@ -377,7 +387,7 @@ pub async fn handle_server_action(
             Ok(response)
         }
         Err(e) => {
-            error!("Server action execution failed: {}", e);
+            tracing::error!("Server action execution failed: {}", e);
             let mut response = Json(ServerActionResponse {
                 success: false,
                 result: None,
@@ -409,7 +419,7 @@ pub async fn handle_form_action(
     let form_data = match parse_form_data(&body) {
         Ok(data) => data,
         Err(e) => {
-            error!("Failed to parse form data: {}", e);
+            tracing::error!("Failed to parse form data: {}", e);
             return Err(StatusCode::BAD_REQUEST);
         }
     };
@@ -418,7 +428,7 @@ pub async fn handle_form_action(
     let export_name = form_data.get("__export_name").ok_or(StatusCode::BAD_REQUEST)?;
 
     if is_reserved_export_name(export_name) {
-        error!("Attempted to call reserved export name in form action: {}", export_name);
+        tracing::error!("Attempted to call reserved export name in form action: {}", export_name);
         return Err(StatusCode::BAD_REQUEST);
     }
 
@@ -433,7 +443,7 @@ pub async fn handle_form_action(
     let sanitized_args = match validate_and_sanitize_args(&args, &validation_config) {
         Ok(args) => args,
         Err(e) => {
-            error!("Form action input validation failed: {}", e);
+            tracing::error!("Form action input validation failed: {}", e);
             return Err(StatusCode::BAD_REQUEST);
         }
     };
@@ -563,7 +573,7 @@ pub async fn handle_form_action(
             Ok(redirect_response)
         }
         Err(e) => {
-            error!("Form action execution failed: {}", e);
+            tracing::error!("Form action execution failed: {}", e);
             let mut response = StatusCode::INTERNAL_SERVER_ERROR.into_response();
             append_pending_cookies(response.headers_mut(), &request_context.pending_cookies);
             Ok(response)

--- a/crates/rari/src/server/handlers/api.rs
+++ b/crates/rari/src/server/handlers/api.rs
@@ -5,7 +5,6 @@ use axum::{
     extract::State,
     http::{HeaderMap, HeaderValue, Request, Response, StatusCode},
 };
-use tracing::error;
 
 use crate::server::{
     ServerState,
@@ -157,7 +156,7 @@ pub async fn handle_api_route(
             Ok(response)
         }
         Err(e) => {
-            error!(
+            tracing::error!(
                 route_path = %route_match.route.path,
                 method = %method,
                 error = %e,

--- a/crates/rari/src/server/handlers/app.rs
+++ b/crates/rari/src/server/handlers/app.rs
@@ -26,7 +26,6 @@ use tokio::{
     sync::{Mutex, mpsc::Receiver},
     time::{self, Duration},
 };
-use tracing::error;
 
 use crate::{
     RscHtmlRenderer,
@@ -170,7 +169,7 @@ pub(crate) async fn collect_page_metadata(
         env::current_dir().ok().map(|p| p.join("dist/server")).and_then(|p| p.canonicalize().ok());
 
     let Some(base_path) = dist_server_path else {
-        error!("Could not determine dist/server path for metadata collection");
+        tracing::error!("Could not determine dist/server path for metadata collection");
         return None;
     };
 
@@ -216,12 +215,12 @@ pub(crate) async fn collect_page_metadata(
                 Some(metadata)
             }
             Err(e) => {
-                error!("Failed to deserialize metadata: {}", e);
+                tracing::error!("Failed to deserialize metadata: {}", e);
                 None
             }
         },
         Err(e) => {
-            error!("Failed to collect metadata from runtime: {}", e);
+            tracing::error!("Failed to collect metadata from runtime: {}", e);
             None
         }
     }
@@ -336,7 +335,7 @@ pub async fn render_with_fallback(
     {
         Ok(response) => Ok(response),
         Err(e) => {
-            error!("Streaming render failed, falling back to synchronous: {}", e);
+            tracing::error!("Streaming render failed, falling back to synchronous: {}", e);
             render_synchronous(state, route_match, context, accept_encoding).await
         }
     }
@@ -367,9 +366,10 @@ pub async fn render_rsc_navigation_streaming(
     {
         Ok(result) => result,
         Err(e) => {
-            error!(
+            tracing::error!(
                 "Failed to render RSC navigation for streaming '{}': {}",
-                route_match.route.path, e
+                route_match.route.path,
+                e
             );
             return Err(StatusCode::INTERNAL_SERVER_ERROR);
         }
@@ -385,7 +385,7 @@ pub async fn render_rsc_navigation_streaming(
             accept_encoding,
         )),
         RenderResult::FizzHtmlStream { .. } => {
-            error!("FizzHtmlStream not supported in RSC-only mode");
+            tracing::error!("FizzHtmlStream not supported in RSC-only mode");
             let status_code = if is_not_found { StatusCode::NOT_FOUND } else { StatusCode::OK };
             #[expect(
                 clippy::expect_used,
@@ -534,7 +534,7 @@ pub async fn render_synchronous(
                     match inject_assets_into_html(&html_content, &state.config).await {
                         Ok(html) => html,
                         Err(e) => {
-                            error!("Failed to inject assets into HTML: {}", e);
+                            tracing::error!("Failed to inject assets into HTML: {}", e);
                             html_content
                         }
                     };
@@ -595,7 +595,7 @@ pub async fn render_synchronous(
             }
         },
         Err(e) => {
-            error!("Synchronous rendering failed: {}", e);
+            tracing::error!("Synchronous rendering failed: {}", e);
             render_fallback_html(&state, &route_match.route.path, is_not_found).await
         }
     }
@@ -627,13 +627,13 @@ fn render_fizz_html_stream(
                     }
                 }
                 Ok(Some(Err(e))) => {
-                    error!("Error in Fizz stream chunk: {}", e);
+                    tracing::error!("Error in Fizz stream chunk: {}", e);
                     yield Err(Error::other(e));
                     break;
                 }
                 Ok(None) => break,
                 Err(_) => {
-                    error!(
+                    tracing::error!(
                         "Fizz stream stalled: no chunk received within {} ms",
                         stall_timeout.as_millis()
                     );
@@ -769,7 +769,7 @@ async fn render_streaming_response(
                                 break;
                             }
 
-                            error!("Error converting RSC chunk to HTML: {}", e);
+                            tracing::error!("Error converting RSC chunk to HTML: {}", e);
                             yield Err(Error::other(e.to_string()));
                         }
                     }
@@ -822,14 +822,25 @@ pub async fn render_streaming_with_layout(
     {
         Ok(result) => result,
         Err(e) => {
-            error!("Failed to render route for streaming '{}': {}", route_match.route.path, e);
-            error!(
+            tracing::error!(
+                "Failed to render route for streaming '{}': {}",
+                route_match.route.path,
+                e
+            );
+            tracing::error!(
                 "Route rendering failure context - Route: {}, Page component: {}, Layout count: {}",
-                route_match.route.path, route_match.route.file_path, layout_count
+                route_match.route.path,
+                route_match.route.file_path,
+                layout_count
             );
 
             for (idx, layout) in route_match.layouts.iter().enumerate() {
-                error!("  Layout {}: {} (is_root: {})", idx, layout.file_path, layout.is_root);
+                tracing::error!(
+                    "  Layout {}: {} (is_root: {})",
+                    idx,
+                    layout.file_path,
+                    layout.is_root
+                );
             }
 
             return render_synchronous(state, route_match, context, accept_encoding).await;
@@ -856,7 +867,7 @@ pub async fn render_streaming_with_layout(
             let html_with_assets = match inject_assets_into_html(&html, &state.config).await {
                 Ok(html) => html,
                 Err(e) => {
-                    error!("Failed to inject assets into HTML: {}", e);
+                    tracing::error!("Failed to inject assets into HTML: {}", e);
                     html
                 }
             };
@@ -1070,7 +1081,11 @@ pub async fn handle_app_route(
                             .expect("Valid static file response"));
                     }
                     Err(e) => {
-                        error!("Failed to read static file {}: {}", file_path.display(), e);
+                        tracing::error!(
+                            "Failed to read static file {}: {}",
+                            file_path.display(),
+                            e
+                        );
                     }
                 }
             }
@@ -1176,7 +1191,7 @@ pub async fn handle_app_route(
             }
             Ok(false) => {}
             Err(e) => {
-                error!("Failed to check if page is not found: {}", e);
+                tracing::error!("Failed to check if page is not found: {}", e);
             }
         }
     }
@@ -1300,7 +1315,7 @@ pub async fn handle_app_route(
                         .expect("Valid RSC response"))
                 }
                 Err(e) => {
-                    error!("Failed to render RSC: {}", e);
+                    tracing::error!("Failed to render RSC: {}", e);
                     Err(StatusCode::INTERNAL_SERVER_ERROR)
                 }
             }
@@ -1548,7 +1563,7 @@ pub async fn handle_app_route(
             {
                 Ok(result) => result,
                 Err(e) => {
-                    error!("Direct HTML rendering failed: {}, falling back to shell", e);
+                    tracing::error!("Direct HTML rendering failed: {}, falling back to shell", e);
                     return render_fallback_html(&state, path, route_match.not_found.is_some())
                         .await;
                 }
@@ -1560,7 +1575,7 @@ pub async fn handle_app_route(
                         match inject_assets_into_html(&html_content, &state.config).await {
                             Ok(html) => html,
                             Err(e) => {
-                                error!("Failed to inject assets into HTML: {}", e);
+                                tracing::error!("Failed to inject assets into HTML: {}", e);
                                 html_content
                             }
                         };
@@ -1584,7 +1599,7 @@ pub async fn handle_app_route(
                                 html.push_str(&String::from_utf8_lossy(&chunk_data));
                             }
                             Err(e) => {
-                                error!("FizzHtmlStream chunk error in build mode: {e}");
+                                tracing::error!("FizzHtmlStream chunk error in build mode: {e}");
                                 break;
                             }
                         }
@@ -1657,7 +1672,7 @@ pub async fn handle_app_route(
                                 }
                             }
                             Err(e) => {
-                                error!("Error converting RSC chunk to HTML: {}", e);
+                                tracing::error!("Error converting RSC chunk to HTML: {}", e);
                                 return render_fallback_html(
                                     &state,
                                     path,
@@ -1674,7 +1689,7 @@ pub async fn handle_app_route(
                     (final_html, etag)
                 }
                 RenderResult::StaticBinary(_bytes) => {
-                    error!("StaticBinary not supported in build mode");
+                    tracing::error!("StaticBinary not supported in build mode");
                     return render_fallback_html(&state, path, route_match.not_found.is_some())
                         .await;
                 }

--- a/crates/rari/src/server/handlers/app.rs
+++ b/crates/rari/src/server/handlers/app.rs
@@ -165,8 +165,13 @@ pub(crate) async fn collect_page_metadata(
     route_match: &AppRouteMatch,
     context: &LayoutRenderContext,
 ) -> Option<PageMetadata> {
-    let dist_server_path =
-        env::current_dir().ok().map(|p| p.join("dist/server")).and_then(|p| p.canonicalize().ok());
+    let dist_server_path = match env::current_dir() {
+        Ok(cwd) => {
+            let path = cwd.join("dist/server");
+            fs::canonicalize(&path).await.ok()
+        }
+        Err(_) => None,
+    };
 
     let Some(base_path) = dist_server_path else {
         tracing::error!("Could not determine dist/server path for metadata collection");
@@ -1065,7 +1070,7 @@ pub async fn handle_app_route(
             }
 
             if let Ok(file_path) =
-                validate_safe_path(state.config.public_dir(), path_without_leading_slash)
+                validate_safe_path(state.config.public_dir(), path_without_leading_slash).await
                 && let Ok(metadata) = fs::metadata(&file_path).await
                 && metadata.is_file()
             {

--- a/crates/rari/src/server/handlers/app.rs
+++ b/crates/rari/src/server/handlers/app.rs
@@ -173,15 +173,14 @@ pub(crate) async fn collect_page_metadata(
         return None;
     };
 
-    let layout_paths: Vec<String> = route_match
-        .layouts
-        .iter()
-        .filter_map(|layout| {
-            let file_path =
-                component_dist_path(&base_path, &layout.file_path, layout.component_id.as_deref());
-            if file_path.exists() { Some(path_to_file_url(&file_path)) } else { None }
-        })
-        .collect();
+    let mut layout_paths = Vec::with_capacity(route_match.layouts.len());
+    for layout in &route_match.layouts {
+        let file_path =
+            component_dist_path(&base_path, &layout.file_path, layout.component_id.as_deref());
+        if fs::try_exists(&file_path).await.unwrap_or(false) {
+            layout_paths.push(path_to_file_url(&file_path));
+        }
+    }
 
     let page_file_path = component_dist_path(
         &base_path,
@@ -189,7 +188,7 @@ pub(crate) async fn collect_page_metadata(
         route_match.route.component_id.as_deref(),
     );
 
-    if !page_file_path.exists() {
+    if !fs::try_exists(&page_file_path).await.unwrap_or(false) {
         return None;
     }
 
@@ -922,12 +921,16 @@ pub async fn render_fallback_html(
 ) -> Result<Response, StatusCode> {
     let index_path = if state.config.is_development() {
         let root_index = PathBuf::from("index.html");
-        if root_index.exists() { root_index } else { state.config.public_dir().join("index.html") }
+        if fs::try_exists(&root_index).await.unwrap_or(false) {
+            root_index
+        } else {
+            state.config.public_dir().join("index.html")
+        }
     } else {
         state.config.public_dir().join("index.html")
     };
 
-    if index_path.exists() {
+    if fs::try_exists(&index_path).await.unwrap_or(false) {
         if state.config.is_production()
             && let Some(cached_html) = state.html_cache.get(path)
         {

--- a/crates/rari/src/server/handlers/app.rs
+++ b/crates/rari/src/server/handlers/app.rs
@@ -96,10 +96,10 @@ async fn decompress_bytes(
     }
 }
 
-fn sort_rsc_rows(wire_format: &str) -> String {
+fn sort_rsc_rows(flight_protocol: &str) -> String {
     let mut rows_with_ids: Vec<(u32, String)> = Vec::new();
 
-    for row in wire_format.lines() {
+    for row in flight_protocol.lines() {
         if let Some(colon_pos) = row.find(':') {
             if let Ok(row_id) = u32::from_str_radix(&row[..colon_pos], 16) {
                 rows_with_ids.push((row_id, row.to_string()));
@@ -397,15 +397,15 @@ pub async fn render_rsc_navigation_streaming(
                 .body(Body::from("0:\"Error: FizzHtmlStream not supported in RSC mode\"\n"))
                 .expect("Valid error response"))
         }
-        RenderResult::Static(rsc_wire_format) => {
+        RenderResult::Static(rsc_flight_protocol) => {
             let status_code = if is_not_found { StatusCode::NOT_FOUND } else { StatusCode::OK };
 
-            let sorted_wire_format = sort_rsc_rows(&rsc_wire_format);
+            let sorted_flight_protocol = sort_rsc_rows(&rsc_flight_protocol);
 
-            let final_payload = if sorted_wire_format.ends_with('\n') {
-                sorted_wire_format
+            let final_payload = if sorted_flight_protocol.ends_with('\n') {
+                sorted_flight_protocol
             } else {
-                format!("{sorted_wire_format}\n")
+                format!("{sorted_flight_protocol}\n")
             };
 
             let mut response_builder = Response::builder()
@@ -463,7 +463,7 @@ fn render_rsc_streaming_response(
     let should_continue = Arc::new(AtomicBool::new(true));
     let should_continue_clone = should_continue;
 
-    let rsc_wire_stream = async_stream::stream! {
+    let rsc_flight_stream = async_stream::stream! {
         while should_continue_clone.load(Relaxed) {
             match rsc_stream.next_chunk().await {
                 Some(chunk) => {
@@ -480,7 +480,7 @@ fn render_rsc_streaming_response(
     };
 
     let encoding = CompressionEncoding::from_accept_encoding(accept_encoding);
-    let compressed_stream = compress_stream(rsc_wire_stream, encoding);
+    let compressed_stream = compress_stream(rsc_flight_stream, encoding);
 
     let status_code = if is_not_found { StatusCode::NOT_FOUND } else { StatusCode::OK };
     let cache_control = state.config.get_cache_control_for_route(&context.pathname);
@@ -1243,7 +1243,7 @@ pub async fn handle_app_route(
                 .render_route_by_mode(&route_match, &context, Some(Arc::clone(&request_context)))
                 .await
             {
-                Ok(rsc_wire_format) => {
+                Ok(rsc_flight_protocol) => {
                     let status_code = if route_match.not_found.is_some() {
                         StatusCode::NOT_FOUND
                     } else {
@@ -1275,7 +1275,7 @@ pub async fn handle_app_route(
 
                     if cache_policy.enabled && state.response_cache.config.enabled {
                         let cached_response = response::CachedResponse {
-                            body: bytes::Bytes::from(rsc_wire_format.clone()),
+                            body: bytes::Bytes::from(rsc_flight_protocol.clone()),
                             headers: cache_headers,
                             metadata: response::CacheMetadata {
                                 cached_at: Instant::now(),
@@ -1296,7 +1296,7 @@ pub async fn handle_app_route(
                         reason = "Response::builder() with valid components never fails"
                     )]
                     Ok(response_builder
-                        .body(Body::from(rsc_wire_format))
+                        .body(Body::from(rsc_flight_protocol))
                         .expect("Valid RSC response"))
                 }
                 Err(e) => {

--- a/crates/rari/src/server/handlers/hmr.rs
+++ b/crates/rari/src/server/handlers/hmr.rs
@@ -471,7 +471,7 @@ async fn handle_reload_component(
 ) -> Result<Json<Value>, StatusCode> {
     let project_root = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
-    let bundle_full_path = match validate_safe_path(&project_root, &bundle_path) {
+    let bundle_full_path = match validate_safe_path(&project_root, &bundle_path).await {
         Ok(path) => path,
         Err(e) => {
             tracing::error!(

--- a/crates/rari/src/server/handlers/hmr.rs
+++ b/crates/rari/src/server/handlers/hmr.rs
@@ -11,7 +11,6 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::{fs, time};
-use tracing::error;
 
 use crate::server::{
     ServerState,
@@ -103,7 +102,7 @@ async fn handle_register(state: ServerState, file_path: String) -> Result<Json<V
     let file_path = normalize_component_path(&file_path);
 
     if let Err(e) = validate_component_path(&file_path) {
-        error!(
+        tracing::error!(
             file_path = %file_path,
             error = %e,
             "Component path validation failed"
@@ -114,7 +113,7 @@ async fn handle_register(state: ServerState, file_path: String) -> Result<Json<V
     let component_id = match extract_component_id(&file_path) {
         Ok(id) => id,
         Err(e) => {
-            error!("Failed to extract component ID from {}: {}", file_path, e);
+            tracing::error!("Failed to extract component ID from {}: {}", file_path, e);
             return Err(StatusCode::BAD_REQUEST);
         }
     };
@@ -137,7 +136,7 @@ async fn handle_register(state: ServerState, file_path: String) -> Result<Json<V
             .execute_script("clear_resolved_cache".to_string(), clear_cache_script.to_string())
             .await
         {
-            error!("Failed to clear resolved cache: {}", e);
+            tracing::error!("Failed to clear resolved cache: {}", e);
         }
     }
 
@@ -148,7 +147,7 @@ async fn handle_register(state: ServerState, file_path: String) -> Result<Json<V
     match &reload_result {
         Ok(()) => {}
         Err(e) => {
-            error!(
+            tracing::error!(
                 component_id = component_id,
                 file_path = file_path,
                 error = %e,
@@ -170,7 +169,7 @@ async fn handle_register(state: ServerState, file_path: String) -> Result<Json<V
     if reload_result.is_err()
         && let Err(e) = immediate_component_reregistration(&state, &file_path).await
     {
-        error!(
+        tracing::error!(
             component_id = component_id,
             file_path = file_path,
             error = %e,
@@ -282,7 +281,7 @@ async fn handle_invalidate(
         renderer.clear_component_cache(&component_id);
 
         if let Err(e) = renderer.runtime.clear_module_loader_caches(&component_id).await {
-            error!("Failed to clear module loader caches for {}: {}", component_id, e);
+            tracing::error!("Failed to clear module loader caches for {}: {}", component_id, e);
         }
 
         let clear_script = format!(
@@ -351,7 +350,7 @@ async fn handle_invalidate(
             "cleared": clear_result
         }))),
         Err(e) => {
-            error!("Failed to invalidate component cache for {}: {}", component_id, e);
+            tracing::error!("Failed to invalidate component cache for {}: {}", component_id, e);
             Ok(Json(serde_json::json!({
                 "success": false,
                 "componentId": component_id,
@@ -367,7 +366,7 @@ async fn handle_reload(
     file_path: String,
 ) -> Result<Json<Value>, StatusCode> {
     let Some(config) = Config::get() else {
-        error!("Failed to get global configuration for HMR reload");
+        tracing::error!("Failed to get global configuration for HMR reload");
         return Ok(Json(serde_json::json!({
             "success": false,
             "componentId": component_id,
@@ -376,7 +375,7 @@ async fn handle_reload(
     };
 
     if file_path.contains("://") {
-        error!("Invalid file path: contains URL scheme");
+        tracing::error!("Invalid file path: contains URL scheme");
         return Ok(Json(serde_json::json!({
             "success": false,
             "componentId": component_id,
@@ -397,7 +396,7 @@ async fn handle_reload(
     let transpiled_code = match client.get(&vite_url).send().await {
         Ok(response) => {
             if !response.status().is_success() {
-                error!("Vite returned error status: {}", response.status());
+                tracing::error!("Vite returned error status: {}", response.status());
                 return Ok(Json(serde_json::json!({
                     "success": false,
                     "componentId": component_id,
@@ -408,7 +407,7 @@ async fn handle_reload(
             match response.text().await {
                 Ok(code) => code,
                 Err(e) => {
-                    error!("Failed to read response from Vite: {}", e);
+                    tracing::error!("Failed to read response from Vite: {}", e);
                     return Ok(Json(serde_json::json!({
                         "success": false,
                         "componentId": component_id,
@@ -418,7 +417,7 @@ async fn handle_reload(
             }
         }
         Err(e) => {
-            error!("Failed to fetch from Vite dev server: {}", e);
+            tracing::error!("Failed to fetch from Vite dev server: {}", e);
             return Ok(Json(serde_json::json!({
                 "success": false,
                 "componentId": component_id,
@@ -437,7 +436,7 @@ async fn handle_reload(
             "codeSize": transpiled_code.len()
         }))),
         Err(e) => {
-            error!("Failed to reload component {}: {}", component_id, e);
+            tracing::error!("Failed to reload component {}: {}", component_id, e);
             Ok(Json(serde_json::json!({
                 "success": false,
                 "componentId": component_id,
@@ -475,7 +474,7 @@ async fn handle_reload_component(
     let bundle_full_path = match validate_safe_path(&project_root, &bundle_path) {
         Ok(path) => path,
         Err(e) => {
-            error!(
+            tracing::error!(
                 bundle_path = %bundle_path,
                 error = %e,
                 "Bundle path validation failed"
@@ -506,7 +505,7 @@ async fn handle_reload_component(
     }
 
     if let Some(e) = last_error {
-        error!("Failed to read bundle file {}: {}", bundle_full_path.display(), e);
+        tracing::error!("Failed to read bundle file {}: {}", bundle_full_path.display(), e);
         return Ok(Json(serde_json::json!({
             "success": false,
             "message": format!("Failed to read bundle: {}", e)
@@ -517,7 +516,7 @@ async fn handle_reload_component(
         let renderer = state.renderer.lock().await;
         renderer.runtime.invalidate_component(&component_id).await
     } {
-        error!("Failed to invalidate component {}: {}", component_id, e);
+        tracing::error!("Failed to invalidate component {}: {}", component_id, e);
     }
 
     let load_result = {
@@ -546,7 +545,7 @@ async fn handle_reload_component(
                         registry.mark_component_initially_loaded(&component_id);
                     }
                     Err(e) => {
-                        error!("Failed to register component {}: {}", component_id, e);
+                        tracing::error!("Failed to register component {}: {}", component_id, e);
                         registry.remove_component(&component_id);
                         return Ok(Json(serde_json::json!({
                             "success": false,
@@ -564,7 +563,7 @@ async fn handle_reload_component(
             })))
         }
         Err(e) => {
-            error!("Failed to reload component {}: {}", component_id, e);
+            tracing::error!("Failed to reload component {}: {}", component_id, e);
             Ok(Json(serde_json::json!({
                 "success": false,
                 "message": format!("Failed to reload component: {}", e)

--- a/crates/rari/src/server/handlers/rsc.rs
+++ b/crates/rari/src/server/handlers/rsc.rs
@@ -134,7 +134,7 @@ pub async fn reload_component_from_dist(
         }
     };
 
-    if !dist_path.exists() {
+    if !fs::try_exists(&dist_path).await.unwrap_or(false) {
         return Err(format!(
             "Dist file not found: {}. Vite may not have finished building yet. Last known good version will be preserved.",
             dist_path.display()

--- a/crates/rari/src/server/handlers/rsc.rs
+++ b/crates/rari/src/server/handlers/rsc.rs
@@ -9,7 +9,6 @@ use cow_utils::CowUtils;
 use rari_rsc::utils;
 use serde_json::Value;
 use tokio::{fs, time};
-use tracing::error;
 
 use crate::server::{
     RegisterClientRequest, RegisterRequest, ServerState,
@@ -62,7 +61,11 @@ pub async fn register_component(
                     )
                     .await
                 {
-                    error!("Failed to mark {} as client component: {}", request.component_id, e);
+                    tracing::error!(
+                        "Failed to mark {} as client component: {}",
+                        request.component_id,
+                        e
+                    );
                 }
             }
 
@@ -72,7 +75,7 @@ pub async fn register_component(
             })))
         }
         Err(e) => {
-            error!("Failed to register component {}: {}", request.component_id, e);
+            tracing::error!("Failed to register component {}: {}", request.component_id, e);
             Err(StatusCode::INTERNAL_SERVER_ERROR)
         }
     }
@@ -106,7 +109,7 @@ pub async fn reload_component_from_dist(
     let normalized_path = normalize_component_path(file_path);
 
     if let Err(e) = validate_component_path(&normalized_path) {
-        error!(
+        tracing::error!(
             component_id = component_id,
             file_path = file_path,
             normalized_path = %normalized_path,
@@ -121,7 +124,7 @@ pub async fn reload_component_from_dist(
     let dist_path = match get_dist_path_for_component(file_path) {
         Ok(path) => path,
         Err(e) => {
-            error!(
+            tracing::error!(
                 component_id = component_id,
                 file_path = file_path,
                 error = %e,
@@ -142,7 +145,7 @@ pub async fn reload_component_from_dist(
     let mut dist_code = match fs::read_to_string(&dist_path).await {
         Ok(code) => code,
         Err(e) => {
-            error!(
+            tracing::error!(
                 component_id = component_id,
                 dist_path = %dist_path.display(),
                 error = %e,
@@ -178,7 +181,7 @@ pub async fn reload_component_from_dist(
         let new_dist_code = match fs::read_to_string(&dist_path).await {
             Ok(code) => code,
             Err(e) => {
-                error!(
+                tracing::error!(
                     component_id = component_id,
                     dist_path = %dist_path.display(),
                     error = %e,
@@ -219,7 +222,7 @@ pub async fn reload_component_from_dist(
         renderer.clear_component_cache(component_id);
 
         if let Err(e) = renderer.runtime.clear_module_loader_caches(component_id).await {
-            error!("Failed to clear module loader caches for {}: {}", component_id, e);
+            tracing::error!("Failed to clear module loader caches for {}: {}", component_id, e);
         }
 
         let timestamp =
@@ -229,7 +232,7 @@ pub async fn reload_component_from_dist(
 
         renderer.runtime.add_module_to_loader(&hmr_specifier, dist_code.clone()).await.map_err(
             |e| {
-                error!(
+                tracing::error!(
                     component_id = component_id,
                     error = %e,
                     "Failed to add HMR module to loader"
@@ -239,7 +242,7 @@ pub async fn reload_component_from_dist(
         )?;
 
         let module_id = renderer.runtime.load_es_module(component_id).await.map_err(|e| {
-            error!(
+            tracing::error!(
                 component_id = component_id,
                 error = %e,
                 "Failed to load ES module during HMR"
@@ -248,7 +251,7 @@ pub async fn reload_component_from_dist(
         })?;
 
         renderer.runtime.evaluate_module(module_id).await.map_err(|e| {
-            error!(
+            tracing::error!(
                 component_id = component_id,
                 module_id = module_id,
                 error = %e,
@@ -279,7 +282,7 @@ pub async fn reload_component_from_dist(
             )
             .await
             .map_err(|e| {
-                error!(
+                tracing::error!(
                     component_id = component_id,
                     error = %e,
                     "Failed to clear old component"
@@ -337,7 +340,7 @@ pub async fn reload_component_from_dist(
             )
             .await
             .map_err(|e| {
-                error!(
+                tracing::error!(
                     component_id = component_id,
                     error = %e,
                     "Failed to register ESM module exports to globalThis"
@@ -376,7 +379,7 @@ pub async fn reload_component_from_dist(
             .await;
 
         if let Err(e) = execution_result {
-            error!(
+            tracing::error!(
                 component_id = component_id,
                 dist_path = %dist_path.display(),
                 error = %e,
@@ -422,7 +425,7 @@ pub async fn reload_component_from_dist(
     {
         Ok(json) => json,
         Err(e) => {
-            error!(
+            tracing::error!(
                 component_id = component_id,
                 error = %e,
                 "Failed to execute verification script. Last known good version will be preserved."
@@ -447,7 +450,7 @@ pub async fn reload_component_from_dist(
             let expected_key =
                 result_json.get("expectedKey").and_then(|v| v.as_str()).unwrap_or(component_id);
 
-            error!(
+            tracing::error!(
                 component_id = component_id,
                 expected_key = expected_key,
                 actual_keys = actual_keys,
@@ -462,7 +465,7 @@ pub async fn reload_component_from_dist(
             .into())
         }
     } else {
-        error!(
+        tracing::error!(
             component_id = component_id,
             verification_result = ?result_json,
             "Invalid verification result format. Last known good version will be preserved."
@@ -478,7 +481,7 @@ pub async fn immediate_component_reregistration(
     let normalized_path = normalize_component_path(file_path);
 
     if let Err(e) = validate_component_path(&normalized_path) {
-        error!(
+        tracing::error!(
             file_path = file_path,
             normalized_path = %normalized_path,
             error = %e,
@@ -498,14 +501,14 @@ pub async fn immediate_component_reregistration(
         renderer.clear_script_cache();
 
         if let Err(e) = renderer.clear_component_module_cache(component_name).await {
-            error!("Failed to clear component module cache for {}: {}", component_name, e);
+            tracing::error!("Failed to clear component module cache for {}: {}", component_name, e);
         }
     }
 
     let content = match fs::read_to_string(file_path).await {
         Ok(c) => c,
         Err(e) => {
-            error!(
+            tracing::error!(
                 component_name = component_name,
                 file_path = file_path,
                 error = %e,
@@ -520,7 +523,7 @@ pub async fn immediate_component_reregistration(
         if let Err(e) =
             state.renderer.lock().await.register_component(component_name, &content).await
         {
-            error!(
+            tracing::error!(
                 component_name = component_name,
                 error = %e,
                 "Failed to register component directly, preserving last known good version"
@@ -531,7 +534,11 @@ pub async fn immediate_component_reregistration(
 
             let mut renderer = state.renderer.lock().await;
             if let Err(e) = renderer.clear_component_module_cache(component_name).await {
-                error!("Failed to clear component module cache for {}: {}", component_name, e);
+                tracing::error!(
+                    "Failed to clear component module cache for {}: {}",
+                    component_name,
+                    e
+                );
             }
             drop(renderer);
 
@@ -540,7 +547,7 @@ pub async fn immediate_component_reregistration(
             if let Err(e) =
                 state.renderer.lock().await.register_component(component_name, &content).await
             {
-                error!(
+                tracing::error!(
                     component_name = component_name,
                     error = %e,
                     "Failed to re-register component after cache clear, preserving last known good version"

--- a/crates/rari/src/server/handlers/static.rs
+++ b/crates/rari/src/server/handlers/static.rs
@@ -6,7 +6,6 @@ use axum::{
     http::StatusCode,
     response::Response,
 };
-use tracing::error;
 
 use crate::server::{
     ServerState,
@@ -16,7 +15,7 @@ use crate::server::{
 
 pub async fn root_handler(State(_state): State<ServerState>) -> Result<Response, StatusCode> {
     let Some(config) = Config::get() else {
-        error!("Failed to get global configuration for root_handler");
+        tracing::error!("Failed to get global configuration for root_handler");
         return Err(StatusCode::INTERNAL_SERVER_ERROR);
     };
 
@@ -38,7 +37,7 @@ pub async fn root_handler(State(_state): State<ServerState>) -> Result<Response,
                     .expect("Valid HTML response"));
             }
             Err(e) => {
-                error!("Failed to read index.html: {}", e);
+                tracing::error!("Failed to read index.html: {}", e);
                 return Err(StatusCode::INTERNAL_SERVER_ERROR);
             }
         }
@@ -59,7 +58,7 @@ pub async fn static_or_spa_handler(
     }
 
     let Some(config) = Config::get() else {
-        error!("Failed to get global configuration for static_or_spa_handler");
+        tracing::error!("Failed to get global configuration for static_or_spa_handler");
         return Err(StatusCode::INTERNAL_SERVER_ERROR);
     };
 
@@ -83,7 +82,7 @@ pub async fn static_or_spa_handler(
                     .expect("Valid static file response"));
             }
             Err(e) => {
-                error!("Failed to read static file {}: {}", file_path.display(), e);
+                tracing::error!("Failed to read static file {}: {}", file_path.display(), e);
                 return Err(StatusCode::INTERNAL_SERVER_ERROR);
             }
         }
@@ -123,7 +122,7 @@ pub async fn static_or_spa_handler(
                     .expect("Valid HTML response"));
             }
             Err(e) => {
-                error!("Failed to read index.html: {}", e);
+                tracing::error!("Failed to read index.html: {}", e);
                 return Err(StatusCode::INTERNAL_SERVER_ERROR);
             }
         }
@@ -168,7 +167,7 @@ pub async fn serve_static_asset(
                 .expect("Valid static asset response"))
         }
         Err(e) => {
-            error!("Failed to read static asset {}: {}", file_path.display(), e);
+            tracing::error!("Failed to read static asset {}: {}", file_path.display(), e);
             Err(StatusCode::INTERNAL_SERVER_ERROR)
         }
     }

--- a/crates/rari/src/server/handlers/static.rs
+++ b/crates/rari/src/server/handlers/static.rs
@@ -1,11 +1,10 @@
-use std::fs;
-
 use axum::{
     body::Body,
     extract::{Path, State},
     http::StatusCode,
     response::Response,
 };
+use tokio::fs;
 
 use crate::server::{
     ServerState,
@@ -20,8 +19,8 @@ pub async fn root_handler(State(_state): State<ServerState>) -> Result<Response,
     };
 
     let index_path = config.public_dir().join("index.html");
-    if index_path.exists() {
-        match fs::read_to_string(&index_path) {
+    if fs::try_exists(&index_path).await.unwrap_or(false) {
+        match fs::read_to_string(&index_path).await {
             Ok(content) => {
                 let cache_control = config.get_cache_control_for_route("/");
                 let response_builder = Response::builder()
@@ -66,8 +65,10 @@ pub async fn static_or_spa_handler(
         return Err(StatusCode::NOT_FOUND);
     };
 
-    if file_path.is_file() {
-        match fs::read(&file_path) {
+    if let Ok(metadata) = fs::metadata(&file_path).await
+        && metadata.is_file()
+    {
+        match fs::read(&file_path).await {
             Ok(content) => {
                 let content_type = get_content_type(&path);
                 let cache_control = &config.caching.static_files;
@@ -105,8 +106,8 @@ pub async fn static_or_spa_handler(
     let route_path = if path.is_empty() { "/" } else { &format!("/{path}") };
 
     let index_path = config.public_dir().join("index.html");
-    if index_path.exists() {
-        match fs::read_to_string(&index_path) {
+    if fs::try_exists(&index_path).await.unwrap_or(false) {
+        match fs::read_to_string(&index_path).await {
             Ok(content) => {
                 let cache_control = config.get_cache_control_for_route(route_path);
                 let response_builder = Response::builder()
@@ -147,11 +148,15 @@ pub async fn serve_static_asset(
         return Err(StatusCode::NOT_FOUND);
     };
 
-    if !file_path.is_file() {
+    let Ok(metadata) = fs::metadata(&file_path).await else {
+        return Err(StatusCode::NOT_FOUND);
+    };
+
+    if !metadata.is_file() {
         return Err(StatusCode::NOT_FOUND);
     }
 
-    match fs::read(&file_path) {
+    match fs::read(&file_path).await {
         Ok(content) => {
             let content_type = get_content_type(&asset_path);
             let cache_control = &state.config.caching.static_files;

--- a/crates/rari/src/server/handlers/static.rs
+++ b/crates/rari/src/server/handlers/static.rs
@@ -61,7 +61,7 @@ pub async fn static_or_spa_handler(
         return Err(StatusCode::INTERNAL_SERVER_ERROR);
     };
 
-    let Ok(file_path) = validate_safe_path(config.public_dir(), &path) else {
+    let Ok(file_path) = validate_safe_path(config.public_dir(), &path).await else {
         return Err(StatusCode::NOT_FOUND);
     };
 
@@ -144,7 +144,7 @@ pub async fn serve_static_asset(
 
     let assets_dir = state.config.public_dir().join("assets");
 
-    let Ok(file_path) = validate_safe_path(&assets_dir, &asset_path) else {
+    let Ok(file_path) = validate_safe_path(&assets_dir, &asset_path).await else {
         return Err(StatusCode::NOT_FOUND);
     };
 

--- a/crates/rari/src/server/image/optimizer.rs
+++ b/crates/rari/src/server/image/optimizer.rs
@@ -947,10 +947,10 @@ impl ImageOptimizer {
             let public_path = self.project_path.join("public");
             let file_path = public_path.join(url.trim_start_matches('/'));
 
-            let canonical_public = public_path.canonicalize().map_err(|e| {
+            let canonical_public = fs::canonicalize(&public_path).await.map_err(|e| {
                 ImageError::FetchError(format!("Failed to canonicalize public directory: {e}"))
             })?;
-            let canonical_file = file_path.canonicalize().map_err(|e| {
+            let canonical_file = fs::canonicalize(&file_path).await.map_err(|e| {
                 ImageError::FetchError(format!(
                     "Failed to canonicalize file path {}: {}",
                     file_path.display(),

--- a/crates/rari/src/server/loaders/cache.rs
+++ b/crates/rari/src/server/loaders/cache.rs
@@ -1,9 +1,10 @@
-use std::{fs, path::Path};
+use std::path::Path;
 
 use cow_utils::CowUtils;
 use rari_error::RariError;
 use regex::Regex;
 use rustc_hash::FxHashMap;
+use tokio::fs;
 
 use crate::server::ServerState;
 
@@ -14,7 +15,7 @@ impl CacheLoader {
     #[expect(clippy::missing_errors_doc)]
     pub async fn load_page_cache_configs(state: &ServerState) -> Result<(), RariError> {
         let pages_dir = Path::new("src/pages");
-        if !pages_dir.exists() {
+        if !fs::try_exists(pages_dir).await.unwrap_or(false) {
             return Ok(());
         }
 
@@ -32,18 +33,30 @@ impl CacheLoader {
         let mut dirs_to_scan = vec![dir.to_path_buf()];
 
         while let Some(current_dir) = dirs_to_scan.pop() {
-            let entries = fs::read_dir(&current_dir)
+            let mut entries = fs::read_dir(&current_dir)
+                .await
                 .map_err(|e| RariError::io(format!("Failed to read pages directory: {e}")))?;
 
-            for entry in entries {
-                let entry = entry
-                    .map_err(|e| RariError::io(format!("Failed to read directory entry: {e}")))?;
+            while let Some(entry) = entries
+                .next_entry()
+                .await
+                .map_err(|e| RariError::io(format!("Failed to read directory entry: {e}")))?
+            {
                 let path = entry.path();
+                let file_type = entry
+                    .file_type()
+                    .await
+                    .map_err(|e| RariError::io(format!("Failed to read file type: {e}")))?;
 
-                if path.is_dir() {
+                if file_type.is_dir() {
                     dirs_to_scan.push(path);
-                } else if path.is_file()
-                    && let Some(extension) = path.extension()
+                } else if {
+                    #[expect(
+                        clippy::filetype_is_file,
+                        reason = "Page cache config is only read from regular source files"
+                    )]
+                    file_type.is_file()
+                } && let Some(extension) = path.extension()
                     && (extension == "tsx"
                         || extension == "jsx"
                         || extension == "ts"
@@ -65,6 +78,7 @@ impl CacheLoader {
         state: &ServerState,
     ) -> Result<(), RariError> {
         let content = fs::read_to_string(page_path)
+            .await
             .map_err(|e| RariError::io(format!("Failed to read page file: {e}")))?;
 
         if let Some(cache_config) = Self::extract_cache_config_from_content(&content) {

--- a/crates/rari/src/server/loaders/cache.rs
+++ b/crates/rari/src/server/loaders/cache.rs
@@ -4,7 +4,6 @@ use cow_utils::CowUtils;
 use rari_error::RariError;
 use regex::Regex;
 use rustc_hash::FxHashMap;
-use tracing::error;
 
 use crate::server::ServerState;
 
@@ -51,7 +50,7 @@ impl CacheLoader {
                         || extension == "js")
                 {
                     if let Err(e) = Self::load_page_cache_config(&path, state).await {
-                        error!("Failed to load page cache config for {:?}: {}", path, e);
+                        tracing::error!("Failed to load page cache config for {:?}: {}", path, e);
                     }
                     *loaded_count += 1;
                 }

--- a/crates/rari/src/server/loaders/component.rs
+++ b/crates/rari/src/server/loaders/component.rs
@@ -1,11 +1,12 @@
 #![expect(clippy::missing_errors_doc, clippy::too_many_lines)]
-use std::{fs, future::Future, path::Path, pin::Pin, sync::Arc};
+use std::{future::Future, path::Path, pin::Pin, sync::Arc};
 
 use cow_utils::CowUtils;
 use rari_error::RariError;
 use rari_rsc::utils::extract_dependencies;
 use rari_utils::path_to_file_url;
 use serde_json::Value;
+use tokio::fs;
 
 use crate::{
     rendering::base::RscRenderer,
@@ -23,11 +24,11 @@ pub struct ComponentLoader;
 impl ComponentLoader {
     pub async fn load_production_components(renderer: &mut RscRenderer) -> Result<(), RariError> {
         let manifest_path = Path::new(DIST_DIR).join("server").join("manifest.json");
-        if !manifest_path.exists() {
+        if !fs::try_exists(&manifest_path).await.unwrap_or(false) {
             return Ok(());
         }
 
-        let manifest = Self::read_manifest(&manifest_path)?;
+        let manifest = Self::read_manifest(&manifest_path).await?;
         let components = Self::parse_manifest_components(&manifest)?;
 
         let mut sorted_components: Vec<_> = components.iter().collect();
@@ -46,12 +47,13 @@ impl ComponentLoader {
                 })?;
 
             let component_file = Path::new(DIST_DIR).join(bundle_path);
-            if !component_file.exists() {
+            if !fs::try_exists(&component_file).await.unwrap_or(false) {
                 tracing::error!("Component file not found: {}", component_file.display());
                 continue;
             }
 
             let component_code = fs::read_to_string(&component_file)
+                .await
                 .map_err(|_e| RariError::io("Failed to read component file".to_string()))?;
 
             let is_server_action = has_use_server_directive(&component_code);
@@ -233,7 +235,7 @@ impl ComponentLoader {
         renderer: &mut RscRenderer,
     ) -> Result<(), RariError> {
         let src_dir = Path::new("src");
-        if !src_dir.exists() {
+        if !fs::try_exists(src_dir).await.unwrap_or(false) {
             return Ok(());
         }
 
@@ -247,13 +249,15 @@ impl ComponentLoader {
         renderer: &'a mut RscRenderer,
     ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + 'a>> {
         Box::pin(async move {
-            let entries = fs::read_dir(dir).map_err(|e| {
+            let mut entries = fs::read_dir(dir).await.map_err(|e| {
                 RariError::io(format!("Failed to read directory {}: {}", dir.display(), e))
             })?;
 
-            for entry in entries {
-                let entry = entry
-                    .map_err(|e| RariError::io(format!("Failed to read directory entry: {e}")))?;
+            while let Some(entry) = entries
+                .next_entry()
+                .await
+                .map_err(|e| RariError::io(format!("Failed to read directory entry: {e}")))?
+            {
                 let path = entry.path();
 
                 if path.is_dir() {
@@ -264,7 +268,7 @@ impl ComponentLoader {
                     .map(|s| s == "ts" || s == "tsx" || s == "js" || s == "jsx")
                     .unwrap_or(false)
                 {
-                    let Ok(code) = fs::read_to_string(&path) else {
+                    let Ok(code) = fs::read_to_string(&path).await else {
                         continue;
                     };
 
@@ -284,8 +288,8 @@ impl ComponentLoader {
                         let dist_path =
                             Path::new(DIST_DIR).join("server").join(format!("{action_id}.js"));
 
-                        if dist_path.exists() {
-                            match fs::read_to_string(&dist_path) {
+                        if fs::try_exists(&dist_path).await.unwrap_or(false) {
+                            match fs::read_to_string(&dist_path).await {
                                 Ok(dist_code) => {
                                     let canonical_path =
                                         dist_path.canonicalize().unwrap_or(dist_path.clone());
@@ -454,7 +458,7 @@ impl ComponentLoader {
 
     pub async fn load_app_router_components(renderer: &mut RscRenderer) -> Result<(), RariError> {
         let server_dir = Path::new(DIST_DIR).join("server");
-        if !server_dir.exists() {
+        if !fs::try_exists(&server_dir).await.unwrap_or(false) {
             return Ok(());
         }
 
@@ -469,13 +473,15 @@ impl ComponentLoader {
         renderer: &'a mut RscRenderer,
     ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + 'a>> {
         Box::pin(async move {
-            let entries = fs::read_dir(dir).map_err(|e| {
+            let mut entries = fs::read_dir(dir).await.map_err(|e| {
                 RariError::io(format!("Failed to read directory {}: {}", dir.display(), e))
             })?;
 
-            for entry in entries {
-                let entry = entry
-                    .map_err(|e| RariError::io(format!("Failed to read directory entry: {e}")))?;
+            while let Some(entry) = entries
+                .next_entry()
+                .await
+                .map_err(|e| RariError::io(format!("Failed to read directory entry: {e}")))?
+            {
                 let path = entry.path();
 
                 if path.is_dir() {
@@ -486,7 +492,7 @@ impl ComponentLoader {
                         continue;
                     }
 
-                    let component_code = fs::read_to_string(&path).map_err(|e| {
+                    let component_code = fs::read_to_string(&path).await.map_err(|e| {
                         RariError::io(format!("Failed to read component file: {e}"))
                     })?;
 
@@ -904,8 +910,9 @@ impl ComponentLoader {
         })
     }
 
-    fn read_manifest(manifest_path: &Path) -> Result<serde_json::Value, RariError> {
+    async fn read_manifest(manifest_path: &Path) -> Result<serde_json::Value, RariError> {
         let manifest_content = fs::read_to_string(manifest_path)
+            .await
             .map_err(|e| RariError::io(format!("Failed to read server manifest: {e}")))?;
 
         serde_json::from_str(&manifest_content)
@@ -932,7 +939,7 @@ impl ComponentLoader {
 
         let component_file = Path::new(DIST_DIR).join(bundle_path);
 
-        if !component_file.exists() {
+        if !fs::try_exists(&component_file).await.unwrap_or(false) {
             return Err(RariError::not_found(format!(
                 "Component file not found: {}",
                 component_file.display()
@@ -940,6 +947,7 @@ impl ComponentLoader {
         }
 
         let component_code = fs::read_to_string(&component_file)
+            .await
             .map_err(|e| RariError::io(format!("Failed to read component file: {e}")))?;
 
         renderer
@@ -952,7 +960,7 @@ impl ComponentLoader {
         runtime: &Arc<JsExecutionRuntime>,
     ) -> Result<(), RariError> {
         let manifest_path = Path::new(DIST_DIR).join("ssr").join("manifest.json");
-        if !manifest_path.exists() {
+        if !fs::try_exists(&manifest_path).await.unwrap_or(false) {
             return Ok(());
         }
 
@@ -969,7 +977,8 @@ impl ComponentLoader {
             .await
             .map_err(|e| RariError::internal(format!("Failed to initialize ssrModules: {e}")))?;
 
-        let manifest_content = fs::read_to_string(manifest_path)
+        let manifest_content = fs::read_to_string(&manifest_path)
+            .await
             .map_err(|e| RariError::io(format!("Failed to read SSR manifest: {e}")))?;
 
         let manifest: serde_json::Value = serde_json::from_str(&manifest_content)
@@ -984,11 +993,11 @@ impl ComponentLoader {
             let bundle_path = info.get("bundlePath").and_then(|v| v.as_str()).unwrap_or_default();
 
             let component_file = Path::new(DIST_DIR).join(bundle_path);
-            if !component_file.exists() {
+            if !fs::try_exists(&component_file).await.unwrap_or(false) {
                 continue;
             }
 
-            let Ok(code) = fs::read_to_string(&component_file) else {
+            let Ok(code) = fs::read_to_string(&component_file).await else {
                 continue;
             };
 
@@ -1060,11 +1069,12 @@ impl ComponentLoader {
     ) -> Result<(), RariError> {
         let manifest_path =
             Path::new(DIST_DIR).join("server").join("client-reference-manifest.json");
-        if !manifest_path.exists() {
+        if !fs::try_exists(&manifest_path).await.unwrap_or(false) {
             return Ok(());
         }
 
-        let manifest_content = fs::read_to_string(manifest_path)
+        let manifest_content = fs::read_to_string(&manifest_path)
+            .await
             .map_err(|e| RariError::io(format!("Failed to read client reference manifest: {e}")))?;
 
         let manifest: Value = serde_json::from_str(&manifest_content).map_err(|e| {

--- a/crates/rari/src/server/loaders/component.rs
+++ b/crates/rari/src/server/loaders/component.rs
@@ -6,7 +6,6 @@ use rari_error::RariError;
 use rari_rsc::utils::extract_dependencies;
 use rari_utils::path_to_file_url;
 use serde_json::Value;
-use tracing::error;
 
 use crate::{
     rendering::base::RscRenderer,
@@ -48,7 +47,7 @@ impl ComponentLoader {
 
             let component_file = Path::new(DIST_DIR).join(bundle_path);
             if !component_file.exists() {
-                error!("Component file not found: {}", component_file.display());
+                tracing::error!("Component file not found: {}", component_file.display());
                 continue;
             }
 
@@ -61,16 +60,22 @@ impl ComponentLoader {
                 if let Err(e) =
                     renderer.runtime.add_module_to_loader(specifier, component_code.clone()).await
                 {
-                    error!("Failed to add component {} to module loader: {}", component_id, e);
+                    tracing::error!(
+                        "Failed to add component {} to module loader: {}",
+                        component_id,
+                        e
+                    );
                     continue;
                 }
 
                 match renderer.runtime.load_es_module(component_id).await {
                     Ok(module_id) => {
                         if let Err(e) = renderer.runtime.evaluate_module(module_id).await {
-                            error!(
+                            tracing::error!(
                                 "Failed to evaluate module {} (id: {}): {}",
-                                component_id, module_id, e
+                                component_id,
+                                module_id,
+                                e
                             );
                             continue;
                         }
@@ -79,17 +84,19 @@ impl ComponentLoader {
                             Ok(_namespace) => {
                                 let specifier_json = serde_json::to_string(specifier)
                                     .unwrap_or_else(|e| {
-                                        error!(
+                                        tracing::error!(
                                             "Failed to serialize module specifier for {}: {}",
-                                            component_id, e
+                                            component_id,
+                                            e
                                         );
                                         "\"\"".to_string()
                                     });
                                 let component_id_json = serde_json::to_string(component_id)
                                     .unwrap_or_else(|e| {
-                                        error!(
+                                        tracing::error!(
                                             "Failed to serialize component_id {}: {}",
-                                            component_id, e
+                                            component_id,
+                                            e
                                         );
                                         "\"\"".to_string()
                                     });
@@ -140,7 +147,7 @@ impl ComponentLoader {
                                                 .and_then(serde_json::Value::as_bool)
                                                 && !success
                                             {
-                                                error!(
+                                                tracing::error!(
                                                     "Failed to register server action {}: {:?}",
                                                     component_id,
                                                     result.get("error")
@@ -148,9 +155,10 @@ impl ComponentLoader {
                                             }
                                         }
                                         Err(e) => {
-                                            error!(
+                                            tracing::error!(
                                                 "Failed to register server action {}: {}",
-                                                component_id, e
+                                                component_id,
+                                                e
                                             );
                                         }
                                     }
@@ -179,7 +187,7 @@ impl ComponentLoader {
                                                 .and_then(serde_json::Value::as_bool)
                                                 && !success
                                             {
-                                                error!(
+                                                tracing::error!(
                                                     "Failed to register component {} to globalThis: {:?}",
                                                     component_id,
                                                     result.get("error")
@@ -187,28 +195,34 @@ impl ComponentLoader {
                                             }
                                         }
                                         Err(e) => {
-                                            error!(
+                                            tracing::error!(
                                                 "Failed to register component {} to globalThis: {}",
-                                                component_id, e
+                                                component_id,
+                                                e
                                             );
                                         }
                                     }
                                 }
                             }
                             Err(e) => {
-                                error!(
+                                tracing::error!(
                                     "Failed to get module namespace for {}: {}",
-                                    component_id, e
+                                    component_id,
+                                    e
                                 );
                             }
                         }
                     }
                     Err(e) => {
-                        error!("Failed to load component {} as ESM module: {}", component_id, e);
+                        tracing::error!(
+                            "Failed to load component {} as ESM module: {}",
+                            component_id,
+                            e
+                        );
                     }
                 }
             } else {
-                error!("Component {} missing moduleSpecifier in manifest.", component_id);
+                tracing::error!("Component {} missing moduleSpecifier in manifest.", component_id);
             }
         }
 
@@ -290,23 +304,25 @@ impl ComponentLoader {
                                                     .evaluate_module(module_id)
                                                     .await
                                                 {
-                                                    error!(
+                                                    tracing::error!(
                                                         "Failed to evaluate server action module {}: {}",
-                                                        action_id, e
+                                                        action_id,
+                                                        e
                                                     );
                                                 } else {
                                                     let module_specifier_json = serde_json::to_string(&module_specifier)
                                                         .map_err(|e| {
-                                                            error!("Failed to serialize module_specifier for {}: {}", action_id, e);
+                                                            tracing::error!("Failed to serialize module_specifier for {}: {}", action_id, e);
                                                             RariError::internal(format!("Failed to serialize module_specifier: {e}"))
                                                         })?;
                                                     let action_id_json = serde_json::to_string(
                                                         &action_id,
                                                     )
                                                     .map_err(|e| {
-                                                        error!(
+                                                        tracing::error!(
                                                             "Failed to serialize action_id {}: {}",
-                                                            action_id, e
+                                                            action_id,
+                                                            e
                                                         );
                                                         RariError::internal(format!(
                                                             "Failed to serialize action_id: {e}"
@@ -363,12 +379,13 @@ impl ComponentLoader {
                                                                     .get("error")
                                                                     .and_then(|v| v.as_str())
                                                                 {
-                                                                    error!(
+                                                                    tracing::error!(
                                                                         "Failed to register server action {}: {}",
-                                                                        action_id, error_msg
+                                                                        action_id,
+                                                                        error_msg
                                                                     );
                                                                 } else {
-                                                                    error!(
+                                                                    tracing::error!(
                                                                         "Failed to register server action {}: unknown error",
                                                                         action_id
                                                                     );
@@ -376,18 +393,20 @@ impl ComponentLoader {
                                                             }
                                                         }
                                                         Err(e) => {
-                                                            error!(
+                                                            tracing::error!(
                                                                 "Failed to register server action {}: {}",
-                                                                action_id, e
+                                                                action_id,
+                                                                e
                                                             );
                                                         }
                                                     }
                                                 }
                                             }
                                             Err(e) => {
-                                                error!(
+                                                tracing::error!(
                                                     "Failed to load server action {} as ESM module: {}",
-                                                    action_id, e
+                                                    action_id,
+                                                    e
                                                 );
                                             }
                                         }
@@ -407,18 +426,20 @@ impl ComponentLoader {
                                         {
                                             Ok(_) => {}
                                             Err(e) => {
-                                                error!(
+                                                tracing::error!(
                                                     "Failed to load server action {}: {}",
-                                                    action_id, e
+                                                    action_id,
+                                                    e
                                                 );
                                             }
                                         }
                                     }
                                 }
                                 Err(e) => {
-                                    error!(
+                                    tracing::error!(
                                         "Failed to read built server action {:?}: {}",
-                                        dist_path, e
+                                        dist_path,
+                                        e
                                     );
                                 }
                             }
@@ -492,18 +513,20 @@ impl ComponentLoader {
                                     if let Err(e) =
                                         renderer.runtime.evaluate_module(module_id).await
                                     {
-                                        error!(
+                                        tracing::error!(
                                             "Failed to evaluate server action module {}: {}",
-                                            relative_str, e
+                                            relative_str,
+                                            e
                                         );
                                     } else {
                                         let module_specifier_json = serde_json::to_string(
                                             &module_specifier,
                                         )
                                         .map_err(|e| {
-                                            error!(
+                                            tracing::error!(
                                                 "Failed to serialize module_specifier for {}: {}",
-                                                relative_str, e
+                                                relative_str,
+                                                e
                                             );
                                             RariError::internal(format!(
                                                 "Failed to serialize module_specifier: {e}"
@@ -511,9 +534,10 @@ impl ComponentLoader {
                                         })?;
                                         let relative_str_json =
                                             serde_json::to_string(&relative_str).map_err(|e| {
-                                                error!(
+                                                tracing::error!(
                                                     "Failed to serialize relative_str {}: {}",
-                                                    relative_str, e
+                                                    relative_str,
+                                                    e
                                                 );
                                                 RariError::internal(format!(
                                                     "Failed to serialize relative_str: {e}"
@@ -568,12 +592,13 @@ impl ComponentLoader {
                                                     if let Some(error_msg) =
                                                         result.get("error").and_then(|v| v.as_str())
                                                     {
-                                                        error!(
+                                                        tracing::error!(
                                                             "Failed to register server functions from {}: {}",
-                                                            relative_str, error_msg
+                                                            relative_str,
+                                                            error_msg
                                                         );
                                                     } else {
-                                                        error!(
+                                                        tracing::error!(
                                                             "Failed to register server functions from {}: unknown error",
                                                             relative_str
                                                         );
@@ -581,18 +606,20 @@ impl ComponentLoader {
                                                 }
                                             }
                                             Err(e) => {
-                                                error!(
+                                                tracing::error!(
                                                     "Failed to register server functions from {}: {}",
-                                                    relative_str, e
+                                                    relative_str,
+                                                    e
                                                 );
                                             }
                                         }
                                     }
                                 }
                                 Err(e) => {
-                                    error!(
+                                    tracing::error!(
                                         "Failed to load server action {} as ESM module: {}",
-                                        relative_str, e
+                                        relative_str,
+                                        e
                                     );
                                 }
                             }
@@ -609,9 +636,10 @@ impl ComponentLoader {
                             {
                                 Ok(_) => {}
                                 Err(e) => {
-                                    error!(
+                                    tracing::error!(
                                         "Failed to load server actions from {}: {}",
-                                        relative_str, e
+                                        relative_str,
+                                        e
                                     );
                                 }
                             }
@@ -657,17 +685,20 @@ impl ComponentLoader {
                         match renderer.runtime.load_es_module(&component_id).await {
                             Ok(module_id) => {
                                 if let Err(e) = renderer.runtime.evaluate_module(module_id).await {
-                                    error!(
+                                    tracing::error!(
                                         "Failed to evaluate ESM module {} (id: {}): {}",
-                                        component_id, module_id, e
+                                        component_id,
+                                        module_id,
+                                        e
                                     );
                                 } else {
                                     let skip_global_binding = component_id.starts_with("lib/");
                                     let module_specifier_json =
                                         serde_json::to_string(&module_specifier).map_err(|e| {
-                                            error!(
+                                            tracing::error!(
                                                 "Failed to serialize module_specifier for {}: {}",
-                                                component_id, e
+                                                component_id,
+                                                e
                                             );
                                             RariError::internal(format!(
                                                 "Failed to serialize module_specifier: {e}"
@@ -675,9 +706,10 @@ impl ComponentLoader {
                                         })?;
                                     let component_id_json = serde_json::to_string(&component_id)
                                         .map_err(|e| {
-                                            error!(
+                                            tracing::error!(
                                                 "Failed to serialize component_id {}: {}",
-                                                component_id, e
+                                                component_id,
+                                                e
                                             );
                                             RariError::internal(format!(
                                                 "Failed to serialize component_id: {e}"
@@ -705,7 +737,7 @@ impl ComponentLoader {
                                                 .unwrap_or(false);
 
                                             if !registration_succeeded {
-                                                error!(
+                                                tracing::error!(
                                                     "Failed to register component {} to globalThis: {:?}",
                                                     component_id,
                                                     result.get("error")
@@ -717,9 +749,10 @@ impl ComponentLoader {
                                                     &component_id,
                                                 )
                                                 .unwrap_or_else(|e| {
-                                                    error!(
+                                                    tracing::error!(
                                                         "Failed to serialize component_id {}: {}",
-                                                        component_id, e
+                                                        component_id,
+                                                        e
                                                     );
                                                     "\"\"".to_string()
                                                 });
@@ -761,26 +794,29 @@ impl ComponentLoader {
                                                     )
                                                     .await
                                                 {
-                                                    error!(
+                                                    tracing::error!(
                                                         "Failed to mark component {} as client: {}",
-                                                        component_id, e
+                                                        component_id,
+                                                        e
                                                     );
                                                 }
                                             }
                                         }
                                         Err(e) => {
-                                            error!(
+                                            tracing::error!(
                                                 "Failed to register component {}: {}",
-                                                component_id, e
+                                                component_id,
+                                                e
                                             );
                                         }
                                     }
                                 }
                             }
                             Err(e) => {
-                                error!(
+                                tracing::error!(
                                     "Failed to load component {} as ESM module: {}",
-                                    component_id, e
+                                    component_id,
+                                    e
                                 );
                             }
                         }
@@ -798,9 +834,10 @@ impl ComponentLoader {
                                     let skip_global_binding = component_id.starts_with("lib/");
                                     let component_id_json = serde_json::to_string(&component_id)
                                         .unwrap_or_else(|e| {
-                                            error!(
+                                            tracing::error!(
                                                 "Failed to serialize component_id {}: {}",
-                                                component_id, e
+                                                component_id,
+                                                e
                                             );
                                             "\"\"".to_string()
                                         });
@@ -843,15 +880,20 @@ impl ComponentLoader {
                                         )
                                         .await
                                     {
-                                        error!(
+                                        tracing::error!(
                                             "Failed to mark component {} as client: {}",
-                                            component_id, e
+                                            component_id,
+                                            e
                                         );
                                     }
                                 }
                             }
                             Err(e) => {
-                                error!("Failed to execute component {}: {}", component_id, e);
+                                tracing::error!(
+                                    "Failed to execute component {}: {}",
+                                    component_id,
+                                    e
+                                );
                             }
                         }
                     }
@@ -952,7 +994,7 @@ impl ComponentLoader {
 
             let module_specifier = format!("file:///{}", bundle_path.cow_replace('\\', "/"));
             if let Err(e) = runtime.add_module_to_loader(&module_specifier, code).await {
-                error!("Failed to add SSR module {}: {}", module_path, e);
+                tracing::error!("Failed to add SSR module {}: {}", module_path, e);
                 continue;
             }
 
@@ -1006,7 +1048,7 @@ impl ComponentLoader {
                 )
                 .await
             {
-                error!("Failed to load SSR module {}: {}", module_path, e);
+                tracing::error!("Failed to load SSR module {}: {}", module_path, e);
             }
         }
 

--- a/crates/rari/src/server/loaders/component.rs
+++ b/crates/rari/src/server/loaders/component.rs
@@ -259,8 +259,12 @@ impl ComponentLoader {
                 .map_err(|e| RariError::io(format!("Failed to read directory entry: {e}")))?
             {
                 let path = entry.path();
+                let file_type = entry
+                    .file_type()
+                    .await
+                    .map_err(|e| RariError::io(format!("Failed to read file type: {e}")))?;
 
-                if path.is_dir() {
+                if file_type.is_dir() {
                     Self::scan_for_server_actions(&path, renderer).await?;
                 } else if path
                     .extension()
@@ -292,7 +296,7 @@ impl ComponentLoader {
                             match fs::read_to_string(&dist_path).await {
                                 Ok(dist_code) => {
                                     let canonical_path =
-                                        dist_path.canonicalize().unwrap_or(dist_path.clone());
+                                        fs::canonicalize(&dist_path).await.unwrap_or(dist_path);
                                     let module_specifier = path_to_file_url(&canonical_path);
 
                                     let esm_load_result = renderer
@@ -483,8 +487,12 @@ impl ComponentLoader {
                 .map_err(|e| RariError::io(format!("Failed to read directory entry: {e}")))?
             {
                 let path = entry.path();
+                let file_type = entry
+                    .file_type()
+                    .await
+                    .map_err(|e| RariError::io(format!("Failed to read file type: {e}")))?;
 
-                if path.is_dir() {
+                if file_type.is_dir() {
                     Self::load_server_components_recursive(&path, base_dir, renderer).await?;
                 } else if path.extension().and_then(|s| s.to_str()) == Some("js") {
                     let file_name = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
@@ -505,7 +513,8 @@ impl ComponentLoader {
                             .cow_replace('\\', "/")
                             .into_owned();
 
-                        let canonical_path = path.canonicalize().unwrap_or(path.clone());
+                        let canonical_path =
+                            fs::canonicalize(&path).await.unwrap_or_else(|_| path.clone());
                         let module_specifier = path_to_file_url(&canonical_path);
 
                         let esm_load_result = renderer
@@ -679,7 +688,8 @@ impl ComponentLoader {
                         );
                     }
 
-                    let canonical_path = path.canonicalize().unwrap_or(path.clone());
+                    let canonical_path =
+                        fs::canonicalize(&path).await.unwrap_or_else(|_| path.clone());
                     let module_specifier = path_to_file_url(&canonical_path);
 
                     let esm_load_result = renderer

--- a/crates/rari/src/server/middleware/proxy.rs
+++ b/crates/rari/src/server/middleware/proxy.rs
@@ -18,7 +18,6 @@ use rari_utils::path_to_file_url;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use tower::{Layer, Service};
-use tracing::error;
 
 use crate::server::core::types::ServerState;
 
@@ -171,7 +170,7 @@ where
                                 *request.uri_mut() = uri;
                             }
                             Err(e) => {
-                                error!("Failed to parse rewrite path: {}", e);
+                                tracing::error!("Failed to parse rewrite path: {}", e);
                                 return inner.call(request).await;
                             }
                         }
@@ -221,7 +220,7 @@ where
                     inner.call(request).await
                 }
                 Err(e) => {
-                    error!("Proxy execution failed: {}", e);
+                    tracing::error!("Proxy execution failed: {}", e);
                     inner.call(request).await
                 }
             }
@@ -309,18 +308,18 @@ pub async fn initialize_proxy(state: &ServerState) -> Result<(), Box<dyn Error>>
                         .get("error")
                         .and_then(|v| v.as_str())
                         .unwrap_or("Unknown error during proxy initialization");
-                    error!("Proxy initialization failed: {error_msg}");
+                    tracing::error!("Proxy initialization failed: {error_msg}");
                     Err(RariError::js_runtime(format!("Proxy initialization failed: {error_msg}"))
                         .into())
                 }
             } else {
-                error!("Proxy initialization returned invalid result format");
+                tracing::error!("Proxy initialization returned invalid result format");
                 Err(RariError::js_runtime("Proxy initialization returned invalid result format")
                     .into())
             }
         }
         Err(e) => {
-            error!("Failed to register proxy function: {}", e);
+            tracing::error!("Failed to register proxy function: {}", e);
             Err(e.into())
         }
     }

--- a/crates/rari/src/server/middleware/proxy.rs
+++ b/crates/rari/src/server/middleware/proxy.rs
@@ -1,7 +1,7 @@
 use std::{
     env,
     error::Error,
-    fs, mem,
+    fs as std_fs, mem,
     path::{Path, PathBuf},
     task::{Context, Poll},
 };
@@ -17,6 +17,7 @@ use rari_error::RariError;
 use rari_utils::path_to_file_url;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
+use tokio::fs;
 use tower::{Layer, Service};
 
 use crate::server::core::types::ServerState;
@@ -52,7 +53,7 @@ use std::sync::OnceLock;
 static PROXY_ENABLED: OnceLock<bool> = OnceLock::new();
 
 fn is_proxy_enabled() -> bool {
-    *PROXY_ENABLED.get_or_init(|| fs::metadata("dist/server/proxy.js").is_ok())
+    *PROXY_ENABLED.get_or_init(|| std_fs::metadata("dist/server/proxy.js").is_ok())
 }
 
 async fn execute_proxy(
@@ -228,13 +229,13 @@ where
     }
 }
 
-fn resolve_rari_package_dir() -> Option<PathBuf> {
+async fn resolve_rari_package_dir() -> Option<PathBuf> {
     let cwd = env::current_dir().ok()?;
     let mut search_dir = cwd.as_path();
 
     loop {
         let candidate = search_dir.join("node_modules").join("rari");
-        if candidate.exists() {
+        if fs::try_exists(&candidate).await.unwrap_or(false) {
             return Some(candidate);
         }
         search_dir = search_dir.parent()?;
@@ -250,14 +251,14 @@ pub async fn initialize_proxy(state: &ServerState) -> Result<(), Box<dyn Error>>
     let renderer = state.renderer.lock().await;
     let runtime = &renderer.runtime;
 
-    let Some(rari_pkg_dir) = resolve_rari_package_dir() else {
+    let Some(rari_pkg_dir) = resolve_rari_package_dir().await else {
         tracing::debug!("Proxy: rari package directory not found in node_modules");
         return Ok(());
     };
 
     let executor_path = rari_pkg_dir.join("dist/proxy/runtime-executor.mjs");
 
-    if !executor_path.exists() {
+    if !fs::try_exists(&executor_path).await.unwrap_or(false) {
         tracing::debug!(
             "Proxy: executor not found at {}, skipping proxy setup",
             executor_path.display()
@@ -265,23 +266,18 @@ pub async fn initialize_proxy(state: &ServerState) -> Result<(), Box<dyn Error>>
         return Ok(());
     }
 
-    let executor_absolute =
-        if let Ok(canonical) = executor_path.canonicalize() { canonical } else { executor_path };
+    let executor_absolute = fs::canonicalize(&executor_path).await.unwrap_or(executor_path);
     let executor_specifier = path_to_file_url(&executor_absolute);
 
     let rari_request_path = rari_pkg_dir.join("dist/proxy/RariRequest.mjs");
-    let rari_request_absolute = if let Ok(canonical) = rari_request_path.canonicalize() {
-        canonical
-    } else {
-        rari_request_path
-    };
+    let rari_request_absolute =
+        fs::canonicalize(&rari_request_path).await.unwrap_or(rari_request_path);
     let rari_request_specifier = path_to_file_url(&rari_request_absolute);
 
     let proxy_file_path = Path::new("dist/server/proxy.js");
-    let proxy_absolute = if let Ok(canonical) = proxy_file_path.canonicalize() {
-        canonical
-    } else {
-        env::current_dir()?.join(proxy_file_path)
+    let proxy_absolute = match fs::canonicalize(proxy_file_path).await {
+        Ok(canonical) => canonical,
+        Err(_) => env::current_dir()?.join(proxy_file_path),
     };
     let proxy_specifier = path_to_file_url(&proxy_absolute);
 

--- a/crates/rari/src/server/og/cache.rs
+++ b/crates/rari/src/server/og/cache.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::hash_map::DefaultHasher,
     error::Error,
-    fs as StdFs,
+    fs as std_fs,
     hash::{Hash, Hasher},
     io::ErrorKind::NotFound,
     path::{Path, PathBuf},
@@ -56,7 +56,7 @@ impl OgImageCache {
 
     async fn ensure_cache_dir(&self) {
         let dir = self.cache_dir.clone();
-        let result = task::spawn_blocking(move || StdFs::create_dir_all(&dir)).await;
+        let result = task::spawn_blocking(move || std_fs::create_dir_all(&dir)).await;
         if let Ok(Err(e)) = result {
             tracing::error!("Failed to create OG cache directory: {}", e);
         }
@@ -225,7 +225,7 @@ mod tests {
     #[tokio::test]
     async fn test_handler_fallback_to_disk() {
         let project_path = test_project_path("fallback-to-disk");
-        let _ = StdFs::remove_dir_all(&project_path);
+        let _ = std_fs::remove_dir_all(&project_path);
 
         let handler_a = Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: 8,
@@ -254,6 +254,6 @@ mod tests {
         assert_eq!(in_new_handler, Some(payload.clone()), "write-through to new handler missing");
 
         cache_b.clear().await.expect("clear");
-        let _ = StdFs::remove_dir_all(&project_path);
+        let _ = std_fs::remove_dir_all(&project_path);
     }
 }

--- a/crates/rari/src/server/rendering/utils.rs
+++ b/crates/rari/src/server/rendering/utils.rs
@@ -3,7 +3,6 @@ use std::fmt::Write;
 use axum::http::StatusCode;
 use cow_utils::CowUtils;
 use tokio::fs;
-use tracing::error;
 
 use crate::server::config::Config;
 
@@ -195,8 +194,8 @@ pub async fn inject_assets_into_html(html: &str, config: &Config) -> Result<Stri
             let has_root_after = final_html.contains(r#"id="root""#);
 
             if has_root_before && !has_root_after {
-                error!("CRITICAL: Root element was LOST during asset injection!");
-                error!("This will cause hydration to fail in the browser.");
+                tracing::error!("CRITICAL: Root element was LOST during asset injection!");
+                tracing::error!("This will cause hydration to fail in the browser.");
 
                 let recovered_html = if html.trim_start().starts_with("<!DOCTYPE") {
                     html.to_string()
@@ -208,7 +207,7 @@ pub async fn inject_assets_into_html(html: &str, config: &Config) -> Result<Stri
             }
         }
         Err(e) => {
-            error!("Asset injection failed with error: {:?}", e);
+            tracing::error!("Asset injection failed with error: {:?}", e);
         }
     }
 
@@ -354,7 +353,7 @@ async fn inject_assets_into_complete_document(
 
     let has_root_after = final_html.contains(r#"id="root""#);
     if has_root_before && !has_root_after {
-        error!("Root element was lost during asset injection!");
+        tracing::error!("Root element was lost during asset injection!");
 
         let trimmed_lower = html.trim_start().cow_to_lowercase();
         if trimmed_lower.starts_with("<!doctype") {
@@ -504,8 +503,10 @@ async fn inject_content_into_template(
     };
 
     if !final_html.contains(r#"id="root""#) {
-        error!("CRITICAL: Root element missing in final HTML after template injection!");
-        error!("This should never happen as template injection should always create root element");
+        tracing::error!("CRITICAL: Root element missing in final HTML after template injection!");
+        tracing::error!(
+            "This should never happen as template injection should always create root element"
+        );
 
         let recovered_html = format!(
             r#"<!DOCTYPE html>

--- a/crates/rari/src/server/routing/api_routes.rs
+++ b/crates/rari/src/server/routing/api_routes.rs
@@ -16,7 +16,6 @@ use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::fs;
-use tracing::error;
 
 use crate::{
     runtime::JsExecutionRuntime,
@@ -260,7 +259,7 @@ impl ApiRouteHandler {
         let dist_path = Self::resolve_route_dist_path(route)?;
 
         if !dist_path.exists() {
-            error!(
+            tracing::error!(
                 file_path = %file_path,
                 dist_path = %dist_path.display(),
                 route_path = %route.path,
@@ -273,7 +272,7 @@ impl ApiRouteHandler {
         }
 
         let code = fs::read_to_string(&dist_path).await.map_err(|e| {
-            error!(
+            tracing::error!(
                 file_path = %file_path,
                 dist_path = %dist_path.display(),
                 error = %e,
@@ -390,7 +389,7 @@ impl ApiRouteHandler {
         const MAX_API_BODY_SIZE: usize = 10 * 1024 * 1024;
 
         let handler = self.load_handler(&route_match.route, is_development).await.map_err(|e| {
-            error!(
+            tracing::error!(
                 route_path = %route_match.route.path,
                 method = %route_match.method,
                 error = %e,
@@ -402,7 +401,7 @@ impl ApiRouteHandler {
         let (parts, body) = request.into_parts();
 
         let body_bytes = body::to_bytes(body, MAX_API_BODY_SIZE).await.map_err(|e| {
-            error!(
+            tracing::error!(
                 route_path = %route_match.route.path,
                 method = %route_match.method,
                 error = %e,
@@ -444,7 +443,7 @@ impl ApiRouteHandler {
                 if let Err(e) =
                     self.runtime.add_module_to_loader(&module_specifier, handler.code.clone()).await
                 {
-                    error!(
+                    tracing::error!(
                         route_path = %route_match.route.path,
                         method = %route_match.method,
                         module_id = %handler.module_id,
@@ -475,7 +474,7 @@ impl ApiRouteHandler {
                 });
 
                 let module_id = self.runtime.load_es_module(&component_id).await.map_err(|e| {
-                    error!(
+                    tracing::error!(
                         route_path = %route_match.route.path,
                         method = %route_match.method,
                         component_id = %component_id,
@@ -486,7 +485,7 @@ impl ApiRouteHandler {
                 })?;
 
                 if let Err(e) = self.runtime.evaluate_module(module_id).await {
-                    error!(
+                    tracing::error!(
                         route_path = %route_match.route.path,
                         method = %route_match.method,
                         module_id = module_id,
@@ -504,7 +503,7 @@ impl ApiRouteHandler {
                     )
                     .await
                     .map_err(|e| {
-                        error!(
+                        tracing::error!(
                             route_path = %route_match.route.path,
                             method = %route_match.method,
                             module_id = %handler.module_id,
@@ -515,7 +514,7 @@ impl ApiRouteHandler {
                     })?;
 
                 let response = Self::create_response(&result).map_err(|e| {
-                    error!(
+                    tracing::error!(
                         route_path = %route_match.route.path,
                         method = %route_match.method,
                         error = %e,

--- a/crates/rari/src/server/routing/api_routes.rs
+++ b/crates/rari/src/server/routing/api_routes.rs
@@ -425,7 +425,7 @@ impl ApiRouteHandler {
         self.runtime
             .execute_with_request_context(request_context, async {
                 let dist_path = Self::resolve_route_dist_path(&route_match.route)?;
-                let canonical_path = dist_path.canonicalize().map_err(|e| {
+                let canonical_path = fs::canonicalize(&dist_path).await.map_err(|e| {
                     RariError::io(format!(
                         "Failed to canonicalize API route path {}: {e}",
                         dist_path.display()

--- a/crates/rari/src/server/routing/api_routes.rs
+++ b/crates/rari/src/server/routing/api_routes.rs
@@ -258,7 +258,7 @@ impl ApiRouteHandler {
 
         let dist_path = Self::resolve_route_dist_path(route)?;
 
-        if !dist_path.exists() {
+        if !fs::try_exists(&dist_path).await.unwrap_or(false) {
             tracing::error!(
                 file_path = %file_path,
                 dist_path = %dist_path.display(),

--- a/crates/rari/src/server/vite.rs
+++ b/crates/rari/src/server/vite.rs
@@ -16,8 +16,7 @@ use http::uri::PathAndQuery;
 use rari_error::RariError;
 use reqwest::Client;
 use tokio::time;
-use tokio_tungstenite::{connect_async, tungstenite::Message};
-use tracing::error;
+use tokio_tungstenite::tungstenite::Message;
 use tungstenite::{client::IntoClientRequest, http::Request as HttpRequest};
 
 use crate::server::config::Config;
@@ -35,7 +34,7 @@ fn create_client() -> Client {
 
 pub async fn vite_src_proxy(req: Request) -> impl IntoResponse {
     let Some(config) = Config::get() else {
-        error!("Failed to get global configuration for Vite proxy");
+        tracing::error!("Failed to get global configuration for Vite proxy");
         return create_error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             "Configuration not available",
@@ -57,7 +56,7 @@ pub async fn vite_src_proxy(req: Request) -> impl IntoResponse {
     let body_bytes = match body::to_bytes(req.into_body(), usize::MAX).await {
         Ok(bytes) => bytes,
         Err(e) => {
-            error!("Failed to read request body: {}", e);
+            tracing::error!("Failed to read request body: {}", e);
             return create_error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Failed to read request body",
@@ -84,7 +83,7 @@ pub async fn vite_src_proxy(req: Request) -> impl IntoResponse {
             match response_builder.body(Body::from_stream(response.bytes_stream())) {
                 Ok(response) => response,
                 Err(e) => {
-                    error!("Failed to build proxy response: {}", e);
+                    tracing::error!("Failed to build proxy response: {}", e);
                     create_error_response(
                         StatusCode::INTERNAL_SERVER_ERROR,
                         "Failed to build response",
@@ -112,7 +111,7 @@ pub async fn vite_src_proxy(req: Request) -> impl IntoResponse {
 
 pub async fn vite_reverse_proxy(req: Request) -> impl IntoResponse {
     let Some(config) = Config::get() else {
-        error!("Failed to get global configuration for Vite proxy");
+        tracing::error!("Failed to get global configuration for Vite proxy");
         return create_error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             "Configuration not available",
@@ -134,7 +133,7 @@ pub async fn vite_reverse_proxy(req: Request) -> impl IntoResponse {
     let body_bytes = match body::to_bytes(req.into_body(), usize::MAX).await {
         Ok(bytes) => bytes,
         Err(e) => {
-            error!("Failed to read request body: {}", e);
+            tracing::error!("Failed to read request body: {}", e);
             return create_error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Failed to read request body",
@@ -161,7 +160,7 @@ pub async fn vite_reverse_proxy(req: Request) -> impl IntoResponse {
             match response_builder.body(Body::from_stream(response.bytes_stream())) {
                 Ok(response) => response,
                 Err(e) => {
-                    error!("Failed to build proxy response: {}", e);
+                    tracing::error!("Failed to build proxy response: {}", e);
                     create_error_response(
                         StatusCode::INTERNAL_SERVER_ERROR,
                         "Failed to build response",
@@ -193,12 +192,12 @@ pub async fn vite_websocket_proxy(ws: WebSocketUpgrade, uri: Uri) -> impl IntoRe
 
 async fn handle_websocket(mut client_socket: WebSocket, uri: Uri) {
     if let Err(e) = client_socket.send(WsMessage::Ping("rari-vite-proxy".into())).await {
-        error!("Failed to send initial ping to client: {}", e);
+        tracing::error!("Failed to send initial ping to client: {}", e);
         return;
     }
 
     let Some(config) = Config::get() else {
-        error!("Failed to get global configuration for WebSocket proxy");
+        tracing::error!("Failed to get global configuration for WebSocket proxy");
         let _ = client_socket.send(WsMessage::Close(None)).await;
         return;
     };
@@ -217,16 +216,16 @@ async fn handle_websocket(mut client_socket: WebSocket, uri: Uri) {
     {
         Ok(request) => request,
         Err(e) => {
-            error!("Failed to create Vite WebSocket request: {}", e);
+            tracing::error!("Failed to create Vite WebSocket request: {}", e);
             let _ = client_socket.send(WsMessage::Close(None)).await;
             return;
         }
     };
 
-    let vite_socket = match connect_async(vite_ws_request).await {
+    let vite_socket = match tokio_tungstenite::connect_async(vite_ws_request).await {
         Ok((stream, _)) => stream,
         Err(e) => {
-            error!("Failed to connect to Vite WebSocket server: {}", e);
+            tracing::error!("Failed to connect to Vite WebSocket server: {}", e);
 
             let error_msg = serde_json::json!({
                 "type": "error",

--- a/examples/app-router-example/src/app/actions/page.tsx
+++ b/examples/app-router-example/src/app/actions/page.tsx
@@ -170,7 +170,7 @@ export default async function ActionsPage() {
               <div className="w-8 h-8 bg-indigo-100 rounded flex items-center justify-center">
                 <span className="text-indigo-600 font-bold">4</span>
               </div>
-              <h4 className="text-gray-900 font-semibold">Wire Format</h4>
+              <h4 className="text-gray-900 font-semibold">Flight Protocol</h4>
             </div>
             <p className="text-sm text-gray-600 leading-relaxed">
               Actions return JSON responses that can include redirects, error

--- a/examples/app-router-example/src/app/server-data/page.tsx
+++ b/examples/app-router-example/src/app/server-data/page.tsx
@@ -70,10 +70,10 @@ export default async function ServerDataPage() {
 
       <div className="mt-8 p-6 bg-amber-50 border border-amber-200 rounded-lg">
         <h3 className="text-amber-700 mb-2 text-xl font-semibold">
-          💡 With RSC Wire Format
+          💡 With RSC Flight Protocol
         </h3>
         <p className="text-gray-600 leading-relaxed">
-          If we implemented the full RSC wire format, this server component
+          If we implemented the full RSC Flight protocol, this server component
           could:
         </p>
         <ul className="leading-loose text-gray-600 pl-6 mt-2">

--- a/examples/app-router-example/src/components/TodoList.tsx
+++ b/examples/app-router-example/src/components/TodoList.tsx
@@ -6,7 +6,7 @@ export default function TodoList() {
   const [todos, setTodos] = useState<
     Array<{ id: number, text: string, done: boolean }>
   >([
-    { id: 1, text: 'Test RSC wire format', done: true },
+    { id: 1, text: 'Test RSC Flight protocol', done: true },
     { id: 2, text: 'Add client components', done: true },
     { id: 3, text: 'Verify streaming works', done: false },
   ])

--- a/packages/rari/src/runtime/AppRouterProvider.tsx
+++ b/packages/rari/src/runtime/AppRouterProvider.tsx
@@ -6,7 +6,7 @@ import { useEffect, useRef, useState } from 'react'
 // @ts-expect-error - virtual module resolved by Vite
 import { createFromReadableStream } from 'virtual:react-flight-client'
 import { PATH_TRAILING_SLASH_REGEX } from '../shared/regex-constants'
-import { preloadModulesFromWireFormat } from './shared/preload-modules'
+import { preloadModulesFromFlightProtocol } from './shared/preload-modules'
 
 const TIMESTAMP_REGEX = /"timestamp":(\d+)/
 const STALE_PAYLOAD_THRESHOLD_MS = 5000
@@ -24,7 +24,7 @@ interface NavigationDetail {
   options: any
   routeInfo?: any
   abortSignal?: AbortSignal
-  rscWireFormat?: string
+  rscFlightProtocol?: string
   rscResponse?: Response
   rscResponsePromise?: Promise<Response>
   isStreaming?: boolean
@@ -147,14 +147,14 @@ export function AppRouterProvider({ children, initialPayload, onNavigate }: AppR
       consecutiveFailuresRef.current = 0
   }
 
-  const isStaleContent = (wireFormat: string): boolean => {
+  const isStaleContent = (flightProtocol: string): boolean => {
     if (!lastSuccessfulPayloadRef.current)
       return false
 
-    if (wireFormat === lastSuccessfulPayloadRef.current)
+    if (flightProtocol === lastSuccessfulPayloadRef.current)
       return true
 
-    const timestampMatch = wireFormat.match(TIMESTAMP_REGEX)
+    const timestampMatch = flightProtocol.match(TIMESTAMP_REGEX)
     if (timestampMatch) {
       const payloadTimestamp = Number.parseInt(timestampMatch[1], 10)
       const now = Date.now()
@@ -165,12 +165,12 @@ export function AppRouterProvider({ children, initialPayload, onNavigate }: AppR
     return false
   }
 
-  const parseRscWireFormat = async (wireFormat: string) => {
-    await preloadModulesFromWireFormat(wireFormat, preloadedModuleIdsRef.current)
+  const parseRscFlightProtocol = async (flightProtocol: string) => {
+    await preloadModulesFromFlightProtocol(flightProtocol, preloadedModuleIdsRef.current)
 
     const stream = new ReadableStream({
       start(controller) {
-        controller.enqueue(new TextEncoder().encode(wireFormat))
+        controller.enqueue(new TextEncoder().encode(flightProtocol))
         controller.close()
       },
     })
@@ -182,7 +182,7 @@ export function AppRouterProvider({ children, initialPayload, onNavigate }: AppR
     return {
       element,
       rawElement: element,
-      wireFormat,
+      flightProtocol,
     }
   }
 
@@ -197,13 +197,13 @@ export function AppRouterProvider({ children, initialPayload, onNavigate }: AppR
       return {
         element,
         rawElement: element,
-        wireFormat: '',
+        flightProtocol: '',
       }
     }
 
     const clonedResponse = response.clone()
-    const wireFormat = await clonedResponse.text()
-    await preloadModulesFromWireFormat(wireFormat, preloadedModuleIdsRef.current)
+    const flightProtocol = await clonedResponse.text()
+    await preloadModulesFromFlightProtocol(flightProtocol, preloadedModuleIdsRef.current)
 
     const buffer = new Uint8Array(await response.arrayBuffer())
     const stream = new ReadableStream({
@@ -217,7 +217,7 @@ export function AppRouterProvider({ children, initialPayload, onNavigate }: AppR
     return {
       element,
       rawElement: element,
-      wireFormat,
+      flightProtocol,
     }
   }
 
@@ -259,17 +259,17 @@ export function AppRouterProvider({ children, initialPayload, onNavigate }: AppR
         }
 
         let parsedPayload
-        let rscWireFormat = ''
+        let rscFlightProtocol = ''
         try {
           const clonedResponse = response.clone()
-          rscWireFormat = await clonedResponse.text()
+          rscFlightProtocol = await clonedResponse.text()
 
-          if (isStaleContent(rscWireFormat)) {
+          if (isStaleContent(rscFlightProtocol)) {
             if (rscPayload)
               return rscPayload
           }
 
-          await preloadModulesFromWireFormat(rscWireFormat, preloadedModuleIdsRef.current)
+          await preloadModulesFromFlightProtocol(rscFlightProtocol, preloadedModuleIdsRef.current)
 
           const buffer = new Uint8Array(await response.arrayBuffer())
           const stream = new ReadableStream({
@@ -279,14 +279,14 @@ export function AppRouterProvider({ children, initialPayload, onNavigate }: AppR
             },
           })
           const element = await createFromReadableStream(stream)
-          parsedPayload = { element, rawElement: element, wireFormat: rscWireFormat }
+          parsedPayload = { element, rawElement: element, flightProtocol: rscFlightProtocol }
         }
         catch (parseError) {
           const error = parseError instanceof Error ? parseError : new Error(String(parseError))
           trackHMRFailure(
             error,
             'parse',
-            `Failed to parse RSC wire format: ${error.message}`,
+            `Failed to parse RSC Flight protocol: ${error.message}`,
             window.location.pathname,
           )
           throw error
@@ -294,7 +294,7 @@ export function AppRouterProvider({ children, initialPayload, onNavigate }: AppR
 
         if (currentNavigationIdRef.current === navigationId) {
           setRscPayload(parsedPayload)
-          lastSuccessfulPayloadRef.current = rscWireFormat
+          lastSuccessfulPayloadRef.current = rscFlightProtocol
           resetFailureTracking()
         }
 
@@ -322,12 +322,12 @@ export function AppRouterProvider({ children, initialPayload, onNavigate }: AppR
     return fetchPromise
   }
 
-  const parseRscWireFormatRef = useRef<(wireFormat: string) => Promise<any>>(parseRscWireFormat)
+  const parseRscFlightProtocolRef = useRef<(flightProtocol: string) => Promise<any>>(parseRscFlightProtocol)
   const parseRscResponseRef = useRef<(responsePromise: Promise<Response>, isStreaming?: boolean) => Promise<any>>(parseRscResponse)
   const refetchRscPayloadRef = useRef<(targetPath?: string, abortSignal?: AbortSignal) => Promise<any>>(refetchRscPayload)
 
   useEffect(() => {
-    parseRscWireFormatRef.current = parseRscWireFormat
+    parseRscFlightProtocolRef.current = parseRscFlightProtocol
     parseRscResponseRef.current = parseRscResponse
     refetchRscPayloadRef.current = refetchRscPayload
   })
@@ -369,8 +369,8 @@ export function AppRouterProvider({ children, initialPayload, onNavigate }: AppR
           if (currentNavigationIdRef.current !== detail.navigationId)
             return
         }
-        else if (detail.rscWireFormat) {
-          parsedPayload = await parseRscWireFormatRef.current!(detail.rscWireFormat)
+        else if (detail.rscFlightProtocol) {
+          parsedPayload = await parseRscFlightProtocolRef.current!(detail.rscFlightProtocol)
         }
         else if (!detail.isStreaming) {
           parsedPayload = await refetchRscPayloadRef.current!(
@@ -426,8 +426,8 @@ export function AppRouterProvider({ children, initialPayload, onNavigate }: AppR
             setHmrError(null)
           })
         }
-        if (detail.rscWireFormat)
-          lastSuccessfulPayloadRef.current = detail.rscWireFormat
+        if (detail.rscFlightProtocol)
+          lastSuccessfulPayloadRef.current = detail.rscFlightProtocol
 
         resetFailureTracking()
 

--- a/packages/rari/src/runtime/entry-client.ts
+++ b/packages/rari/src/runtime/entry-client.ts
@@ -14,7 +14,7 @@ import { AppRouterProvider } from 'virtual:app-router-provider'
 import { createFromReadableStream } from 'virtual:react-flight-client'
 import { NUMERIC_REGEX } from '../shared/regex-constants'
 import { getClientComponent, getClientComponentAsync, getComponentFromInfo } from './shared/get-client-component'
-import { preloadModulesFromWireFormat } from './shared/preload-modules'
+import { preloadModulesFromFlightProtocol } from './shared/preload-modules'
 import { isSuspenseType } from './shared/suspense'
 // eslint-disable-next-line ts/ban-ts-comment
 // @ts-ignore - virtual module resolved by Vite
@@ -377,7 +377,7 @@ export async function renderApp(): Promise<void> {
             buffer[i] = binaryString.charCodeAt(i)
 
           const textForPreload = new TextDecoder().decode(buffer)
-          await preloadModulesFromWireFormat(textForPreload)
+          await preloadModulesFromFlightProtocol(textForPreload)
 
           const stream = new ReadableStream({
             start(controller) {
@@ -389,7 +389,7 @@ export async function renderApp(): Promise<void> {
         }
         else {
           const payloadText = payloadScript.textContent!
-          await preloadModulesFromWireFormat(payloadText)
+          await preloadModulesFromFlightProtocol(payloadText)
 
           const stream = new ReadableStream({
             start(controller) {
@@ -514,7 +514,7 @@ export async function renderApp(): Promise<void> {
       try {
         const payloadJson = payloadScript.textContent
 
-        await preloadModulesFromWireFormat(payloadJson)
+        await preloadModulesFromFlightProtocol(payloadJson)
 
         const hasBufferedRows = getWindow()['~rari']?.streaming?.bufferedRows && getWindow()['~rari'].streaming!.bufferedRows!.length > 0
         const isStreaming = getWindow()['~rari']?.streaming?.complete === undefined || hasBufferedRows

--- a/packages/rari/src/runtime/shared/preload-modules.ts
+++ b/packages/rari/src/runtime/shared/preload-modules.ts
@@ -1,10 +1,10 @@
 import { getClientComponentAsync } from './get-client-component'
 
-export async function preloadModulesFromWireFormat(
-  wireFormat: string,
+export async function preloadModulesFromFlightProtocol(
+  flightProtocol: string,
   preloadedModuleIds?: Set<string>,
 ): Promise<void> {
-  const lines = wireFormat.split('\n')
+  const lines = flightProtocol.split('\n')
   const moduleIds = new Set<string>()
 
   for (const line of lines) {

--- a/test/e2e/streaming.spec.ts
+++ b/test/e2e/streaming.spec.ts
@@ -21,7 +21,7 @@ test.describe('RSC Streaming Infrastructure Tests', () => {
     await page.waitForLoadState('networkidle')
 
     const rscErrors = consoleErrors.filter(err =>
-      err.includes('RSC') || err.includes('wire format') || err.includes('streaming') || err.includes('parse'),
+      err.includes('RSC') || err.includes('Flight protocol') || err.includes('streaming') || err.includes('parse'),
     )
 
     expect(rscErrors.length).toBe(0)
@@ -234,7 +234,7 @@ test.describe('RSC Protocol Tests', () => {
     await page.waitForLoadState('networkidle')
 
     const parsingErrors = consoleErrors.filter(err =>
-      err.includes('parse') || err.includes('JSON') || err.includes('wire'),
+      err.includes('parse') || err.includes('JSON') || err.includes('Flight') || err.includes('flight'),
     )
 
     expect(parsingErrors.length).toBe(0)
@@ -354,7 +354,7 @@ test.describe('Client-Side Navigation Tests', () => {
     await expect(page.locator('h1')).toBeVisible()
   })
 
-  test('should receive RSC wire format on navigation', async ({ page }) => {
+  test('should receive RSC Flight protocol on navigation', async ({ page }) => {
     await page.goto('/')
     await page.waitForLoadState('networkidle')
 

--- a/web/public/content/blog/building-rari-with-rari.mdx
+++ b/web/public/content/blog/building-rari-with-rari.mdx
@@ -156,7 +156,7 @@ A message channel between the HTTP server and a single JS thread sounds like a b
 
 When a request arrives, axum checks the response cache first. Hit? Served from memory on the HTTP thread. V8 doesn't wake up. Under load, most requests follow this path, which means throughput scales with the HTTP layer's capacity rather than JavaScript's execution speed.
 
-V8 only runs when there's rendering to do. In practice that means the first request for a route. That sends a message to the JS thread, which runs the composition script, renders the tree, and hands back the RSC wire format. That result gets converted to HTML, compressed with <a href="https://github.com/facebook/zstd" target="_blank" rel="noopener noreferrer">zstd</a>, and cached. From that point forward, the JS thread is idle for that route.
+V8 only runs when there's rendering to do. In practice that means the first request for a route. That sends a message to the JS thread, which runs the composition script, renders the tree, and hands back the RSC Flight protocol. That result gets converted to HTML, compressed with <a href="https://github.com/facebook/zstd" target="_blank" rel="noopener noreferrer">zstd</a>, and cached. From that point forward, the JS thread is idle for that route.
 
 The usual Node API surface (fetch, fs, crypto) works because we're using Deno's extension crates under the hood. Module resolution from `node_modules` happens at runtime when V8 first imports a package, but results are cached and most server code is pre-bundled by Vite.
 
@@ -168,7 +168,7 @@ After warmup, the server is a Rust HTTP server with an in-memory cache. V8 sits 
 
 Most of the throughput gain comes from the response cache. The full lifecycle of a request looks like this:
 
-On the first request for a route, the HTTP thread sees a cache miss and sends the composition script to the JS thread. V8 renders the component tree, produces RSC wire format, and sends it back. The HTTP thread converts that to HTML, compresses it with zstd, stores both the raw HTML and the compressed bytes in a `DashMap`, and serves the compressed response to the client.
+On the first request for a route, the HTTP thread sees a cache miss and sends the composition script to the JS thread. V8 renders the component tree, produces RSC Flight protocol, and sends it back. The HTTP thread converts that to HTML, compresses it with zstd, stores both the raw HTML and the compressed bytes in a `DashMap`, and serves the compressed response to the client.
 
 On every subsequent request for that route, the HTTP thread finds the pre-compressed bytes in the `DashMap` and writes them to the socket. No JSON parsing, no HTML conversion, no compression, no V8. The response path is a hash lookup and a `memcpy`.
 

--- a/web/src/lib/sentry-init.ts
+++ b/web/src/lib/sentry-init.ts
@@ -34,7 +34,7 @@ if (typeof window !== 'undefined') {
 
               if (error.message.includes('Unexpected non-whitespace character after JSON')) {
                 const stack = error.stack || ''
-                if (stack.includes('parseRscWireFormat') || stack.includes('AppRouter')) {
+                if (stack.includes('parseRscFlightProtocol') || stack.includes('AppRouter')) {
                   console.warn('[Sentry] Skipping RSC parsing error (likely userscript corruption)')
                   return null
                 }


### PR DESCRIPTION
- Replace explicit type names with the corresponding types in extension trait implementations for various modules, including `deno_cache`, `deno_crypto`, `deno_http`, and others.
- Update the `extensions` function calls to use the simplified types directly, enhancing code readability and maintainability.
- Apply consistent usage of `Self` in trait implementations to adhere to coding standards and improve clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor / Chores**
  * Standardized built-in extension wiring and internal references (no behavior change).
  * Migrated RSC rendering and payload handling from **wire format** to **Flight protocol**, including the renderer entrypoint, module preloading, and public client API naming (e.g., `renderFlightToHtml`, `rscFlightProtocol`).
  * Updated server/client code to use consistent “Flight protocol” terminology end-to-end.
* **Bug Fixes**
  * Improved permission derivation by falling back safely if derivation fails.
* **Documentation / Tests**
  * Updated examples, blog content, e2e streaming/RSC assertions, and Sentry filtering to **Flight protocol** terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->