### PR TITLE
chore: enhance module loader functionality by adding component ID aliasing and refining component specifier registration

### DIFF
--- a/crates/rari/src/runtime/factory/runtime.rs
+++ b/crates/rari/src/runtime/factory/runtime.rs
@@ -477,7 +477,7 @@ async fn handle_js_request(
                 .map(|spec| spec.contains("/rari_hmr/"))
                 .unwrap_or(false);
             if is_hmr_specifier || !has_existing_hmr_mapping {
-                module_loader.component_specifiers.insert(component_id, specifier);
+                module_loader.register_component_specifier(&component_id, &specifier);
             }
             let _ = result_tx.send(Ok(()));
         }

--- a/crates/rari/src/runtime/module_loader/core.rs
+++ b/crates/rari/src/runtime/module_loader/core.rs
@@ -118,6 +118,21 @@ fn append_extension_only(path: &str) -> (String, &str) {
     (base_with_ext, suffix)
 }
 
+fn component_id_aliases(component_id: &str) -> Vec<String> {
+    let mut aliases = vec![component_id.to_string()];
+    if let Some(stripped) = component_id.strip_prefix('/') {
+        aliases.push(stripped.to_string());
+    } else {
+        aliases.push(format!("/{component_id}"));
+    }
+    if let Some(stem) = component_id.rsplit('/').next() {
+        if !aliases.iter().any(|alias| alias == stem) {
+            aliases.push(stem.to_string());
+        }
+    }
+    aliases
+}
+
 #[derive(Debug)]
 pub struct RariModuleLoader {
     storage: ModuleStorage,
@@ -239,9 +254,17 @@ export default {{}};
         self.storage.set_module_code(specifier, code);
     }
 
+    pub fn register_component_specifier(&self, component_id: &str, specifier: &str) {
+        for alias in component_id_aliases(component_id) {
+            self.component_specifiers.insert(alias, specifier.to_string());
+        }
+    }
+
     pub fn get_component_specifier(&self, component_id: &str) -> Option<String> {
-        if let Some(spec) = self.component_specifiers.get(component_id) {
-            return Some(spec.value().clone());
+        for alias in component_id_aliases(component_id) {
+            if let Some(spec) = self.component_specifiers.get(&alias) {
+                return Some(spec.value().clone());
+            }
         }
 
         let component_stub = format!("file://{RARI_COMPONENT_PATH}component_{component_id}.js");

--- a/crates/rari/src/runtime/module_loader/core.rs
+++ b/crates/rari/src/runtime/module_loader/core.rs
@@ -125,11 +125,6 @@ fn component_id_aliases(component_id: &str) -> Vec<String> {
     } else {
         aliases.push(format!("/{component_id}"));
     }
-    if let Some(stem) = component_id.rsplit('/').next() {
-        if !aliases.iter().any(|alias| alias == stem) {
-            aliases.push(stem.to_string());
-        }
-    }
     aliases
 }
 
@@ -313,7 +308,9 @@ export default {{}};
             .unwrap_or(true);
 
         if should_remove_mapping {
-            self.component_specifiers.remove(component_id);
+            for alias in component_id_aliases(component_id) {
+                self.component_specifiers.remove(&alias);
+            }
         }
 
         self.storage.set_module_meta(format!("hmr_{component_specifier}"), false);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component-to-module resolution so specifier matching works across component ID variants (with or without a leading `/`).
  * Component specifiers are now registered and retrieved using alias-aware lookups, reducing missed mappings during module loading.
  * Updated cache clearing to ensure previously resolved specifier mappings are consistently removed for all supported ID aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->