### PR TITLE
chore: simplify build scripts by removing redundant clean command

### DIFF
--- a/packages/create-rari-app/package.json
+++ b/packages/create-rari-app/package.json
@@ -40,7 +40,7 @@
     "templates"
   ],
   "scripts": {
-    "build": "pnpm --silent clean && pnpm typecheck && vp pack",
+    "build": "pnpm typecheck && vp pack",
     "dev": "vp pack --watch",
     "clean": "node --eval \"import('node:fs').then(fs => fs.rmSync('dist', { recursive: true, force: true }))\"",
     "lint": "vp lint",

--- a/packages/rari/package.json
+++ b/packages/rari/package.json
@@ -106,7 +106,7 @@
     "node": ">=22.18.0"
   },
   "scripts": {
-    "build": "pnpm --silent clean && pnpm typecheck && vp pack",
+    "build": "pnpm typecheck && vp pack",
     "clean": "node --eval \"import('node:fs').then(fs => fs.rmSync('dist', { recursive: true, force: true }))\"",
     "lint": "vp lint",
     "lint:fix": "vp lint --fix",

--- a/packages/use-cache/package.json
+++ b/packages/use-cache/package.json
@@ -53,7 +53,7 @@
     "node": ">=22.18.0"
   },
   "scripts": {
-    "build": "pnpm --silent clean && pnpm typecheck && vp pack",
+    "build": "pnpm typecheck && vp pack",
     "clean": "node --eval \"import('node:fs').then(fs => fs.rmSync('dist', { recursive: true, force: true }))\"",
     "lint": "vp lint",
     "lint:fix": "vp lint --fix",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the build process across multiple packages by removing an automatic cleanup step before type checking and packaging.
  * Builds now run more directly, which should help reduce unnecessary work and speed up package builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->