### PR TITLE
Add CodSpeed continuous performance benchmarks

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,40 @@
+name: CodSpeed
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  # `workflow_dispatch` allows CodSpeed to trigger backtest
+  # performance analysis in order to generate initial data.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # for OpenID Connect authentication with CodSpeed
+
+jobs:
+  benchmarks:
+    name: Run benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: nightly
+
+      - uses: ./.github/actions/setup-rust-build-deps
+
+      - name: Install cargo-codspeed
+        run: cargo install cargo-codspeed --locked
+
+      - name: Build the benchmarks
+        run: cargo codspeed build -p rari_use_cache
+
+      - name: Run the benchmarks
+        uses: CodSpeedHQ/action@a4a36bb07c0638b0b4ca52bf1f3dad1b4289e52f # v4.18.1
+        with:
+          mode: simulation
+          run: cargo codspeed run -p rari_use_cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,6 +1110,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -1161,6 +1162,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "codspeed"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7083f253260bcb4aaa3b4aa4c52973703dabc1a85c2f193997e2689aafa8a919"
+dependencies = [
+ "anyhow",
+ "cc",
+ "colored",
+ "getrandom 0.4.2",
+ "glob",
+ "libc",
+ "nix 0.31.3",
+ "serde",
+ "serde_json",
+ "statrs",
+]
+
+[[package]]
+name = "codspeed-divan-compat"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc1065d507e1cbab731a7976db4cef7e47e49b87b4dbc0a925df07d343558420"
+dependencies = [
+ "clap",
+ "codspeed",
+ "codspeed-divan-compat-macros",
+ "codspeed-divan-compat-walltime",
+ "regex",
+]
+
+[[package]]
+name = "codspeed-divan-compat-macros"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd05482a95823ffe421e8a9ba24fa22a6a30d594e2c60455cbb43a41bf2d8fa"
+dependencies = [
+ "divan-macros",
+ "itertools 0.14.0",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "codspeed-divan-compat-walltime"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f8eae75b8fa85357020a404899c4280d590c9fd1c47640b3ce53106c62d2ee"
+dependencies = [
+ "cfg-if",
+ "clap",
+ "codspeed",
+ "condtype",
+ "divan-macros",
+ "libc",
+ "regex-lite",
 ]
 
 [[package]]
@@ -1274,6 +1335,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "condtype"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "const-oid"
@@ -3382,6 +3449,17 @@ name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "divan-macros"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc51d98e636f5e3b0759a39257458b22619cac7e96d932da6eeb052891bb67c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7116,6 +7194,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7568,6 +7655,7 @@ dependencies = [
 name = "rari_use_cache"
 version = "0.0.0"
 dependencies = [
+ "codspeed-divan-compat",
  "deno_ast",
  "hex",
  "napi",
@@ -7881,6 +7969,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
@@ -8965,6 +9059,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "num-traits",
+]
+
+[[package]]
 name = "strck"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9673,6 +9777,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "terminfo"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10027,6 +10141,36 @@ dependencies = [
  "libc",
  "tokio",
  "vsock",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -11368,6 +11512,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11560,7 +11713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a6a39b6b5ba0d02c910d05d7fbc366a4befb8901ea107dcde9c1c97acb8a366"
 dependencies = [
  "rowan",
- "winnow",
+ "winnow 0.6.26",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 [![npm version](https://img.shields.io/npm/v/rari.svg)](https://www.npmjs.com/package/rari)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://app.codspeed.io/rari-build/rari?utm_source=badge)
 [![Discord](https://img.shields.io/badge/chat-discord-blue?style=flat&logo=discord)](https://discord.gg/GSh2Ak3b8Q)
 
 **rari** is a React Server Components framework running on a Rust runtime. It has three layers: a Rust runtime (HTTP server, RSC renderer, and router with embedded V8), a React framework (app router, server actions, streaming/Suspense), and a build toolchain (Rolldown-powered Vite bundling, tsgo type checking). You write standard React, the runtime underneath is Rust instead of Node.

--- a/crates/rari_use_cache/Cargo.toml
+++ b/crates/rari_use_cache/Cargo.toml
@@ -7,7 +7,10 @@ repository = { workspace = true }
 publish = false
 
 [lib]
-crate-type = [ "cdylib" ]
+crate-type = [
+  "cdylib",
+  "rlib",
+]
 
 [dependencies]
 deno_ast = { workspace = true, features = [
@@ -26,6 +29,13 @@ sha2 = { workspace = true }
 
 [build-dependencies]
 napi-build = "2.3.2"
+
+[dev-dependencies]
+divan = { package = "codspeed-divan-compat", version = "5.0.1" }
+
+[[bench]]
+name = "transform"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/rari_use_cache/benches/transform.rs
+++ b/crates/rari_use_cache/benches/transform.rs
@@ -1,0 +1,183 @@
+//! Benchmarks for the `use cache` source transformer.
+//!
+//! These cover the build-time hot paths of `rari_use_cache`:
+//! - `detect_use_cache`: fast byte-scan pre-filter run on every source file
+//! - `transform_source`: the full parse -> visit -> codegen pipeline
+//! - `generate_reference_id`: the SHA-256 based stable reference id generator
+//!
+//! Fixtures mirror real app patterns: function-level directives, file-level
+//! `'use cache'`, remote cache kinds, and closure capture for cache keys.
+
+use divan::{Bencher, black_box};
+use rari_use_cache::{directive, id, transform};
+
+fn main() {
+    divan::main();
+}
+
+// A component module that does NOT use the cache directive. This represents
+// the common case where the pre-filter should bail out quickly.
+const PLAIN_COMPONENT: &str = r"
+import React from 'react'
+import { useState } from 'react'
+
+export function Counter({ initial }: { initial: number }) {
+  const [count, setCount] = useState(initial)
+  return (
+    <button onClick={() => setCount((c) => c + 1)}>
+      Count: {count}
+    </button>
+  )
+}
+
+export default function App() {
+  return <Counter initial={0} />
+}
+";
+
+// Function-level directives on async exports, including a non-default cache kind
+// and closure capture (`PAGE_SIZE`) for bound-arg key material.
+const CACHED_MODULE: &str = r"
+import { db } from './db'
+import { formatUser } from './utils'
+
+const PAGE_SIZE = 20
+
+export async function getUser(id: string) {
+  'use cache'
+  const user = await db.users.findById(id)
+  return formatUser(user)
+}
+
+export async function listUsers(page: number) {
+  'use cache: stale-while-revalidate'
+  const offset = page * PAGE_SIZE
+  const rows = await db.users.list(offset, PAGE_SIZE)
+  return rows.map((row) => formatUser(row))
+}
+
+export default async function dashboard(userId: string) {
+  'use cache'
+  const user = await getUser(userId)
+  const users = await listUsers(0)
+  return { user, users }
+}
+";
+
+// File-level directive: all async exports inherit the module cache scope.
+const FILE_LEVEL_CACHED_MODULE: &str = r"
+'use cache'
+
+import { db } from './db'
+
+const PAGE_SIZE = 20
+
+export async function getCachedItems(label: string) {
+  const rows = await db.items.list(PAGE_SIZE)
+  return rows.map((row) => `${label}:${row.id}`)
+}
+
+export async function getCachedCount() {
+  return db.items.count()
+}
+";
+
+// Remote cache kind used for shared redis/redb storage backends.
+const REMOTE_CACHED_MODULE: &str = r"
+import { db } from './db'
+
+let callCount = 0
+
+export async function getRemoteUser(id: string) {
+  'use cache: remote'
+  callCount += 1
+  const user = await db.users.findById(id)
+  return { id: user.id, calls: callCount }
+}
+
+export async function listRemoteUsers() {
+  'use cache: remote'
+  return db.users.list(0, 10)
+}
+";
+
+#[divan::bench]
+fn detect_use_cache_hit(bencher: Bencher) {
+    bencher.bench(|| directive::detect_use_cache(black_box(CACHED_MODULE)));
+}
+
+#[divan::bench]
+fn detect_use_cache_file_level(bencher: Bencher) {
+    bencher.bench(|| directive::detect_use_cache(black_box(FILE_LEVEL_CACHED_MODULE)));
+}
+
+#[divan::bench]
+fn detect_use_cache_remote(bencher: Bencher) {
+    bencher.bench(|| directive::detect_use_cache(black_box(REMOTE_CACHED_MODULE)));
+}
+
+#[divan::bench]
+fn detect_use_cache_miss(bencher: Bencher) {
+    bencher.bench(|| directive::detect_use_cache(black_box(PLAIN_COMPONENT)));
+}
+
+#[divan::bench]
+fn transform_cached_module(bencher: Bencher) {
+    bencher.bench(|| {
+        transform::transform_source(
+            black_box(CACHED_MODULE),
+            black_box("dashboard.tsx"),
+            black_box("rari-use-cache-v1"),
+        )
+    });
+}
+
+#[divan::bench]
+fn transform_file_level_cached_module(bencher: Bencher) {
+    bencher.bench(|| {
+        transform::transform_source(
+            black_box(FILE_LEVEL_CACHED_MODULE),
+            black_box("cached-helpers.ts"),
+            black_box("rari-use-cache-v1"),
+        )
+    });
+}
+
+#[divan::bench]
+fn transform_remote_cached_module(bencher: Bencher) {
+    bencher.bench(|| {
+        transform::transform_source(
+            black_box(REMOTE_CACHED_MODULE),
+            black_box("use-cache-remote/page.tsx"),
+            black_box("rari-use-cache-v1"),
+        )
+    });
+}
+
+#[divan::bench]
+fn transform_plain_component(bencher: Bencher) {
+    bencher.bench(|| {
+        transform::transform_source(
+            black_box(PLAIN_COMPONENT),
+            black_box("app.tsx"),
+            black_box("rari-use-cache-v1"),
+        )
+    });
+}
+
+#[divan::bench]
+fn generate_reference_id(bencher: Bencher) {
+    bencher.bench(|| {
+        id::generate_reference_id(
+            black_box("rari-use-cache-v1"),
+            black_box("src/app/dashboard/page.tsx"),
+            black_box("getUser"),
+            black_box(true),
+        )
+    });
+}
+
+#[divan::bench]
+fn generate_cache_export_name(bencher: Bencher) {
+    bencher.bench(|| id::generate_cache_export_name(black_box(3), black_box("getUserProfile")));
+}


### PR DESCRIPTION
## Summary
- Add CodSpeed GitHub workflow for `rari_use_cache` transform benchmarks
- Add divan benches covering detect/transform hot paths, including file-level and remote cache fixtures
- Add CodSpeed badge to README

## Test plan
- [x] `cargo build -p rari_use_cache --benches`
- [x] `cargo bench -p rari_use_cache --bench transform`
- [x] `cargo clippy -p rari_use_cache --benches -- -D warnings`
- [ ] CI CodSpeed workflow passes on this PR