### PR TITLE
feat: add redb backend for use cache remote storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ packages/use-cache-*/
 .pnpm-store/
 .build
 .cache
+*.redb
 coverage
 test-results
 playwright-report

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7476,6 +7476,7 @@ dependencies = [
  "parking_lot",
  "parley",
  "rari_error",
+ "redb",
  "redis",
  "regex",
  "reqwest",
@@ -7792,6 +7793,15 @@ dependencies = [
  "bytemuck",
  "font-types 0.12.0",
  "once_cell",
+]
+
+[[package]]
+name = "redb"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/crates/rari/Cargo.toml
+++ b/crates/rari/Cargo.toml
@@ -176,6 +176,7 @@ dashmap = "6.2.1"
 lru = "0.18.0"
 parking_lot = { workspace = true }
 redis = { version = "1.3.0", default-features = false, features = [ "tokio-comp" ] }
+redb = "4.1.0"
 regex = { workspace = true }
 rustc-hash = { workspace = true }
 smallvec = { workspace = true }

--- a/crates/rari/src/runtime/ext/mod.rs
+++ b/crates/rari/src/runtime/ext/mod.rs
@@ -85,7 +85,7 @@ pub fn extensions(options: &ExtensionOptions, is_snapshot: bool) -> Vec<Extensio
     extensions.extend(webidl::extensions(is_snapshot));
     extensions.extend(web::extensions(options.web.clone(), is_snapshot));
     extensions.extend(rari::extensions(is_snapshot));
-    extensions.extend(rari::redis_cache_extensions(is_snapshot));
+    extensions.extend(rari::cache::extensions(is_snapshot));
     extensions.extend(cache::extensions(options.cache, is_snapshot));
     extensions.extend(crypto::extensions(options.crypto_seed, is_snapshot));
     extensions.extend(fs::extensions(Arc::clone(&options.filesystem), is_snapshot));

--- a/crates/rari/src/runtime/ext/rari/cache/mod.rs
+++ b/crates/rari/src/runtime/ext/rari/cache/mod.rs
@@ -1,1 +1,77 @@
+use deno_core::Extension;
+
+use crate::server::config::CacheLayerConfig;
+
+pub mod redb_cache;
 pub mod redis_cache;
+
+fn remote_layer_has_url(layer: &CacheLayerConfig) -> bool {
+    layer.url.as_deref().map(str::trim).is_some_and(|url| !url.is_empty())
+}
+
+fn configured_remote_handler(layer: &CacheLayerConfig) -> Option<&'static str> {
+    match layer.handler.as_str() {
+        "test" => Some("test"),
+        "redis" if remote_layer_has_url(layer) => Some("redis"),
+        "redb" if remote_layer_has_url(layer) => Some("redb"),
+        _ => None,
+    }
+}
+
+pub fn extensions(is_snapshot: bool) -> Vec<Extension> {
+    let mut extensions = Vec::new();
+    extensions.extend(redis_cache::extensions(None, is_snapshot));
+    extensions.extend(redb_cache::extensions(None, is_snapshot));
+    extensions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{configured_remote_handler, remote_layer_has_url};
+    use crate::server::config::CacheLayerConfig;
+
+    fn layer(handler: &str, url: Option<&str>) -> CacheLayerConfig {
+        CacheLayerConfig {
+            handler: handler.to_string(),
+            url: url.map(String::from),
+            max_entries: 1000,
+            default_ttl_secs: 60,
+        }
+    }
+
+    #[test]
+    fn remote_layer_has_url_rejects_blank_values() {
+        assert!(!remote_layer_has_url(&layer("redis", None)));
+        assert!(!remote_layer_has_url(&layer("redis", Some(""))));
+        assert!(!remote_layer_has_url(&layer("redis", Some("   "))));
+        assert!(remote_layer_has_url(&layer("redis", Some("redis://localhost:6379"))));
+    }
+
+    #[test]
+    fn test_handler_is_configured() {
+        assert_eq!(configured_remote_handler(&layer("test", None)), Some("test"));
+    }
+
+    #[test]
+    fn redis_handler_requires_url() {
+        assert_eq!(
+            configured_remote_handler(&layer("redis", Some("redis://localhost:6379"))),
+            Some("redis")
+        );
+        assert_eq!(configured_remote_handler(&layer("redis", None)), None);
+    }
+
+    #[test]
+    fn redb_handler_requires_url() {
+        assert_eq!(
+            configured_remote_handler(&layer("redb", Some("/tmp/cache.redb"))),
+            Some("redb")
+        );
+        assert_eq!(configured_remote_handler(&layer("redb", None)), None);
+    }
+
+    #[test]
+    fn unknown_handler_is_not_configured() {
+        assert_eq!(configured_remote_handler(&layer("memory", None)), None);
+    }
+}

--- a/crates/rari/src/runtime/ext/rari/cache/redb_cache.rs
+++ b/crates/rari/src/runtime/ext/rari/cache/redb_cache.rs
@@ -5,6 +5,7 @@ use std::{
     fs::create_dir_all,
     io::Error,
     path::PathBuf,
+    process,
     rc::Rc,
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
@@ -22,7 +23,7 @@ const EXPIRY_NEVER: u64 = 0;
 const TABLE_NAME: &str = "use_cache_remote_entries";
 
 fn test_redb_path() -> PathBuf {
-    env::temp_dir().join("rari-use-cache-redb-test.redb")
+    env::temp_dir().join(format!("rari-use-cache-redb-test-{}.redb", process::id()))
 }
 
 const TABLE_DEFINITION: redb::TableDefinition<&str, &[u8]> = redb::TableDefinition::new(TABLE_NAME);

--- a/crates/rari/src/runtime/ext/rari/cache/redb_cache.rs
+++ b/crates/rari/src/runtime/ext/rari/cache/redb_cache.rs
@@ -1,0 +1,412 @@
+use std::{
+    cell::RefCell,
+    env,
+    fmt::Display,
+    fs::create_dir_all,
+    io::Error,
+    path::PathBuf,
+    rc::Rc,
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use deno_core::{Extension, OpState, extension, op2};
+use deno_error::JsErrorBox;
+use redb::ReadableDatabase;
+use tokio::task::{JoinError, spawn_blocking};
+
+use crate::{runtime::ext::ExtensionTrait, server::config::Config};
+
+const DEFAULT_TTL_SECS: u64 = 60;
+const EXPIRY_NEVER: u64 = 0;
+const TABLE_NAME: &str = "use_cache_remote_entries";
+
+fn test_redb_path() -> PathBuf {
+    env::temp_dir().join("rari-use-cache-redb-test.redb")
+}
+
+const TABLE_DEFINITION: redb::TableDefinition<&str, &[u8]> = redb::TableDefinition::new(TABLE_NAME);
+
+extension!(
+    rari_redb_cache,
+    ops = [op_redb_cache_get, op_redb_cache_set],
+    options = {},
+    state = |state, _options| {
+        state.put(Arc::new(RedbCacheState::from_config()));
+    },
+);
+
+impl ExtensionTrait<()> for rari_redb_cache {
+    fn init((): ()) -> Extension {
+        Self::init()
+    }
+}
+
+pub fn extensions(_options: Option<()>, is_snapshot: bool) -> Vec<Extension> {
+    vec![rari_redb_cache::build((), is_snapshot)]
+}
+
+pub struct RedbCacheState {
+    path: Option<PathBuf>,
+    default_ttl_secs: u64,
+    database: parking_lot::Mutex<Option<Arc<redb::Database>>>,
+}
+
+impl RedbCacheState {
+    pub fn from_config() -> Self {
+        let remote = Config::get().and_then(|config| config.use_cache.remote.as_ref());
+
+        let path = remote.and_then(|remote| match remote.handler.as_str() {
+            "test" => Some(test_redb_path()),
+            _ => remote.url.as_ref().map(PathBuf::from),
+        });
+        let default_ttl_secs =
+            remote.map(|remote| remote.default_ttl_secs).unwrap_or(DEFAULT_TTL_SECS);
+
+        Self { path, default_ttl_secs, database: parking_lot::Mutex::new(None) }
+    }
+
+    fn database(&self) -> Result<Arc<redb::Database>, RedbCacheError> {
+        let Some(path) = self.path.as_ref() else {
+            return Err(RedbCacheError::NotConfigured);
+        };
+
+        let mut guard = self.database.lock();
+        if let Some(db) = guard.as_ref() {
+            return Ok(Arc::clone(db));
+        }
+
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            create_dir_all(parent)?;
+        }
+
+        let db = redb::Database::create(path).map_err(redb::Error::from)?;
+        let arc = Arc::new(db);
+        *guard = Some(Arc::clone(&arc));
+        Ok(arc)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum RedbCacheError {
+    #[error("redb cache state is not initialized")]
+    StateMissing,
+    #[error("redb cache is not configured")]
+    NotConfigured,
+    #[error("redb: {0}")]
+    Op(#[from] redb::Error),
+    #[error("redb: {0}")]
+    Table(#[from] redb::TableError),
+    #[error("redb: {0}")]
+    Transaction(#[from] redb::TransactionError),
+    #[error("redb: {0}")]
+    Commit(#[from] redb::CommitError),
+    #[error("redb: {0}")]
+    Storage(#[from] redb::StorageError),
+    #[error("redb: {0}")]
+    Database(#[from] redb::DatabaseError),
+    #[error("redb io: {0}")]
+    Io(#[from] Error),
+    #[error("redb join: {0}")]
+    Join(#[from] JoinError),
+}
+
+fn expires_at_ms_from_ttl(ttl_ms: u32, default_ttl_secs: u64) -> Result<u64, RedbCacheError> {
+    let ttl_duration_ms =
+        if ttl_ms == 0 { default_ttl_secs.saturating_mul(1_000) } else { u64::from(ttl_ms) };
+
+    if ttl_duration_ms == 0 {
+        return Ok(EXPIRY_NEVER);
+    }
+
+    Ok(now_ms()?.saturating_add(ttl_duration_ms))
+}
+
+fn now_ms() -> Result<u64, RedbCacheError> {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| RedbCacheError::Io(Error::other(e.to_string())))?
+        .as_millis();
+    u64::try_from(millis)
+        .map_err(|_| RedbCacheError::Io(Error::other("system time millis exceeded u64")))
+}
+
+fn encode_entry(expires_at_ms: u64, payload: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(8 + payload.len());
+    buf.extend_from_slice(&expires_at_ms.to_be_bytes());
+    buf.extend_from_slice(payload);
+    buf
+}
+
+fn decode_entry(bytes: &[u8]) -> Option<(u64, &[u8])> {
+    if bytes.len() < 8 {
+        return None;
+    }
+    let mut arr = [0u8; 8];
+    arr.copy_from_slice(&bytes[..8]);
+    Some((u64::from_be_bytes(arr), &bytes[8..]))
+}
+
+fn js_error(error: &impl Display) -> JsErrorBox {
+    JsErrorBox::generic(error.to_string())
+}
+
+fn read_from_database(
+    database: &Arc<redb::Database>,
+    key: &str,
+) -> Result<Option<String>, RedbCacheError> {
+    let tx = database.begin_read()?;
+    let table = match tx.open_table(TABLE_DEFINITION) {
+        Ok(table) => table,
+        Err(redb::TableError::TableDoesNotExist(_)) => return Ok(None),
+        Err(err) => return Err(redb::Error::from(err).into()),
+    };
+
+    let Some(raw) = table.get(key)? else {
+        return Ok(None);
+    };
+    let bytes = raw.value();
+
+    let Some((expires_at_ms, payload)) = decode_entry(bytes) else {
+        return Ok(None);
+    };
+
+    if expires_at_ms != EXPIRY_NEVER && now_ms()? >= expires_at_ms {
+        drop(table);
+        drop(tx);
+        let _ = remove_expired(database, key);
+        return Ok(None);
+    }
+
+    Ok(String::from_utf8(payload.to_vec()).ok())
+}
+
+fn write_to_database(
+    database: &Arc<redb::Database>,
+    key: &str,
+    payload: &[u8],
+    expires_at_ms: u64,
+) -> Result<(), RedbCacheError> {
+    let encoded = encode_entry(expires_at_ms, payload);
+    let tx = database.begin_write()?;
+    {
+        let mut table = tx.open_table(TABLE_DEFINITION)?;
+        table.insert(key, encoded.as_slice())?;
+    }
+    tx.commit()?;
+    Ok(())
+}
+
+fn remove_expired(database: &Arc<redb::Database>, key: &str) -> Result<(), RedbCacheError> {
+    let tx = database.begin_write()?;
+    {
+        let mut table = tx.open_table(TABLE_DEFINITION)?;
+        let _ = table.remove(key)?;
+    }
+    tx.commit()?;
+    Ok(())
+}
+
+fn get_redb_state(state: &Rc<RefCell<OpState>>) -> Result<Arc<RedbCacheState>, RedbCacheError> {
+    state.borrow().try_borrow::<Arc<RedbCacheState>>().cloned().ok_or(RedbCacheError::StateMissing)
+}
+
+async fn run_redb<T, F>(f: F) -> Result<T, JsErrorBox>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, RedbCacheError> + Send + 'static,
+{
+    spawn_blocking(f).await.map_err(|e| js_error(&e))?.map_err(|e| js_error(&e))
+}
+
+#[op2]
+#[string]
+pub async fn op_redb_cache_get(
+    state: Rc<RefCell<OpState>>,
+    #[string] key: String,
+) -> Result<Option<String>, JsErrorBox> {
+    let redb_state = get_redb_state(&state).map_err(|e| js_error(&e))?;
+
+    run_redb(move || {
+        let database = redb_state.database()?;
+        read_from_database(&database, &key)
+    })
+    .await
+}
+
+#[op2]
+pub async fn op_redb_cache_set(
+    state: Rc<RefCell<OpState>>,
+    #[string] key: String,
+    #[string] value: String,
+    #[smi] ttl_ms: u32,
+) -> Result<(), JsErrorBox> {
+    let redb_state = get_redb_state(&state).map_err(|e| js_error(&e))?;
+    let default_ttl_secs = redb_state.default_ttl_secs;
+    let payload = value.into_bytes();
+    let expires_at_ms =
+        expires_at_ms_from_ttl(ttl_ms, default_ttl_secs).map_err(|e| js_error(&e))?;
+
+    run_redb(move || {
+        let database = redb_state.database()?;
+        write_to_database(&database, &key, &payload, expires_at_ms)
+    })
+    .await
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used)]
+mod tests {
+    use std::{fs, thread::sleep, time::Duration};
+
+    use redb::ReadableTable;
+
+    use super::*;
+
+    fn test_db_path(test_name: &str) -> PathBuf {
+        env::temp_dir().join(format!("rari-test-redb-cache-{test_name}.redb"))
+    }
+
+    fn open_temp_db(test_name: &str) -> Arc<redb::Database> {
+        let path = test_db_path(test_name);
+        if path.exists() {
+            let _ = fs::remove_file(&path);
+        }
+        Arc::new(redb::Database::create(&path).expect("create db"))
+    }
+
+    fn cleanup_expired_all(database: &Arc<redb::Database>) -> Result<usize, RedbCacheError> {
+        let now = now_ms()?;
+        let mut expired_keys: Vec<String> = Vec::new();
+        {
+            let tx = database.begin_read()?;
+            if let Ok(table) = tx.open_table(TABLE_DEFINITION) {
+                for entry in table.iter()? {
+                    let (key, value) = entry?;
+                    let Some((expires_at_ms, _)) = decode_entry(value.value()) else {
+                        continue;
+                    };
+                    if expires_at_ms != EXPIRY_NEVER && now >= expires_at_ms {
+                        expired_keys.push(key.value().to_string());
+                    }
+                }
+            }
+        }
+
+        if expired_keys.is_empty() {
+            return Ok(0);
+        }
+
+        let removed = expired_keys.len();
+        let tx = database.begin_write()?;
+        {
+            let mut table = tx.open_table(TABLE_DEFINITION)?;
+            for key in &expired_keys {
+                let _ = table.remove(key.as_str())?;
+            }
+        }
+        tx.commit()?;
+        Ok(removed)
+    }
+
+    #[test]
+    fn expires_at_ms_from_ttl_default_when_zero() {
+        let now = now_ms().expect("system time");
+        let expires = expires_at_ms_from_ttl(0, 60).expect("ttl");
+        assert!(expires >= now + 59_000);
+        assert!(expires <= now + 61_000);
+    }
+
+    #[test]
+    fn expires_at_ms_from_ttl_never_when_default_zero() {
+        let expires = expires_at_ms_from_ttl(0, 0).expect("ttl");
+        assert_eq!(expires, EXPIRY_NEVER);
+    }
+
+    #[test]
+    fn expires_at_ms_from_ttl_explicit_ttl() {
+        let now = now_ms().expect("system time");
+        let expires = expires_at_ms_from_ttl(5_000, 60).expect("ttl");
+        assert!(expires >= now + 4_500);
+        assert!(expires <= now + 5_500);
+    }
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let expires: u64 = 123_456_789;
+        let payload = b"hello world";
+        let encoded = encode_entry(expires, payload);
+        let (got_expires, got_payload) = decode_entry(&encoded).expect("decoded");
+        assert_eq!(got_expires, expires);
+        assert_eq!(got_payload, payload);
+    }
+
+    #[test]
+    fn decode_too_short_returns_none() {
+        assert!(decode_entry(&[1, 2, 3]).is_none());
+        assert!(decode_entry(&[]).is_none());
+    }
+
+    #[test]
+    fn write_then_read_roundtrip() {
+        let db = open_temp_db("write-then-read");
+        write_to_database(&db, "k1", b"hello", EXPIRY_NEVER).expect("write");
+        let got = read_from_database(&db, "k1").expect("read");
+        assert_eq!(got.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn read_missing_key_returns_none() {
+        let db = open_temp_db("read-missing");
+        let got = read_from_database(&db, "absent").expect("read");
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn expired_entry_returns_none_and_is_removed() {
+        let db = open_temp_db("expired-entry");
+        let expires_at = now_ms().expect("now").saturating_add(50);
+        write_to_database(&db, "k", b"x", expires_at).expect("write");
+
+        sleep(Duration::from_millis(120));
+
+        let got = read_from_database(&db, "k").expect("read");
+        assert!(got.is_none());
+
+        let tx = db.begin_read().expect("tx");
+        let table = tx.open_table(TABLE_DEFINITION).expect("table");
+        assert!(table.get("k").expect("get").is_none());
+    }
+
+    #[test]
+    fn never_expires_entry_persists_past_ttl_window() {
+        let db = open_temp_db("never-expires");
+        write_to_database(&db, "k", b"x", EXPIRY_NEVER).expect("write");
+        sleep(Duration::from_millis(80));
+        let got = read_from_database(&db, "k").expect("read");
+        assert_eq!(got.as_deref(), Some("x"));
+    }
+
+    #[test]
+    fn cleanup_expired_all_removes_only_expired() {
+        let db = open_temp_db("cleanup-expired");
+        let now = now_ms().expect("now");
+        write_to_database(&db, "expired1", b"a", now.saturating_sub(10)).expect("write 1");
+        write_to_database(&db, "expired2", b"b", now.saturating_sub(5)).expect("write 2");
+        write_to_database(&db, "fresh", b"c", now.saturating_add(60_000)).expect("write 3");
+        write_to_database(&db, "forever", b"d", EXPIRY_NEVER).expect("write 4");
+
+        let removed = cleanup_expired_all(&db).expect("cleanup");
+        assert_eq!(removed, 2);
+
+        let tx = db.begin_read().expect("tx");
+        let table = tx.open_table(TABLE_DEFINITION).expect("table");
+        assert!(table.get("expired1").expect("get").is_none());
+        assert!(table.get("expired2").expect("get").is_none());
+        assert!(table.get("fresh").expect("get").is_some());
+        assert!(table.get("forever").expect("get").is_some());
+    }
+}

--- a/crates/rari/src/runtime/ext/rari/cache/redis_cache.rs
+++ b/crates/rari/src/runtime/ext/rari/cache/redis_cache.rs
@@ -11,9 +11,11 @@ const DEFAULT_TTL_SECS: u64 = 60;
 const MS_PER_SEC: u64 = 1_000;
 const REDIS_TIMEOUT: Duration = Duration::from_secs(2);
 
+pub const TEST_REDIS_URL: &str = "redis://localhost:6379";
+
 extension!(
     rari_redis_cache,
-    ops = [op_cache_remote_get, op_cache_remote_set],
+    ops = [op_cache_remote_get, op_cache_remote_set, op_use_cache_remote_handler],
     options = {},
     state = |state, _options| {
         state.put(Arc::new(RedisCacheState::from_config()));
@@ -40,7 +42,10 @@ impl RedisCacheState {
     pub fn from_config() -> Self {
         let remote = Config::get().and_then(|config| config.use_cache.remote.as_ref());
 
-        let url = remote.and_then(|remote| remote.url.clone());
+        let url = remote.and_then(|remote| match remote.handler.as_str() {
+            "test" => Some(TEST_REDIS_URL.to_string()),
+            _ => remote.url.clone(),
+        });
         let default_ttl_secs =
             remote.map(|remote| remote.default_ttl_secs).unwrap_or(DEFAULT_TTL_SECS);
 
@@ -92,6 +97,14 @@ fn js_error(error: &impl Display) -> JsErrorBox {
     JsErrorBox::generic(error.to_string())
 }
 
+#[op2]
+#[string]
+pub fn op_use_cache_remote_handler() -> Option<String> {
+    Config::get()
+        .and_then(|config| config.use_cache.remote.as_ref())
+        .and_then(|layer| super::configured_remote_handler(layer).map(str::to_string))
+}
+
 fn get_redis_state(state: &Rc<RefCell<OpState>>) -> Result<Arc<RedisCacheState>, RedisCacheError> {
     state
         .borrow()
@@ -128,7 +141,13 @@ pub async fn op_cache_remote_set(
     let redis_state = get_redis_state(&state).map_err(|e| js_error(&e))?;
     let mut connection = redis_state.connection().await.map_err(|e| js_error(&e))?;
     let ttl_secs = if ttl_ms == 0 { redis_state.default_ttl_secs } else { ttl_ms_to_secs(ttl_ms) };
-    time::timeout(REDIS_TIMEOUT, connection.set_ex::<_, _, ()>(&key, value.into_bytes(), ttl_secs))
+    let bytes = value.into_bytes();
+    let fut: redis::RedisFuture<'_, ()> = if ttl_secs == 0 {
+        connection.set::<_, _, ()>(&key, bytes)
+    } else {
+        connection.set_ex::<_, _, ()>(&key, bytes, ttl_secs)
+    };
+    time::timeout(REDIS_TIMEOUT, fut)
         .await
         .map_err(|_| js_error(&"redis set timeout"))?
         .map_err(|e| js_error(&e))

--- a/crates/rari/src/runtime/ext/rari/mod.rs
+++ b/crates/rari/src/runtime/ext/rari/mod.rs
@@ -1,6 +1,5 @@
 pub mod cache;
 
-use cache::redis_cache;
 use deno_core::{Extension, extension};
 
 use super::ExtensionTrait;
@@ -41,8 +40,4 @@ impl ExtensionTrait<()> for rari {
 
 pub fn extensions(is_snapshot: bool) -> Vec<Extension> {
     vec![rari::build((), is_snapshot)]
-}
-
-pub fn redis_cache_extensions(is_snapshot: bool) -> Vec<Extension> {
-    redis_cache::extensions(None, is_snapshot)
 }

--- a/crates/rari/src/server/config.rs
+++ b/crates/rari/src/server/config.rs
@@ -648,14 +648,28 @@ impl Config {
                         let trimmed_url = layer.url.as_deref().map(str::trim);
                         let missing_url = trimmed_url.is_none_or(str::is_empty);
 
-                        if layer.handler == "redis" && missing_url {
-                            tracing::warn!(
-                                "Invalid useCache.remote: handler=redis requires a non-empty url. Ignoring remote cache config."
-                            );
-                        } else {
-                            // Store the trimmed URL
-                            layer.url = trimmed_url.map(String::from);
-                            config.use_cache.remote = Some(layer);
+                        match layer.handler.as_str() {
+                            "test" if config.mode == Mode::Production => {
+                                tracing::warn!(
+                                    "Invalid useCache.remote: handler='test' is for e2e tests only and is not allowed in production. Ignoring remote cache config."
+                                );
+                            }
+                            "redis" | "redb" if missing_url => {
+                                tracing::warn!(
+                                    "Invalid useCache.remote: handler={} requires a non-empty url. Ignoring remote cache config.",
+                                    layer.handler
+                                );
+                            }
+                            "redis" | "redb" | "test" => {
+                                layer.url = trimmed_url.map(String::from);
+                                config.use_cache.remote = Some(layer);
+                            }
+                            _ => {
+                                tracing::warn!(
+                                    "Invalid useCache.remote: handler='{}' is not supported (allowed: test, redis, redb). Ignoring remote cache config.",
+                                    layer.handler
+                                );
+                            }
                         }
                     }
                     Err(e) => {

--- a/packages/rari/src/vite/index.ts
+++ b/packages/rari/src/vite/index.ts
@@ -1002,7 +1002,7 @@ if (import.meta.hot) {
 
       const originalCode = code
       let wasUseCacheTransformed = false
-      if (options.experimental?.useCache) {
+      if (options.experimental?.useCache || options.experimental?.useCacheRemote) {
         const transform = await getUseCacheTransform()
         if (transform) {
           const useCacheResult = transform(code, id)

--- a/packages/rari/src/vite/server-build.ts
+++ b/packages/rari/src/vite/server-build.ts
@@ -1034,7 +1034,7 @@ export default registerClientReference(null, ${JSON.stringify(componentId)}, "de
       {
         name: 'use-cache',
         async transform(code: string, id: string) {
-          if (!self.options.experimental?.useCache)
+          if (!self.options.experimental?.useCache && !self.options.experimental?.useCacheRemote)
             return null
 
           const transform = await getUseCacheTransform()
@@ -1235,6 +1235,11 @@ export default registerClientReference(null, ${JSON.stringify(componentId)}, "de
     if (this.options.experimental?.useCacheRemote) {
       serverConfig.useCache = {
         remote: this.options.experimental.useCacheRemote,
+      }
+      if (!this.options.experimental.useCache) {
+        console.warn(
+          '[server-build] experimental.useCacheRemote is set without experimental.useCache; the \'use cache\' transform will still run because useCacheRemote is configured.',
+        )
       }
     }
 

--- a/packages/use-cache/package.json
+++ b/packages/use-cache/package.json
@@ -34,26 +34,6 @@
       "types": "./dist/runtime/cache-wrapper.d.mts",
       "import": "./dist/runtime/cache-wrapper.mjs",
       "default": "./dist/runtime/cache-wrapper.mjs"
-    },
-    "./runtime/deterministic-stringify": {
-      "types": "./dist/runtime/deterministic-stringify.d.mts",
-      "import": "./dist/runtime/deterministic-stringify.mjs",
-      "default": "./dist/runtime/deterministic-stringify.mjs"
-    },
-    "./runtime/cache-storage-redb": {
-      "types": "./dist/runtime/cache-storage-redb.d.mts",
-      "import": "./dist/runtime/cache-storage-redb.mjs",
-      "default": "./dist/runtime/cache-storage-redb.mjs"
-    },
-    "./runtime/cache-storage-remote-ops": {
-      "types": "./dist/runtime/cache-storage-remote-ops.d.mts",
-      "import": "./dist/runtime/cache-storage-remote-ops.mjs",
-      "default": "./dist/runtime/cache-storage-remote-ops.mjs"
-    },
-    "./runtime/cache-storage-test": {
-      "types": "./dist/runtime/cache-storage-test.d.mts",
-      "import": "./dist/runtime/cache-storage-test.mjs",
-      "default": "./dist/runtime/cache-storage-test.mjs"
     }
   },
   "main": "./dist/index.mjs",

--- a/packages/use-cache/package.json
+++ b/packages/use-cache/package.json
@@ -39,6 +39,21 @@
       "types": "./dist/runtime/deterministic-stringify.d.mts",
       "import": "./dist/runtime/deterministic-stringify.mjs",
       "default": "./dist/runtime/deterministic-stringify.mjs"
+    },
+    "./runtime/cache-storage-redb": {
+      "types": "./dist/runtime/cache-storage-redb.d.mts",
+      "import": "./dist/runtime/cache-storage-redb.mjs",
+      "default": "./dist/runtime/cache-storage-redb.mjs"
+    },
+    "./runtime/cache-storage-remote-ops": {
+      "types": "./dist/runtime/cache-storage-remote-ops.d.mts",
+      "import": "./dist/runtime/cache-storage-remote-ops.mjs",
+      "default": "./dist/runtime/cache-storage-remote-ops.mjs"
+    },
+    "./runtime/cache-storage-test": {
+      "types": "./dist/runtime/cache-storage-test.d.mts",
+      "import": "./dist/runtime/cache-storage-test.mjs",
+      "default": "./dist/runtime/cache-storage-test.mjs"
     }
   },
   "main": "./dist/index.mjs",

--- a/packages/use-cache/src/runtime/cache-storage-redb.ts
+++ b/packages/use-cache/src/runtime/cache-storage-redb.ts
@@ -1,0 +1,12 @@
+import type { CacheStorage } from './cache-storage'
+import { hasRemoteOps, RemoteOpsCacheStorage } from './cache-storage-remote-ops'
+
+export const REDB_CACHE_OPS = { get: 'op_redb_cache_get', set: 'op_redb_cache_set' } as const
+
+export function createRedbCacheStorage(): CacheStorage {
+  return new RemoteOpsCacheStorage(REDB_CACHE_OPS)
+}
+
+export function hasRedbOps(): boolean {
+  return hasRemoteOps(REDB_CACHE_OPS)
+}

--- a/packages/use-cache/src/runtime/cache-storage-redis.ts
+++ b/packages/use-cache/src/runtime/cache-storage-redis.ts
@@ -1,74 +1,12 @@
 import type { CacheStorage } from './cache-storage'
+import { hasRemoteOps, RemoteOpsCacheStorage } from './cache-storage-remote-ops'
 
-interface RemoteCacheOps {
-  op_cache_remote_get: (key: string) => Promise<string | null> | string | null
-  op_cache_remote_set: (key: string, value: string, ttlMs: number) => Promise<void> | void
+export const REDIS_CACHE_OPS = { get: 'op_cache_remote_get', set: 'op_cache_remote_set' } as const
+
+export function createRedisCacheStorage(): CacheStorage {
+  return new RemoteOpsCacheStorage(REDIS_CACHE_OPS)
 }
-
-interface RuntimeLike {
-  Deno?: {
-    core?: {
-      ops?: RemoteCacheOps
-    }
-  }
-}
-
-const runtime = globalThis as RuntimeLike
 
 export function hasRedisOps(): boolean {
-  const { ops } = runtime.Deno?.core || {}
-
-  return Boolean(
-    ops
-    && typeof ops.op_cache_remote_get === 'function'
-    && typeof ops.op_cache_remote_set === 'function',
-  )
-}
-
-export class RedisCacheStorage implements CacheStorage {
-  async read(key: string) {
-    const ops = runtime.Deno?.core?.ops
-    let text: string | null = null
-    try {
-      text = await ops?.op_cache_remote_get(key) ?? null
-    }
-    catch (err) {
-      console.error(`[rari] redis cache read failed for key="${key}":`, err)
-    }
-
-    if (!text)
-      return null
-
-    try {
-      return { value: JSON.parse(text) }
-    }
-    catch (err) {
-      console.error(`[rari] redis cache value parse failed for key="${key}":`, err)
-      return null
-    }
-  }
-
-  async write(key: string, value: unknown, ttlMs: number): Promise<void> {
-    const ops = runtime.Deno?.core?.ops
-
-    let serialized: string
-    try {
-      serialized = JSON.stringify(value)
-    }
-    catch (err) {
-      console.error(`[rari] redis cache value not serializable for key="${key}":`, err)
-      return
-    }
-    if (serialized === undefined) {
-      console.error(`[rari] redis cache value not serializable for key="${key}" (got undefined from JSON.stringify)`)
-      return
-    }
-
-    try {
-      await ops?.op_cache_remote_set(key, serialized, ttlMs)
-    }
-    catch (err) {
-      console.error(`[rari] redis cache write failed for key="${key}":`, err)
-    }
-  }
+  return hasRemoteOps(REDIS_CACHE_OPS)
 }

--- a/packages/use-cache/src/runtime/cache-storage-registry.ts
+++ b/packages/use-cache/src/runtime/cache-storage-registry.ts
@@ -39,9 +39,6 @@ function remoteStorageFromAvailableOps(): CacheStorage | undefined {
 
 export function getStorage(kind: string): CacheStorage {
   if (kind === 'remote') {
-    if (getTestStorageBackend() !== undefined)
-      return backends.test()
-
     const configured = remoteStorageFromConfiguredHandler()
     if (configured)
       return configured

--- a/packages/use-cache/src/runtime/cache-storage-registry.ts
+++ b/packages/use-cache/src/runtime/cache-storage-registry.ts
@@ -1,20 +1,55 @@
 import type { CacheStorage } from './cache-storage'
 import { MemoryCacheStorage } from './cache-storage-memory'
-import { hasRedisOps, RedisCacheStorage } from './cache-storage-redis'
+import { createRedbCacheStorage, hasRedbOps } from './cache-storage-redb'
+import { createRedisCacheStorage, hasRedisOps } from './cache-storage-redis'
+import { getConfiguredRemoteHandler } from './cache-storage-remote-ops'
+import { getTestStorageBackend, TestCacheStorage } from './cache-storage-test'
 
 let memoryStorage: CacheStorage | undefined
+let redbStorage: CacheStorage | undefined
 let redisStorage: CacheStorage | undefined
+
+const backends = {
+  test: (): CacheStorage => new TestCacheStorage(),
+  redb: (): CacheStorage => (redbStorage ??= createRedbCacheStorage()),
+  redis: (): CacheStorage => (redisStorage ??= createRedisCacheStorage()),
+  memory: (): CacheStorage => (memoryStorage ??= new MemoryCacheStorage()),
+}
+
+function remoteStorageFromConfiguredHandler(): CacheStorage | undefined {
+  const handler = getConfiguredRemoteHandler()
+  if (handler === 'test')
+    return getTestStorageBackend() !== undefined ? backends.test() : undefined
+  if (handler === 'redb' && hasRedbOps())
+    return backends.redb()
+  if (handler === 'redis' && hasRedisOps())
+    return backends.redis()
+
+  return undefined
+}
+
+function remoteStorageFromAvailableOps(): CacheStorage | undefined {
+  if (hasRedbOps())
+    return backends.redb()
+  if (hasRedisOps())
+    return backends.redis()
+
+  return undefined
+}
 
 export function getStorage(kind: string): CacheStorage {
   if (kind === 'remote') {
-    if (!redisStorage && hasRedisOps())
-      redisStorage = new RedisCacheStorage()
-    if (redisStorage)
-      return redisStorage
+    if (getTestStorageBackend() !== undefined)
+      return backends.test()
+
+    const configured = remoteStorageFromConfiguredHandler()
+    if (configured)
+      return configured
+
+    const fallback = remoteStorageFromAvailableOps()
+    if (fallback)
+      return fallback
   }
 
-  if (!memoryStorage)
-    memoryStorage = new MemoryCacheStorage()
-
-  return memoryStorage
+  return backends.memory()
 }

--- a/packages/use-cache/src/runtime/cache-storage-registry.ts
+++ b/packages/use-cache/src/runtime/cache-storage-registry.ts
@@ -28,24 +28,11 @@ function remoteStorageFromConfiguredHandler(): CacheStorage | undefined {
   return undefined
 }
 
-function remoteStorageFromAvailableOps(): CacheStorage | undefined {
-  if (hasRedbOps())
-    return backends.redb()
-  if (hasRedisOps())
-    return backends.redis()
-
-  return undefined
-}
-
 export function getStorage(kind: string): CacheStorage {
   if (kind === 'remote') {
     const configured = remoteStorageFromConfiguredHandler()
     if (configured)
       return configured
-
-    const fallback = remoteStorageFromAvailableOps()
-    if (fallback)
-      return fallback
   }
 
   return backends.memory()

--- a/packages/use-cache/src/runtime/cache-storage-remote-ops.ts
+++ b/packages/use-cache/src/runtime/cache-storage-remote-ops.ts
@@ -1,0 +1,91 @@
+import type { CacheStorage } from './cache-storage'
+
+type CacheOpFn = ((...args: unknown[]) => unknown) | undefined
+
+interface RuntimeLike {
+  Deno?: {
+    core?: {
+      ops?: Record<string, CacheOpFn>
+    }
+  }
+}
+
+const runtime = globalThis as RuntimeLike
+
+export interface RemoteCacheOps {
+  get: string
+  set: string
+}
+
+export class RemoteOpsCacheStorage implements CacheStorage {
+  constructor(private readonly ops: RemoteCacheOps) {}
+
+  async read(key: string) {
+    const fn = runtime.Deno?.core?.ops?.[this.ops.get]
+    let text: string | null = null
+    try {
+      const result = await fn?.(key)
+      text = typeof result === 'string' ? result : null
+    }
+    catch (err) {
+      console.error(`[rari] ${this.ops.get} read failed for key="${key}":`, err)
+      return null
+    }
+
+    if (!text)
+      return null
+    try {
+      return { value: JSON.parse(text) }
+    }
+    catch (err) {
+      console.error(`[rari] ${this.ops.get} value parse failed for key="${key}":`, err)
+      return null
+    }
+  }
+
+  async write(key: string, value: unknown, ttlMs: number) {
+    const fn = runtime.Deno?.core?.ops?.[this.ops.set]
+
+    let serialized: string
+    try {
+      serialized = JSON.stringify(value)
+    }
+    catch (err) {
+      console.error(`[rari] ${this.ops.set} value not serializable for key="${key}":`, err)
+      return
+    }
+    if (serialized === undefined) {
+      console.error(`[rari] ${this.ops.set} value not serializable for key="${key}" (got undefined from JSON.stringify)`)
+      return
+    }
+
+    try {
+      await fn?.(key, serialized, ttlMs)
+    }
+    catch (err) {
+      console.error(`[rari] ${this.ops.set} write failed for key="${key}":`, err)
+    }
+  }
+}
+
+export function hasRemoteOps(ops: RemoteCacheOps) {
+  const found = runtime.Deno?.core?.ops
+  return Boolean(
+    found
+    && typeof found[ops.get] === 'function'
+    && typeof found[ops.set] === 'function',
+  )
+}
+
+export type RemoteCacheHandler = 'redis' | 'redb' | 'test'
+
+export function getConfiguredRemoteHandler(): RemoteCacheHandler | undefined {
+  const fn = runtime.Deno?.core?.ops?.op_use_cache_remote_handler
+  if (typeof fn !== 'function')
+    return undefined
+  const handler = fn()
+  if (handler === 'redis' || handler === 'redb' || handler === 'test')
+    return handler
+
+  return undefined
+}

--- a/packages/use-cache/src/runtime/cache-storage-remote-ops.ts
+++ b/packages/use-cache/src/runtime/cache-storage-remote-ops.ts
@@ -46,7 +46,7 @@ export class RemoteOpsCacheStorage implements CacheStorage {
   async write(key: string, value: unknown, ttlMs: number) {
     const fn = runtime.Deno?.core?.ops?.[this.ops.set]
 
-    let serialized: string
+    let serialized: string | undefined
     try {
       serialized = JSON.stringify(value)
     }

--- a/packages/use-cache/src/runtime/cache-storage-test.ts
+++ b/packages/use-cache/src/runtime/cache-storage-test.ts
@@ -1,0 +1,43 @@
+import type { CacheStorage } from './cache-storage'
+import { createRedbCacheStorage, REDB_CACHE_OPS } from './cache-storage-redb'
+import { createRedisCacheStorage, REDIS_CACHE_OPS } from './cache-storage-redis'
+import { hasRemoteOps } from './cache-storage-remote-ops'
+
+export type TestStorageBackend = 'redb' | 'redis'
+
+let backend: TestStorageBackend | undefined
+
+export function setTestStorageBackend(next: TestStorageBackend) {
+  backend = next
+}
+
+export function resetTestStorageBackend() {
+  backend = undefined
+}
+
+export function getTestStorageBackend(): TestStorageBackend | undefined {
+  return backend
+}
+
+function backendOps(next: TestStorageBackend) {
+  return next === 'redis' ? REDIS_CACHE_OPS : REDB_CACHE_OPS
+}
+
+export class TestCacheStorage implements CacheStorage {
+  private readonly storage: CacheStorage
+  constructor() {
+    if (!backend)
+      throw new Error('TestCacheStorage: setTestStorageBackend() must be called first')
+    if (!hasRemoteOps(backendOps(backend)))
+      throw new Error(`TestCacheStorage: requested backend '${backend}' ops are not available`)
+    this.storage = backend === 'redis' ? createRedisCacheStorage() : createRedbCacheStorage()
+  }
+
+  read(key: string) {
+    return this.storage.read(key)
+  }
+
+  write(key: string, value: unknown, ttlMs: number) {
+    return this.storage.write(key, value, ttlMs)
+  }
+}

--- a/packages/use-cache/src/runtime/cache-storage.ts
+++ b/packages/use-cache/src/runtime/cache-storage.ts
@@ -1,5 +1,3 @@
-export type CacheStorageKind = 'memory' | 'redis'
-
 export interface CacheStorage {
   read: (key: string) => Promise<CacheStorageEntry | null>
   write: (key: string, value: unknown, ttlMs: number) => Promise<void>

--- a/packages/use-cache/src/runtime/cache-wrapper.ts
+++ b/packages/use-cache/src/runtime/cache-wrapper.ts
@@ -3,6 +3,9 @@ import { serialize } from 'node:v8'
 import { getStorage } from './cache-storage-registry'
 import { deterministicStringify } from './deterministic-stringify'
 
+export { setTestStorageBackend } from './cache-storage-test'
+export type { TestStorageBackend } from './cache-storage-test'
+
 type CacheableFunction<Args extends unknown[]> = (...args: Args) => unknown | Promise<unknown>
 
 const CACHE_ENTRY_TTL_MS = 5 * 60 * 1000

--- a/packages/use-cache/vite.config.ts
+++ b/packages/use-cache/vite.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
     entry: {
       'index': 'src/index.ts',
       'runtime/cache-wrapper': 'src/runtime/cache-wrapper.ts',
+      'runtime/cache-storage-redb': 'src/runtime/cache-storage-redb.ts',
+      'runtime/cache-storage-remote-ops': 'src/runtime/cache-storage-remote-ops.ts',
+      'runtime/cache-storage-test': 'src/runtime/cache-storage-test.ts',
       'runtime/deterministic-stringify': 'src/runtime/deterministic-stringify.ts',
     },
     minify: true,

--- a/packages/use-cache/vite.config.ts
+++ b/packages/use-cache/vite.config.ts
@@ -5,10 +5,6 @@ export default defineConfig({
     entry: {
       'index': 'src/index.ts',
       'runtime/cache-wrapper': 'src/runtime/cache-wrapper.ts',
-      'runtime/cache-storage-redb': 'src/runtime/cache-storage-redb.ts',
-      'runtime/cache-storage-remote-ops': 'src/runtime/cache-storage-remote-ops.ts',
-      'runtime/cache-storage-test': 'src/runtime/cache-storage-test.ts',
-      'runtime/deterministic-stringify': 'src/runtime/deterministic-stringify.ts',
     },
     minify: true,
   },

--- a/test/e2e/use-cache-remote.spec.ts
+++ b/test/e2e/use-cache-remote.spec.ts
@@ -1,19 +1,35 @@
+import type { Page } from '@playwright/test'
 import { expect, test } from '@playwright/test'
 
-test.describe('use cache: remote', () => {
-  test('caches function results within and across requests', async ({ page }) => {
-    async function expectCachePage() {
-      await expect(page.locator('[data-testid="result1"]')).toHaveText('first')
-      await expect(page.locator('[data-testid="result2"]')).toHaveText('first')
-      await expect(page.locator('[data-testid="result3"]')).toHaveText('second')
-      return page.locator('[data-testid="totals"]').textContent()
-    }
+async function expectCachePage(page: Page) {
+  await expect(page.locator('[data-testid="result1"]')).toHaveText('first')
+  await expect(page.locator('[data-testid="result2"]')).toHaveText('first')
+  await expect(page.locator('[data-testid="result3"]')).toHaveText('second')
+  return page.locator('[data-testid="totals"]').textContent()
+}
 
-    await page.goto('/use-cache-remote?case=cache')
-    const totalsAfterFirst = await expectCachePage()
+test.describe('use cache: remote (TestCacheStorage)', () => {
+  test('?backend=redis caches function results within and across requests', async ({ page }, testInfo) => {
+    const cacheCase = `cache-${testInfo.project.name.replace(/\W+/g, '-')}-${Date.now()}`
 
-    await page.goto('/use-cache-remote?case=cache')
-    await expectCachePage()
+    await page.goto(`/use-cache-remote?backend=redis&case=${cacheCase}`)
+    const totalsAfterFirst = await expectCachePage(page)
+    expect(totalsAfterFirst?.replace(/\s+/g, ' ')).toContain('calls: 2')
+
+    await page.goto(`/use-cache-remote?backend=redis&case=${cacheCase}`)
+    await expectCachePage(page)
+    await expect(page.locator('[data-testid="totals"]')).toHaveText(totalsAfterFirst || '')
+  })
+
+  test('?backend=redb caches function results within and across requests', async ({ page }, testInfo) => {
+    const cacheCase = `cache-${testInfo.project.name.replace(/\W+/g, '-')}-${Date.now()}`
+
+    await page.goto(`/use-cache-remote?backend=redb&case=${cacheCase}`)
+    const totalsAfterFirst = await expectCachePage(page)
+    expect(totalsAfterFirst?.replace(/\s+/g, ' ')).toContain('calls: 2')
+
+    await page.goto(`/use-cache-remote?backend=redb&case=${cacheCase}`)
+    await expectCachePage(page)
     await expect(page.locator('[data-testid="totals"]')).toHaveText(totalsAfterFirst || '')
   })
 })

--- a/test/fixtures/app/src/app/use-cache-remote/page.tsx
+++ b/test/fixtures/app/src/app/use-cache-remote/page.tsx
@@ -1,6 +1,6 @@
-import type { TestStorageBackend } from '@rari/use-cache/runtime/cache-storage-test'
+import type { TestStorageBackend } from '@rari/use-cache/runtime/cache-wrapper'
 import type { Metadata } from 'rari'
-import { setTestStorageBackend } from '@rari/use-cache/runtime/cache-storage-test'
+import { setTestStorageBackend } from '@rari/use-cache/runtime/cache-wrapper'
 
 type SearchBackend = TestStorageBackend | undefined
 

--- a/test/fixtures/app/src/app/use-cache-remote/page.tsx
+++ b/test/fixtures/app/src/app/use-cache-remote/page.tsx
@@ -1,16 +1,26 @@
+import type { TestStorageBackend } from '@rari/use-cache/runtime/cache-storage-test'
 import type { Metadata } from 'rari'
+import { setTestStorageBackend } from '@rari/use-cache/runtime/cache-storage-test'
 
-let callCount = 0
+type SearchBackend = TestStorageBackend | undefined
+
+function normalizeBackend(value: string | string[] | undefined): TestStorageBackend {
+  const raw = Array.isArray(value) ? value[0] : value
+  return raw === 'redis' ? 'redis' : 'redb'
+}
+
+const callCounts = new Map<string, number>()
 
 async function getCachedData(label: string, cacheScope: string) {
   'use cache: remote'
-  void cacheScope
-  callCount++
+  callCounts.set(cacheScope, (callCounts.get(cacheScope) ?? 0) + 1)
   return label
 }
 
-export default async function UseCacheRemotePage({ searchParams }: { searchParams?: { case?: string } }) {
+export default async function UseCacheRemotePage({ searchParams }: { searchParams?: { case?: string, backend?: SearchBackend } }) {
+  setTestStorageBackend(normalizeBackend(searchParams?.backend))
   const cacheScope = searchParams?.case ?? 'default'
+
   const result1 = await getCachedData('first', cacheScope)
   const result2 = await getCachedData('first', cacheScope)
   const result3 = await getCachedData('second', cacheScope)
@@ -22,8 +32,7 @@ export default async function UseCacheRemotePage({ searchParams }: { searchParam
       <p data-testid="result2">{result2}</p>
       <p data-testid="result3">{result3}</p>
       <p data-testid="totals">
-        calls:
-        {callCount}
+        {`calls: ${callCounts.get(cacheScope) ?? 0}`}
       </p>
     </div>
   )

--- a/test/fixtures/app/tsconfig.json
+++ b/test/fixtures/app/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "../../../.config/typescript/app.json",
   "compilerOptions": {
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@rari/use-cache/runtime/*": ["../../../packages/use-cache/src/runtime/*"],
+      "@rari/use-cache": ["../../../packages/use-cache/src/index"]
     }
   },
   "include": ["src"]

--- a/test/fixtures/app/tsconfig.json
+++ b/test/fixtures/app/tsconfig.json
@@ -2,9 +2,7 @@
   "extends": "../../../.config/typescript/app.json",
   "compilerOptions": {
     "paths": {
-      "@/*": ["./src/*"],
-      "@rari/use-cache/runtime/*": ["../../../packages/use-cache/src/runtime/*"],
-      "@rari/use-cache": ["../../../packages/use-cache/src/index"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src"]

--- a/test/fixtures/app/vite.config.ts
+++ b/test/fixtures/app/vite.config.ts
@@ -18,7 +18,6 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(import.meta.dirname, 'src'),
-      '@rari/use-cache': path.resolve(import.meta.dirname, '../../../packages/use-cache/src'),
     },
   },
 })

--- a/test/fixtures/app/vite.config.ts
+++ b/test/fixtures/app/vite.config.ts
@@ -9,8 +9,7 @@ export default defineConfig({
       experimental: {
         useCache: true,
         useCacheRemote: {
-          handler: 'redis',
-          url: 'redis://localhost:6379/15',
+          handler: 'test',
         },
       },
     }),
@@ -19,6 +18,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(import.meta.dirname, 'src'),
+      '@rari/use-cache': path.resolve(import.meta.dirname, '../../../packages/use-cache/src'),
     },
   },
 })

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "paths": {
+      "@rari/logger": ["../packages/logger/src/index"],
+      "@rari/use-cache/runtime/*": ["../packages/use-cache/src/runtime/*"],
+      "@rari/use-cache": ["../packages/use-cache/src/index"],
       "@rari/*": ["../packages/rari/src/*"]
     },
     "types": ["node"]

--- a/test/unit/cli-project-context.test.ts
+++ b/test/unit/cli-project-context.test.ts
@@ -1,9 +1,8 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { detectPackageManager } from '@rari/cli'
 import { describe, expect, it } from 'vite-plus/test'
-// eslint-disable-next-line antfu/no-import-dist
-import { detectPackageManager } from '../../packages/rari/dist/cli.mjs'
 
 describe('cli project context', () => {
   it('detects bun from bun.lock', () => {

--- a/test/unit/mdx/define-mdx-components.test.ts
+++ b/test/unit/mdx/define-mdx-components.test.ts
@@ -1,7 +1,7 @@
+import { defineMdxComponents } from '@rari/mdx/define-mdx-components'
 import { describe, expect, it, vi } from 'vite-plus/test'
-import { defineMdxComponents } from '../../../packages/rari/src/mdx/define-mdx-components'
 
-vi.mock('../../../packages/rari/src/runtime/rsc-references', () => ({
+vi.mock('@rari/runtime/rsc-references', () => ({
   registerClientReference: (proxy: unknown) => proxy,
 }))
 

--- a/test/unit/mdx/mdx-components-transform.test.ts
+++ b/test/unit/mdx/mdx-components-transform.test.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { transformDefineMdxComponents } from '@rari/vite/mdx-components-transform'
 import { describe, expect, it } from 'vite-plus/test'
-import { transformDefineMdxComponents } from '../../../packages/rari/src/vite/mdx-components-transform'
 
 describe('transformDefineMdxComponents', () => {
   it('expands component imports with project-relative ids and client detection', () => {

--- a/test/unit/mdx/mdx-registry.test.ts
+++ b/test/unit/mdx/mdx-registry.test.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { discoverMdxRegistryEntries, generateMdxRegistryModule, isMdxRegistryModuleId } from '@rari/vite/mdx-registry'
+import { ModuleAnalysisCache } from '@rari/vite/module-analysis-cache'
 import { describe, expect, it } from 'vite-plus/test'
-import { discoverMdxRegistryEntries, generateMdxRegistryModule, isMdxRegistryModuleId } from '../../../packages/rari/src/vite/mdx-registry'
-import { ModuleAnalysisCache } from '../../../packages/rari/src/vite/module-analysis-cache'
 
 describe('mdx registry', () => {
   it('discovers only client components referenced in MDX content', () => {

--- a/test/unit/runtime/cache-storage-redb.test.ts
+++ b/test/unit/runtime/cache-storage-redb.test.ts
@@ -1,0 +1,105 @@
+import type { MockBackend } from './deno-mock'
+import { createRedbCacheStorage, hasRedbOps } from '@rari/use-cache/runtime/cache-storage-redb'
+import { afterEach, describe, expect, it } from 'vite-plus/test'
+import { patchDenoBackend, restoreDeno } from './deno-mock'
+
+function installRedbOpsMock(backend: MockBackend) {
+  patchDenoBackend(
+    { get: 'op_redb_cache_get', set: 'op_redb_cache_set' },
+    backend,
+  )
+}
+
+function uninstallRedbOpsMock(): void {
+  restoreDeno()
+}
+
+function makeBackend(): MockBackend {
+  const store = new Map<string, string>()
+  return {
+    read: key => store.get(key) ?? null,
+    write: (key, value) => {
+      store.set(key, value)
+    },
+  }
+}
+
+describe('redbCacheStorage', () => {
+  afterEach(() => {
+    uninstallRedbOpsMock()
+  })
+
+  it('hasRedbOps returns true when both ops are present', () => {
+    installRedbOpsMock(makeBackend())
+    expect(hasRedbOps()).toBe(true)
+  })
+
+  it('hasRedbOps returns false when ops missing', () => {
+    uninstallRedbOpsMock()
+    expect(hasRedbOps()).toBe(false)
+  })
+
+  it('read returns null when key is missing', async () => {
+    const redbCacheStorage = createRedbCacheStorage()
+    installRedbOpsMock(makeBackend())
+    expect(await redbCacheStorage.read('absent')).toBeNull()
+  })
+
+  it('write then read roundtrips a serializable value', async () => {
+    const redbCacheStorage = createRedbCacheStorage()
+    installRedbOpsMock(makeBackend())
+    await redbCacheStorage.write('k1', { hello: 'world' }, 60_000)
+    const got = await redbCacheStorage.read('k1')
+    expect(got).toEqual({ value: { hello: 'world' } })
+  })
+
+  it('read returns null when stored value is not valid JSON', async () => {
+    const redbCacheStorage = createRedbCacheStorage()
+    const backend: MockBackend = {
+      read: () => '{not json',
+      write: () => {},
+    }
+    installRedbOpsMock(backend)
+    expect(await redbCacheStorage.read('corrupt')).toBeNull()
+  })
+
+  it('read swallows backend errors and returns null', async () => {
+    const redbCacheStorage = createRedbCacheStorage()
+    const backend: MockBackend = {
+      read: () => {
+        throw new Error('boom')
+      },
+      write: () => {},
+    }
+    installRedbOpsMock(backend)
+    expect(await redbCacheStorage.read('broken')).toBeNull()
+  })
+
+  it('write swallows backend errors', async () => {
+    const redbCacheStorage = createRedbCacheStorage()
+    const backend: MockBackend = {
+      read: () => null,
+      write: () => {
+        throw new Error('write boom')
+      },
+    }
+    installRedbOpsMock(backend)
+    await expect(redbCacheStorage.write('k', 'v', 1000)).resolves.toBeUndefined()
+  })
+
+  it('write short-circuits when value is not serializable', async () => {
+    const redbCacheStorage = createRedbCacheStorage()
+    let written = false
+    const backend: MockBackend = {
+      read: () => null,
+      write: () => {
+        written = true
+      },
+    }
+    installRedbOpsMock(backend)
+    await redbCacheStorage.write('k', () => {
+      throw new Error('not json')
+    }, 1000)
+    expect(written).toBe(false)
+  })
+})

--- a/test/unit/runtime/cache-wrapper.test.ts
+++ b/test/unit/runtime/cache-wrapper.test.ts
@@ -1,12 +1,11 @@
 import type { MockBackend } from './deno-mock'
 import { Buffer } from 'node:buffer'
 import { deserialize } from 'node:v8'
+import { REDB_CACHE_OPS } from '@rari/use-cache/runtime/cache-storage-redb'
+import { REDIS_CACHE_OPS } from '@rari/use-cache/runtime/cache-storage-redis'
 import { $$cache__, encodeBoundArgs } from '@rari/use-cache/runtime/cache-wrapper'
 import { afterEach, describe, expect, it } from 'vite-plus/test'
 import { patchDenoBackend, patchDenoOps, restoreDeno } from './deno-mock'
-
-const REDIS_CACHE_OPS = { get: 'op_cache_remote_get', set: 'op_cache_remote_set' } as const
-const REDB_CACHE_OPS = { get: 'op_redb_cache_get', set: 'op_redb_cache_set' } as const
 
 function installOpsMock(backend: MockBackend, remoteHandler: 'redis' | 'redb' | 'test' = 'redis') {
   patchDenoBackend(REDIS_CACHE_OPS, backend, { remoteHandler })
@@ -180,12 +179,26 @@ describe('$$cache__', () => {
   })
 
   it('falls back to memory storage when remote ops exist but handler is not configured', async () => {
-    const backend = makeInMemoryBackend()
+    let redbGetCalls = 0
+    let redbSetCalls = 0
+    let redisGetCalls = 0
+    let redisSetCalls = 0
+
     patchDenoOps({
-      [REDB_CACHE_OPS.get]: async (key: string) => backend.read(key),
-      [REDB_CACHE_OPS.set]: async (key: string, value: string) => backend.write(key, value, 0),
-      [REDIS_CACHE_OPS.get]: async (key: string) => backend.read(key),
-      [REDIS_CACHE_OPS.set]: async (key: string, value: string) => backend.write(key, value, 0),
+      [REDB_CACHE_OPS.get]: async () => {
+        redbGetCalls++
+        return null
+      },
+      [REDB_CACHE_OPS.set]: async () => {
+        redbSetCalls++
+      },
+      [REDIS_CACHE_OPS.get]: async () => {
+        redisGetCalls++
+        return null
+      },
+      [REDIS_CACHE_OPS.set]: async () => {
+        redisSetCalls++
+      },
     })
 
     let calls = 0
@@ -197,7 +210,10 @@ describe('$$cache__', () => {
     await callCache('remote', 'remote-fallback-unconfigured', 1, fn, [5])
     await callCache('remote', 'remote-fallback-unconfigured', 1, fn, [5])
     expect(calls).toBe(1)
-    expect(backend.read('anything')).toBeNull()
+    expect(redbGetCalls).toBe(0)
+    expect(redbSetCalls).toBe(0)
+    expect(redisGetCalls).toBe(0)
+    expect(redisSetCalls).toBe(0)
   })
 
   it('reads from mock backend on cache hit', async () => {

--- a/test/unit/runtime/cache-wrapper.test.ts
+++ b/test/unit/runtime/cache-wrapper.test.ts
@@ -3,12 +3,13 @@ import { Buffer } from 'node:buffer'
 import { deserialize } from 'node:v8'
 import { $$cache__, encodeBoundArgs } from '@rari/use-cache/runtime/cache-wrapper'
 import { afterEach, describe, expect, it } from 'vite-plus/test'
-import { patchDenoBackend, restoreDeno } from './deno-mock'
+import { patchDenoBackend, patchDenoOps, restoreDeno } from './deno-mock'
 
 const REDIS_CACHE_OPS = { get: 'op_cache_remote_get', set: 'op_cache_remote_set' } as const
+const REDB_CACHE_OPS = { get: 'op_redb_cache_get', set: 'op_redb_cache_set' } as const
 
-function installOpsMock(backend: MockBackend) {
-  patchDenoBackend(REDIS_CACHE_OPS, backend)
+function installOpsMock(backend: MockBackend, remoteHandler: 'redis' | 'redb' | 'test' = 'redis') {
+  patchDenoBackend(REDIS_CACHE_OPS, backend, { remoteHandler })
 }
 
 function uninstallOpsMock(): void {
@@ -176,6 +177,27 @@ describe('$$cache__', () => {
     const second = await callCache('remote', 'remote-fallback-no-ops', 1, fn, [5])
     expect(second).toBe(6)
     expect(calls).toBe(1)
+  })
+
+  it('falls back to memory storage when remote ops exist but handler is not configured', async () => {
+    const backend = makeInMemoryBackend()
+    patchDenoOps({
+      [REDB_CACHE_OPS.get]: async (key: string) => backend.read(key),
+      [REDB_CACHE_OPS.set]: async (key: string, value: string) => backend.write(key, value, 0),
+      [REDIS_CACHE_OPS.get]: async (key: string) => backend.read(key),
+      [REDIS_CACHE_OPS.set]: async (key: string, value: string) => backend.write(key, value, 0),
+    })
+
+    let calls = 0
+    const fn = (a: number) => {
+      calls++
+      return a + 1
+    }
+
+    await callCache('remote', 'remote-fallback-unconfigured', 1, fn, [5])
+    await callCache('remote', 'remote-fallback-unconfigured', 1, fn, [5])
+    expect(calls).toBe(1)
+    expect(backend.read('anything')).toBeNull()
   })
 
   it('reads from mock backend on cache hit', async () => {

--- a/test/unit/runtime/cache-wrapper.test.ts
+++ b/test/unit/runtime/cache-wrapper.test.ts
@@ -1,41 +1,18 @@
+import type { MockBackend } from './deno-mock'
 import { Buffer } from 'node:buffer'
 import { deserialize } from 'node:v8'
 import { $$cache__, encodeBoundArgs } from '@rari/use-cache/runtime/cache-wrapper'
-import { describe, expect, it } from 'vite-plus/test'
+import { afterEach, describe, expect, it } from 'vite-plus/test'
+import { patchDenoBackend, restoreDeno } from './deno-mock'
 
-interface RemoteCacheOps {
-  op_cache_remote_get: (key: string) => Promise<string | null>
-  op_cache_remote_set: (key: string, value: string, ttlMs: number) => Promise<void>
-}
-
-interface DenoLike {
-  core: {
-    ops: RemoteCacheOps
-  }
-}
-
-interface MockBackend {
-  read: (key: string) => string | null
-  write: (key: string, value: string, ttlMs: number) => void
-}
+const REDIS_CACHE_OPS = { get: 'op_cache_remote_get', set: 'op_cache_remote_set' } as const
 
 function installOpsMock(backend: MockBackend) {
-  (globalThis as { Deno?: DenoLike }).Deno = {
-    core: {
-      ops: {
-        async op_cache_remote_get(key: string) {
-          return backend.read(key)
-        },
-        async op_cache_remote_set(key: string, value: string, ttlMs: number) {
-          backend.write(key, value, ttlMs)
-        },
-      },
-    },
-  }
+  patchDenoBackend(REDIS_CACHE_OPS, backend)
 }
 
 function uninstallOpsMock(): void {
-  delete (globalThis as { Deno?: DenoLike }).Deno
+  restoreDeno()
 }
 
 const CACHE_LIMIT = 1000

--- a/test/unit/runtime/deno-mock.ts
+++ b/test/unit/runtime/deno-mock.ts
@@ -24,12 +24,23 @@ function patchDeno(ops: DenoLike['core']['ops']): void {
   target.Deno = { core: { ops } }
 }
 
-export function patchDenoBackend(opNames: BackendOpNames, backend: MockBackend): void {
-  patchDeno({
+export function patchDenoBackend(
+  opNames: BackendOpNames,
+  backend: MockBackend,
+  options?: { remoteHandler?: 'redis' | 'redb' | 'test' },
+): void {
+  const ops: DenoLike['core']['ops'] = {
     [opNames.get]: async (key: string) => backend.read(key),
     [opNames.set]: async (key: string, value: string, ttlMs: number) =>
       backend.write(key, value, ttlMs),
-  })
+  }
+  if (options?.remoteHandler)
+    ops.op_use_cache_remote_handler = () => options.remoteHandler
+  patchDeno(ops)
+}
+
+export function patchDenoOps(ops: DenoLike['core']['ops']): void {
+  patchDeno(ops)
 }
 
 export function restoreDeno(): void {

--- a/test/unit/runtime/deno-mock.ts
+++ b/test/unit/runtime/deno-mock.ts
@@ -1,0 +1,43 @@
+interface DenoLike {
+  core: {
+    ops: Record<string, (...args: any[]) => any>
+  }
+}
+
+export interface MockBackend {
+  read: (key: string) => string | null
+  write: (key: string, value: string, ttlMs: number) => void
+}
+
+export interface BackendOpNames {
+  get: string
+  set: string
+}
+
+let savedDeno: DenoLike | undefined
+let denoWasPresent = false
+
+function patchDeno(ops: DenoLike['core']['ops']): void {
+  const target = globalThis as { Deno?: DenoLike }
+  denoWasPresent = 'Deno' in target
+  savedDeno = target.Deno
+  target.Deno = { core: { ops } }
+}
+
+export function patchDenoBackend(opNames: BackendOpNames, backend: MockBackend): void {
+  patchDeno({
+    [opNames.get]: async (key: string) => backend.read(key),
+    [opNames.set]: async (key: string, value: string, ttlMs: number) =>
+      backend.write(key, value, ttlMs),
+  })
+}
+
+export function restoreDeno(): void {
+  const target = globalThis as { Deno?: DenoLike }
+  if (denoWasPresent)
+    target.Deno = savedDeno
+  else
+    delete target.Deno
+  savedDeno = undefined
+  denoWasPresent = false
+}

--- a/test/unit/runtime/get-client-component.test.ts
+++ b/test/unit/runtime/get-client-component.test.ts
@@ -1,6 +1,6 @@
-import type { ComponentInfo, GlobalWithRari } from '../../../packages/rari/src/runtime/shared/types'
+import type { ComponentInfo, GlobalWithRari } from '@rari/runtime/shared/types'
+import { installRscChunkLoader, pathsMatch, requireClientComponent } from '@rari/runtime/shared/get-client-component'
 import { describe, expect, it, vi } from 'vite-plus/test'
-import { installRscChunkLoader, pathsMatch, requireClientComponent } from '../../../packages/rari/src/runtime/shared/get-client-component'
 
 describe('pathsMatch', () => {
   it('matches identical normalized paths', () => {

--- a/test/unit/runtime/hydration-utils.test.ts
+++ b/test/unit/runtime/hydration-utils.test.ts
@@ -1,5 +1,5 @@
+import { clearServerInjectedErrors, hasFizzMarkers } from '@rari/runtime/shared/hydration'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
-import { clearServerInjectedErrors, hasFizzMarkers } from '../../../packages/rari/src/runtime/shared/hydration'
 
 function mockRoot(options: {
   comments?: string[]

--- a/test/unit/vite/client-import-transform.test.ts
+++ b/test/unit/vite/client-import-transform.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it } from 'vite-plus/test'
 import {
   buildNamespaceClientReferenceReplacement,
   NAMESPACE_IMPORT_LINE_REGEX,
-} from '../../../packages/rari/src/vite/client-import-transform'
+} from '@rari/vite/client-import-transform'
+import { describe, expect, it } from 'vite-plus/test'
 
 describe('namespace client import transform', () => {
   it('matches namespace import lines', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,12 @@ export default defineConfig({
       '@rari/use-cache/runtime/cache-wrapper': fileURLToPath(
         new URL('./packages/use-cache/dist/runtime/cache-wrapper.mjs', import.meta.url),
       ),
+      '@rari/use-cache/runtime/cache-storage-redb': fileURLToPath(
+        new URL('./packages/use-cache/dist/runtime/cache-storage-redb.mjs', import.meta.url),
+      ),
+      '@rari/use-cache/runtime/cache-storage-remote-ops': fileURLToPath(
+        new URL('./packages/use-cache/dist/runtime/cache-storage-remote-ops.mjs', import.meta.url),
+      ),
       '@rari/use-cache/runtime/deterministic-stringify': fileURLToPath(
         new URL('./packages/use-cache/dist/runtime/deterministic-stringify.mjs', import.meta.url),
       ),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,9 @@ export default defineConfig({
       '@rari/use-cache': fileURLToPath(
         new URL('./packages/use-cache/src', import.meta.url),
       ),
+      '@rari/logger': fileURLToPath(
+        new URL('./packages/logger/src', import.meta.url),
+      ),
       '@rari': fileURLToPath(new URL('./packages/rari/src', import.meta.url)),
     },
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,15 +7,6 @@ export default defineConfig({
       '@rari/use-cache/runtime/cache-wrapper': fileURLToPath(
         new URL('./packages/use-cache/dist/runtime/cache-wrapper.mjs', import.meta.url),
       ),
-      '@rari/use-cache/runtime/cache-storage-redb': fileURLToPath(
-        new URL('./packages/use-cache/dist/runtime/cache-storage-redb.mjs', import.meta.url),
-      ),
-      '@rari/use-cache/runtime/cache-storage-remote-ops': fileURLToPath(
-        new URL('./packages/use-cache/dist/runtime/cache-storage-remote-ops.mjs', import.meta.url),
-      ),
-      '@rari/use-cache/runtime/deterministic-stringify': fileURLToPath(
-        new URL('./packages/use-cache/dist/runtime/deterministic-stringify.mjs', import.meta.url),
-      ),
       '@rari/use-cache-darwin-arm64': fileURLToPath(
         new URL('./packages/use-cache-darwin-arm64', import.meta.url),
       ),


### PR DESCRIPTION
Port of #239 by @jarick. Adds redb alongside redis for useCacheRemote with snapshot-safe always-on extension registration, config validation for test/redis/redb handlers, and shared remote ops on the TypeScript side. Also cleans up test imports to use @rari/* path aliases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent **REDB**-backed remote cache with TTL and “never expires” support.
  * Remote cache selection is now handler-based (`redis`, `redb`, plus a test backend), and the “use cache” flow runs when remote cache options are set.
* **Bug Fixes**
  * Improved remote cache configuration validation by warning and ignoring unsupported handlers or empty/invalid URLs.
  * Adjusted remote cache writes to apply TTL only when enabled.
* **Tests**
  * Expanded end-to-end and unit coverage for REDB/Redis remote caching, handler selection, and TTL/expiry behavior.
* **Chores**
  * Updated Git ignore rules for `*.redb` files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->