### PR TITLE
feat(benchmarks): add CodSpeed benchmarks for rari crate

### DIFF
--- a/.github/actions/bundle-react-esm/action.yml
+++ b/.github/actions/bundle-react-esm/action.yml
@@ -1,6 +1,12 @@
 name: Bundle React ESM
 description: Generate React vendor files required by the rari crate
 
+inputs:
+  setup-toolchain:
+    description: Install pnpm and Node.js before bundling (disable when setup-namespace-cache already ran)
+    required: false
+    default: 'true'
+
 runs:
   using: composite
   steps:
@@ -8,7 +14,7 @@ runs:
       with:
         node-version: 22.18.0
         cache: 'false'
-        setup-toolchain: 'false'
+        setup-toolchain: ${{ inputs.setup-toolchain }}
 
     - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,8 @@ jobs:
 
       - name: Bundle React ESM vendor files
         uses: ./.github/actions/bundle-react-esm
+        with:
+          setup-toolchain: 'false'
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
 
@@ -171,6 +173,8 @@ jobs:
 
       - name: Bundle React ESM vendor files
         uses: ./.github/actions/bundle-react-esm
+        with:
+          setup-toolchain: 'false'
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
 
@@ -236,6 +240,8 @@ jobs:
 
       - name: Bundle React ESM vendor files
         uses: ./.github/actions/bundle-react-esm
+        with:
+          setup-toolchain: 'false'
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
 

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -55,6 +55,8 @@ jobs:
     env:
       # Keep bench artifacts separate from CI's shared Namespace rust cache.
       CARGO_TARGET_DIR: target/codspeed
+      # Fat LTO on the full rari crate exceeds runner memory when multiple targets link in parallel.
+      CARGO_BUILD_JOBS: 1
     steps:
       - uses: namespacelabs/nscloud-checkout-action@445c25d7009680597d73eb03c4e1cd5be522ed73 # v9.0.0
 
@@ -89,10 +91,14 @@ jobs:
         run: cargo install cargo-codspeed --locked
 
       - name: Build the benchmarks
-        run: cargo codspeed build -p rari_use_cache -p rari --features rari/bench
+        run: |
+          cargo codspeed build -p rari_use_cache --benches
+          cargo codspeed build -p rari --features rari/bench --benches --bench hot_paths
 
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@a4a36bb07c0638b0b4ca52bf1f3dad1b4289e52f # v4.18.1
         with:
           mode: simulation
-          run: cargo codspeed run -p rari_use_cache -p rari --features rari/bench
+          run: |
+            cargo codspeed run -p rari_use_cache --benches --bench transform
+            cargo codspeed run -p rari --features rari/bench --benches --bench hot_paths

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -39,10 +39,10 @@ jobs:
         run: cargo install cargo-codspeed --locked
 
       - name: Build the benchmarks
-        run: cargo codspeed build -p rari_use_cache
+        run: cargo codspeed build -p rari_use_cache -p rari
 
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@a4a36bb07c0638b0b4ca52bf1f3dad1b4289e52f # v4.18.1
         with:
           mode: simulation
-          run: cargo codspeed run -p rari_use_cache
+          run: cargo codspeed run -p rari_use_cache -p rari

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -17,16 +17,58 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
-  benchmarks:
-    name: Run benchmarks
+  changes:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write # for OpenID Connect authentication with CodSpeed
+      pull-requests: read
+    outputs:
+      benchmarks: ${{ steps.filter.outputs.benchmarks }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          filters: |
+            benchmarks:
+              - '.github/workflows/codspeed.yml'
+              - 'crates/rari/benches/**'
+              - 'crates/rari/Cargo.toml'
+              - 'crates/rari/src/**'
+              - 'crates/rari_use_cache/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+
+  benchmarks:
+    name: Run benchmarks
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.benchmarks == 'true'
+    runs-on: namespace-profile-rari-linux-amd64
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      id-token: write # for OpenID Connect authentication with CodSpeed
+    env:
+      # Keep bench artifacts separate from CI's shared Namespace rust cache.
+      CARGO_TARGET_DIR: target/codspeed
+    steps:
+      - uses: namespacelabs/nscloud-checkout-action@445c25d7009680597d73eb03c4e1cd5be522ed73 # v9.0.0
+
+      - uses: ./.github/actions/setup-namespace-cache
+        with:
+          cache: |
+            apt
+            pnpm
+
+      - name: Configure CodSpeed Rust cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: codspeed
+          cache-targets: true
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
@@ -37,6 +79,8 @@ jobs:
 
       - name: Bundle React ESM vendor files
         uses: ./.github/actions/bundle-react-esm
+        with:
+          setup-toolchain: 'false'
 
       - name: Create snapshot placeholder
         run: just ci-create-snapshot-placeholder

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -35,14 +35,19 @@ jobs:
 
       - uses: ./.github/actions/setup-rust-build-deps
 
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+
+      - name: Create snapshot placeholder
+        run: just ci-create-snapshot-placeholder
+
       - name: Install cargo-codspeed
         run: cargo install cargo-codspeed --locked
 
       - name: Build the benchmarks
-        run: cargo codspeed build -p rari_use_cache -p rari
+        run: cargo codspeed build -p rari_use_cache -p rari --features rari/bench
 
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@a4a36bb07c0638b0b4ca52bf1f3dad1b4289e52f # v4.18.1
         with:
           mode: simulation
-          run: cargo codspeed run -p rari_use_cache -p rari
+          run: cargo codspeed run -p rari_use_cache -p rari --features rari/bench

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -35,7 +35,8 @@ jobs:
 
       - uses: ./.github/actions/setup-rust-build-deps
 
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+      - name: Bundle React ESM vendor files
+        uses: ./.github/actions/bundle-react-esm
 
       - name: Create snapshot placeholder
         run: just ci-create-snapshot-placeholder

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -46,7 +46,7 @@ jobs:
   benchmarks:
     name: Run benchmarks
     needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.benchmarks == 'true'
+    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.benchmarks == 'true')
     runs-on: namespace-profile-rari-linux-amd64
     timeout-minutes: 45
     permissions:
@@ -92,13 +92,13 @@ jobs:
 
       - name: Build the benchmarks
         run: |
-          cargo codspeed build -p rari_use_cache --benches
-          cargo codspeed build -p rari --features rari/bench --benches --bench hot_paths
+          cargo codspeed build -p rari_use_cache --bench transform
+          cargo codspeed build -p rari --features rari/bench --bench hot_paths
 
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@a4a36bb07c0638b0b4ca52bf1f3dad1b4289e52f # v4.18.1
         with:
           mode: simulation
           run: |
-            cargo codspeed run -p rari_use_cache --benches --bench transform
-            cargo codspeed run -p rari --features rari/bench --benches --bench hot_paths
+            cargo codspeed run -p rari_use_cache --bench transform
+            cargo codspeed run -p rari --features rari/bench --bench hot_paths

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Bundle React ESM vendor files
         uses: ./.github/actions/bundle-react-esm
+        with:
+          setup-toolchain: 'false'
 
       - name: Create snapshot placeholder
         run: |
@@ -136,6 +138,8 @@ jobs:
 
       - name: Bundle React ESM vendor files
         uses: ./.github/actions/bundle-react-esm
+        with:
+          setup-toolchain: 'false'
 
       - name: Download V8 snapshot
         uses: namespace-actions/download-artifact@7cbad919e4b0e09f17e9d6311a444ff002992b5b # v2.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7515,6 +7515,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "clap",
+ "codspeed-divan-compat",
  "colored",
  "cow-utils",
  "dashmap 6.2.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ base64 = "0.22.1"
 clap = { version = "4.6.1", features = [ "derive" ] }
 colored = "3.1.1"
 cow-utils = "0.1.3"
+divan = { package = "codspeed-divan-compat", version = "5.0.1" }
 hex = "0.4.3"
 parking_lot = "0.12.5"
 rari = { path = "crates/rari" }

--- a/crates/rari/Cargo.toml
+++ b/crates/rari/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = [ "rlib" ]
 
 [features]
 default = []
+bench = []
 # Optional Deno leaf extensions
 ext-full = [
   "dep:deno_webgpu",
@@ -196,14 +197,9 @@ uuid = { workspace = true }
 workspace = true
 
 [dev-dependencies]
-deno_core = { workspace = true }
 divan = { workspace = true }
-serde_json = { workspace = true }
-tokio = { workspace = true, features = [
-  "rt",
-  "rt-multi-thread"
-] }
 
 [[bench]]
 name = "hot_paths"
 harness = false
+required-features = [ "bench" ]

--- a/crates/rari/Cargo.toml
+++ b/crates/rari/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = [ "rlib" ]
 
 [features]
 default = []
-# Optional Deno leaf extensions (webgpu, kv, cron, node_sqlite).
+# Optional Deno leaf extensions
 ext-full = [
   "dep:deno_webgpu",
   "dep:deno_kv",
@@ -194,3 +194,16 @@ uuid = { workspace = true }
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+deno_core = { workspace = true }
+divan = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = [
+  "rt",
+  "rt-multi-thread"
+] }
+
+[[bench]]
+name = "hot_paths"
+harness = false

--- a/crates/rari/benches/hot_paths.rs
+++ b/crates/rari/benches/hot_paths.rs
@@ -1,0 +1,369 @@
+//! Per-request and build-time hot path benchmarks for the main `rari` crate.
+//!
+//! Covers app and API routing, HTML sanitization and metadata injection, response
+//! compression, cache keys and memory cache, flight protocol sorting, directive
+//! scans, component ID generation, TS/TSX transpilation, and server-action arg
+//! validation.
+
+#![expect(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::{Arc, OnceLock};
+
+use bytes::Bytes;
+use deno_core::{ModuleCodeString, ModuleName};
+use divan::{Bencher, black_box};
+use rari::{
+    rendering::{
+        base::sanitizer::sanitize_html_output,
+        layout::{
+            LayoutRenderContext, create_component_id, create_layout_context, generate_cache_key,
+            sort_flight_protocol,
+        },
+    },
+    runtime::transpile::maybe_transpile_source,
+    server::{
+        actions::{ValidationConfig, validate_and_sanitize_args},
+        cache::{CacheHandler, bench_memory_cache_handler, response::ResponseCache},
+        compression::{CompressionEncoding, compress_body},
+        core::utils::component::{
+            extract_component_id, has_use_client_directive, has_use_server_directive,
+            readable_component_id, short_hash,
+        },
+        rendering::metadata_injection::{bench_page_metadata, inject_metadata},
+        routing::{
+            AppRouteMatch, AppRouter,
+            api_routes::{bench_api_route_manifest, bench_match_api_route},
+            app_router::bench_route_manifest,
+        },
+    },
+};
+use rustc_hash::FxHashMap;
+use serde_json::json;
+use tokio::runtime::{Builder, Runtime};
+
+fn main() {
+    divan::main();
+}
+
+static TOKIO: OnceLock<Runtime> = OnceLock::new();
+
+fn runtime() -> &'static Runtime {
+    TOKIO.get_or_init(|| Builder::new_current_thread().enable_all().build().expect("tokio runtime"))
+}
+
+fn layout_context(route_match: &AppRouteMatch) -> LayoutRenderContext {
+    let mut search_params = FxHashMap::default();
+    search_params.insert("q".to_string(), vec!["rari".to_string(), "bench".to_string()]);
+    search_params.insert("page".to_string(), vec!["2".to_string()]);
+
+    create_layout_context(
+        route_match.params.clone(),
+        search_params,
+        FxHashMap::default(),
+        route_match.pathname.clone(),
+    )
+}
+
+const HTML_SHELL: &str = r#"<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Benchmark Page</title></head>
+<body>
+<div id="root"><main><h1>Welcome</h1><p>Lorem ipsum dolor sit amet.</p></main></div>
+</body>
+</html>
+"#;
+
+fn html_page_shell() -> Bytes {
+    let mut html = String::with_capacity(64 * 1024);
+    for _ in 0..200 {
+        html.push_str(HTML_SHELL);
+    }
+    Bytes::from(html)
+}
+
+const SANITIZE_CLEAN_HTML: &str = r"<div><h1>Title</h1><p>Paragraph with normal content.</p></div>";
+
+const SANITIZE_LEAKY_HTML: &str = r#"<div>Start<pre>\{"debug": "info"\}</pre>Middle\{"id": "456"\}End<div>[{"id":"1"},{"id":"2"}]</div></div>"#;
+
+const TSX_MODULE: &str = r#"
+import type { ReactNode } from 'react'
+
+export interface CardProps {
+  title: string
+  children: ReactNode
+}
+
+export function Card({ title, children }: CardProps) {
+  return (
+    <section>
+      <h2>{title}</h2>
+      {children}
+    </section>
+  )
+}
+
+export default function Page() {
+  return <Card title="Home">Hello</Card>
+}
+"#;
+
+const PLAIN_COMPONENT: &str = r"
+import { useState } from 'react'
+
+export function Counter({ initial }: { initial: number }) {
+  const [count, setCount] = useState(initial)
+  return <button onClick={() => setCount((c) => c + 1)}>{count}</button>
+}
+
+export default function Page() {
+  return <Counter initial={0} />
+}
+";
+
+const USE_CLIENT_COMPONENT: &str = r"'use client'
+
+import { useState } from 'react'
+
+export function Counter() {
+  const [count, setCount] = useState(0)
+  return <button onClick={() => setCount((c) => c + 1)}>{count}</button>
+}
+";
+
+const USE_SERVER_MODULE: &str = r"'use server'
+
+export async function createUser(name: string) {
+  return { id: '1', name }
+}
+";
+
+const METADATA_HTML: &str = r#"<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Default Title</title>
+    <meta name="description" content="placeholder">
+</head>
+<body><div id="root"></div></body>
+</html>"#;
+
+const FLIGHT_PROTOCOL: &str = "a:\"tail\"\n3:\"c\"\n1:\"a\"\n5:\"e\"\n2:\"b\"\n4:\"d\"\n";
+
+fn action_args() -> Vec<serde_json::Value> {
+    vec![json!({
+        "user": {
+            "__proto__": { "isAdmin": true },
+            "name": "Jane",
+            "settings": {
+                "constructor": "bad",
+                "theme": "dark",
+                "tags": ["a", "b", "c"]
+            }
+        },
+        "items": (0..20).map(|i| json!({ "id": i, "label": format!("item-{i}") })).collect::<Vec<_>>()
+    })]
+}
+
+#[divan::bench]
+fn match_route_static(bencher: Bencher) {
+    let router = AppRouter::new(bench_route_manifest());
+    bencher.bench(|| black_box(router.match_route("/about")).unwrap());
+}
+
+#[divan::bench]
+fn match_route_dynamic(bencher: Bencher) {
+    let router = AppRouter::new(bench_route_manifest());
+    bencher.bench(|| black_box(router.match_route("/blog/hello-world")).unwrap());
+}
+
+#[divan::bench]
+fn match_route_catch_all(bencher: Bencher) {
+    let router = AppRouter::new(bench_route_manifest());
+    bencher.bench(|| black_box(router.match_route("/docs/getting-started/installation")).unwrap());
+}
+
+#[divan::bench]
+fn match_route_miss(bencher: Bencher) {
+    let router = AppRouter::new(bench_route_manifest());
+    bencher.bench(|| black_box(router.match_route("/missing-route")).is_err());
+}
+
+#[divan::bench]
+fn sanitize_html_clean(bencher: Bencher) {
+    bencher.bench(|| sanitize_html_output(black_box(SANITIZE_CLEAN_HTML)));
+}
+
+#[divan::bench]
+fn sanitize_html_leaky(bencher: Bencher) {
+    bencher.bench(|| sanitize_html_output(black_box(SANITIZE_LEAKY_HTML)));
+}
+
+#[divan::bench]
+fn compress_body_gzip(bencher: Bencher) {
+    let body = html_page_shell();
+    let rt = runtime();
+    bencher.bench(|| {
+        rt.block_on(async {
+            black_box(compress_body(body.clone(), CompressionEncoding::Gzip).await)
+        })
+    });
+}
+
+#[divan::bench]
+fn layout_generate_cache_key(bencher: Bencher) {
+    let router = AppRouter::new(bench_route_manifest());
+    let route_match = router.match_route("/blog/hello-world").unwrap();
+    let context = layout_context(&route_match);
+    bencher.bench(|| black_box(generate_cache_key(black_box(&route_match), black_box(&context))));
+}
+
+#[divan::bench]
+fn response_generate_cache_key(bencher: Bencher) {
+    let mut params = FxHashMap::default();
+    params.insert("slug".to_string(), "hello-world".to_string());
+    params.insert("lang".to_string(), "en".to_string());
+
+    bencher.bench(|| {
+        black_box(ResponseCache::generate_cache_key_with_mode(
+            "/blog/[slug]",
+            Some(black_box(&params)),
+            Some("static"),
+        ))
+    });
+}
+
+#[divan::bench]
+fn response_generate_etag(bencher: Bencher) {
+    let body = html_page_shell();
+    bencher.bench(|| black_box(ResponseCache::generate_etag(black_box(body.as_ref()))));
+}
+
+#[divan::bench]
+fn maybe_transpile_tsx(bencher: Bencher) {
+    let module_name: ModuleName = "/app/page.tsx".to_string().into();
+    let source: ModuleCodeString = TSX_MODULE.to_string().into();
+    bencher.bench(|| {
+        black_box(
+            maybe_transpile_source(black_box(&module_name), black_box(source.try_clone().unwrap()))
+                .unwrap(),
+        )
+    });
+}
+
+#[divan::bench]
+fn api_match_route_static(bencher: Bencher) {
+    let manifest = bench_api_route_manifest();
+    bencher.bench(|| black_box(bench_match_api_route(&manifest, "/api/health", "GET")).unwrap());
+}
+
+#[divan::bench]
+fn api_match_route_dynamic(bencher: Bencher) {
+    let manifest = bench_api_route_manifest();
+    bencher.bench(|| black_box(bench_match_api_route(&manifest, "/api/users/42", "GET")).unwrap());
+}
+
+#[divan::bench]
+fn api_match_route_catch_all(bencher: Bencher) {
+    let manifest = bench_api_route_manifest();
+    bencher.bench(|| {
+        black_box(bench_match_api_route(&manifest, "/api/files/docs/guide.pdf", "GET")).unwrap()
+    });
+}
+
+#[divan::bench]
+fn api_match_route_miss(bencher: Bencher) {
+    let manifest = bench_api_route_manifest();
+    bencher.bench(|| black_box(bench_match_api_route(&manifest, "/api/missing", "GET")).is_err());
+}
+
+#[divan::bench]
+fn sort_flight_protocol_rows(bencher: Bencher) {
+    bencher.bench(|| black_box(sort_flight_protocol(black_box(FLIGHT_PROTOCOL))));
+}
+
+#[divan::bench]
+fn inject_metadata_rich(bencher: Bencher) {
+    let metadata = bench_page_metadata();
+    bencher
+        .bench(|| black_box(inject_metadata(black_box(METADATA_HTML), black_box(&metadata), None)));
+}
+
+#[divan::bench]
+fn has_use_client_directive_hit(bencher: Bencher) {
+    bencher.bench(|| black_box(has_use_client_directive(black_box(USE_CLIENT_COMPONENT))));
+}
+
+#[divan::bench]
+fn has_use_client_directive_miss(bencher: Bencher) {
+    bencher.bench(|| black_box(has_use_client_directive(black_box(PLAIN_COMPONENT))));
+}
+
+#[divan::bench]
+fn has_use_server_directive_hit(bencher: Bencher) {
+    bencher.bench(|| black_box(has_use_server_directive(black_box(USE_SERVER_MODULE))));
+}
+
+#[divan::bench]
+fn has_use_server_directive_miss(bencher: Bencher) {
+    bencher.bench(|| black_box(has_use_server_directive(black_box(PLAIN_COMPONENT))));
+}
+
+#[divan::bench]
+fn short_hash_component_path(bencher: Bencher) {
+    bencher.bench(|| black_box(short_hash(black_box("app/blog/[slug]/page.tsx"))));
+}
+
+#[divan::bench]
+fn readable_component_id_path(bencher: Bencher) {
+    bencher.bench(|| black_box(readable_component_id(black_box("app/blog/[slug]/page.tsx"))));
+}
+
+#[divan::bench]
+fn create_component_id_path(bencher: Bencher) {
+    bencher.bench(|| black_box(create_component_id(black_box("app/blog/[slug]/page.tsx"))));
+}
+
+#[divan::bench]
+fn extract_component_id_path(bencher: Bencher) {
+    bencher.bench(|| black_box(extract_component_id(black_box("src/app/blog/page.tsx")).unwrap()));
+}
+
+#[divan::bench]
+fn memory_cache_get_hit(bencher: Bencher) {
+    let handler = Arc::new(bench_memory_cache_handler());
+    let rt = runtime();
+    rt.block_on(async {
+        handler.set("bench-key", vec![0u8; 4096], 3600).await.unwrap();
+    });
+
+    bencher.bench(|| {
+        rt.block_on(async { black_box(handler.get(black_box("bench-key")).await.unwrap()) })
+    });
+}
+
+#[divan::bench]
+fn memory_cache_set(bencher: Bencher) {
+    let handler = Arc::new(bench_memory_cache_handler());
+    let rt = runtime();
+    let value = vec![0u8; 4096];
+
+    bencher.bench(|| {
+        rt.block_on(async {
+            black_box(
+                handler
+                    .set(black_box("bench-set-key"), black_box(value.clone()), black_box(3600))
+                    .await
+                    .unwrap(),
+            )
+        })
+    });
+}
+
+#[divan::bench]
+fn validate_and_sanitize_action_args(bencher: Bencher) {
+    let config = ValidationConfig::production();
+    let args = action_args();
+    bencher.bench(|| {
+        black_box(validate_and_sanitize_args(black_box(&args), black_box(&config)).unwrap())
+    });
+}

--- a/crates/rari/src/rendering/layout/mod.rs
+++ b/crates/rari/src/rendering/layout/mod.rs
@@ -8,7 +8,9 @@ pub use core::{LayoutHtmlCache, LayoutRenderer};
 pub use route_composer::{LayoutInfo, RouteComposer};
 pub use types::*;
 pub(crate) use utils::{component_dist_path, drain_chunked_stream};
-pub use utils::{create_layout_context, sort_flight_protocol};
+pub use utils::{
+    create_component_id, create_layout_context, generate_cache_key, sort_flight_protocol,
+};
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used)]

--- a/crates/rari/src/server/cache/handler.rs
+++ b/crates/rari/src/server/cache/handler.rs
@@ -198,6 +198,7 @@ impl Default for MemoryCacheHandler {
 }
 
 /// Memory cache handler for CodSpeed benchmarks.
+#[cfg(feature = "bench")]
 #[doc(hidden)]
 pub fn bench_memory_cache_handler() -> MemoryCacheHandler {
     MemoryCacheHandler::with_config(&MemoryConfig { max_entries: 1000, default_ttl: 3600 })

--- a/crates/rari/src/server/cache/handler.rs
+++ b/crates/rari/src/server/cache/handler.rs
@@ -197,6 +197,12 @@ impl Default for MemoryCacheHandler {
     }
 }
 
+/// Memory cache handler for CodSpeed benchmarks.
+#[doc(hidden)]
+pub fn bench_memory_cache_handler() -> MemoryCacheHandler {
+    MemoryCacheHandler::with_config(&MemoryConfig { max_entries: 1000, default_ttl: 3600 })
+}
+
 #[async_trait::async_trait]
 impl CacheHandler for MemoryCacheHandler {
     async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, CacheError> {

--- a/crates/rari/src/server/rendering/metadata_injection.rs
+++ b/crates/rari/src/server/rendering/metadata_injection.rs
@@ -542,6 +542,7 @@ pub fn inject_metadata(
 }
 
 /// Rich page metadata fixture for CodSpeed head-injection benchmarks.
+#[cfg(feature = "bench")]
 #[doc(hidden)]
 pub fn bench_page_metadata() -> PageMetadata {
     use rustc_hash::FxHashMap;

--- a/crates/rari/src/server/rendering/metadata_injection.rs
+++ b/crates/rari/src/server/rendering/metadata_injection.rs
@@ -541,6 +541,67 @@ pub fn inject_metadata(
     result
 }
 
+/// Rich page metadata fixture for CodSpeed head-injection benchmarks.
+#[doc(hidden)]
+pub fn bench_page_metadata() -> PageMetadata {
+    use rustc_hash::FxHashMap;
+
+    use crate::rendering::layout::types::{
+        AlternatesMetadata, OpenGraphImage, OpenGraphImageDescriptor, OpenGraphMetadata,
+        RobotsMetadata, TwitterMetadata,
+    };
+
+    let mut languages = FxHashMap::default();
+    languages.insert("en".to_string(), "https://example.com/en".to_string());
+    languages.insert("es".to_string(), "https://example.com/es".to_string());
+
+    PageMetadata {
+        title: Some("Benchmark Page".to_string()),
+        description: Some("A page used for CodSpeed metadata injection benchmarks.".to_string()),
+        keywords: Some(vec!["rari".to_string(), "benchmark".to_string()]),
+        open_graph: Some(OpenGraphMetadata {
+            title: Some("OG Title".to_string()),
+            description: Some("OG Description".to_string()),
+            url: Some("https://example.com/blog/post".to_string()),
+            site_name: Some("Example Site".to_string()),
+            images: Some(vec![
+                OpenGraphImage::Simple("https://example.com/simple.jpg".to_string()),
+                OpenGraphImage::Detailed(OpenGraphImageDescriptor {
+                    url: "https://example.com/image.jpg".to_string(),
+                    width: Some(1200),
+                    height: Some(630),
+                    alt: Some("Example Image".to_string()),
+                }),
+            ]),
+            og_type: Some("article".to_string()),
+        }),
+        twitter: Some(TwitterMetadata {
+            card: Some("summary_large_image".to_string()),
+            site: Some("@example".to_string()),
+            creator: Some("@creator".to_string()),
+            title: Some("Twitter Title".to_string()),
+            description: Some("Twitter Description".to_string()),
+            images: Some(vec!["https://example.com/twitter.jpg".to_string()]),
+        }),
+        robots: Some(RobotsMetadata {
+            index: Some(true),
+            follow: Some(true),
+            nocache: Some(false),
+        }),
+        viewport: None,
+        canonical: Some("https://example.com/blog/post".to_string()),
+        icons: None,
+        manifest: Some("/site.webmanifest".to_string()),
+        theme_color: None,
+        apple_web_app: None,
+        alternates: Some(AlternatesMetadata {
+            canonical: Some("https://example.com/blog/post".to_string()),
+            languages: Some(languages),
+            types: None,
+        }),
+    }
+}
+
 #[cfg(test)]
 #[expect(clippy::expect_used)]
 mod tests {

--- a/crates/rari/src/server/routing/api_routes.rs
+++ b/crates/rari/src/server/routing/api_routes.rs
@@ -20,8 +20,9 @@ use tokio::fs;
 use crate::{
     runtime::JsExecutionRuntime,
     server::{
-        core::utils::http::extract_headers, middleware::request_context::RequestContext,
-        routing::types::RouteSegment,
+        core::utils::http::extract_headers,
+        middleware::request_context::RequestContext,
+        routing::types::{RouteSegment, RouteSegmentType},
     },
 };
 
@@ -139,30 +140,7 @@ impl ApiRouteHandler {
 
     #[expect(clippy::missing_errors_doc)]
     pub fn match_route(&self, path: &str, method: &str) -> Result<ApiRouteMatch, RariError> {
-        let normalized_path = Self::normalize_path(path);
-
-        for route in &self.manifest.api_routes {
-            if let Some(params) = Self::match_route_pattern(route, &normalized_path) {
-                if !route.methods.iter().any(|m| m.eq_ignore_ascii_case(method)) {
-                    return Err(RariError::bad_request(format!(
-                        "Method {} not allowed for route {}. Supported methods: {}",
-                        method,
-                        route.path,
-                        route.methods.join(", ")
-                    ))
-                    .with_property("error_type", "method_not_allowed")
-                    .with_property("allowed_methods", &route.methods.join(",")));
-                }
-
-                return Ok(ApiRouteMatch {
-                    route: route.clone(),
-                    params,
-                    method: method.to_string(),
-                });
-            }
-        }
-
-        Err(RariError::not_found(format!("No API route found for path: {path}")))
+        match_api_routes(&self.manifest, path, method)
     }
 
     fn match_route_pattern(route: &ApiRouteEntry, path: &str) -> Option<FxHashMap<String, String>> {
@@ -632,6 +610,122 @@ impl ApiRouteHandler {
                 .map_err(|e| RariError::internal(format!("Failed to build response: {e}")))
         }
     }
+}
+
+fn match_api_routes(
+    manifest: &ApiRouteManifest,
+    path: &str,
+    method: &str,
+) -> Result<ApiRouteMatch, RariError> {
+    let normalized_path = ApiRouteHandler::normalize_path(path);
+
+    for route in &manifest.api_routes {
+        if let Some(params) = ApiRouteHandler::match_route_pattern(route, &normalized_path) {
+            if !route.methods.iter().any(|m| m.eq_ignore_ascii_case(method)) {
+                return Err(RariError::bad_request(format!(
+                    "Method {} not allowed for route {}. Supported methods: {}",
+                    method,
+                    route.path,
+                    route.methods.join(", ")
+                ))
+                .with_property("error_type", "method_not_allowed")
+                .with_property("allowed_methods", &route.methods.join(",")));
+            }
+
+            return Ok(ApiRouteMatch { route: route.clone(), params, method: method.to_string() });
+        }
+    }
+
+    Err(RariError::not_found(format!("No API route found for path: {path}")))
+}
+
+/// API route manifest with ~50 filler routes for CodSpeed routing benchmarks.
+#[doc(hidden)]
+pub fn bench_api_route_manifest() -> ApiRouteManifest {
+    let mut api_routes = Vec::with_capacity(53);
+    for index in 0..50 {
+        api_routes.push(ApiRouteEntry {
+            path: format!("/api/section-{index}"),
+            file_path: format!("api/section-{index}/route.ts"),
+            component_id: None,
+            segments: vec![RouteSegment {
+                segment_type: RouteSegmentType::Static,
+                value: format!("section-{index}"),
+                param: None,
+            }],
+            params: vec![],
+            is_dynamic: false,
+            methods: vec!["GET".to_string()],
+        });
+    }
+
+    api_routes.extend([
+        ApiRouteEntry {
+            path: "/api/health".to_string(),
+            file_path: "api/health/route.ts".to_string(),
+            component_id: None,
+            segments: vec![RouteSegment {
+                segment_type: RouteSegmentType::Static,
+                value: "health".to_string(),
+                param: None,
+            }],
+            params: vec![],
+            is_dynamic: false,
+            methods: vec!["GET".to_string()],
+        },
+        ApiRouteEntry {
+            path: "/api/users/[id]".to_string(),
+            file_path: "api/users/[id]/route.ts".to_string(),
+            component_id: None,
+            segments: vec![
+                RouteSegment {
+                    segment_type: RouteSegmentType::Static,
+                    value: "users".to_string(),
+                    param: None,
+                },
+                RouteSegment {
+                    segment_type: RouteSegmentType::Dynamic,
+                    value: "[id]".to_string(),
+                    param: Some("id".to_string()),
+                },
+            ],
+            params: vec!["id".to_string()],
+            is_dynamic: true,
+            methods: vec!["GET".to_string(), "POST".to_string()],
+        },
+        ApiRouteEntry {
+            path: "/api/files/[...path]".to_string(),
+            file_path: "api/files/[...path]/route.ts".to_string(),
+            component_id: None,
+            segments: vec![
+                RouteSegment {
+                    segment_type: RouteSegmentType::Static,
+                    value: "files".to_string(),
+                    param: None,
+                },
+                RouteSegment {
+                    segment_type: RouteSegmentType::CatchAll,
+                    value: "[...path]".to_string(),
+                    param: Some("path".to_string()),
+                },
+            ],
+            params: vec!["path".to_string()],
+            is_dynamic: true,
+            methods: vec!["GET".to_string()],
+        },
+    ]);
+
+    ApiRouteManifest { api_routes }
+}
+
+/// Match API routes without constructing a full `ApiRouteHandler` (CodSpeed benchmarks).
+#[doc(hidden)]
+pub fn bench_match_api_route(
+    manifest: &ApiRouteManifest,
+    path: &str,
+    method: &str,
+) -> Result<ApiRouteMatch, RariError> {
+    match_api_routes(manifest, path, method)
 }
 
 #[cfg(test)]

--- a/crates/rari/src/server/routing/api_routes.rs
+++ b/crates/rari/src/server/routing/api_routes.rs
@@ -17,12 +17,13 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::fs;
 
+#[cfg(feature = "bench")]
+use crate::server::routing::types::RouteSegmentType;
 use crate::{
     runtime::JsExecutionRuntime,
     server::{
-        core::utils::http::extract_headers,
-        middleware::request_context::RequestContext,
-        routing::types::{RouteSegment, RouteSegmentType},
+        core::utils::http::extract_headers, middleware::request_context::RequestContext,
+        routing::types::RouteSegment,
     },
 };
 
@@ -640,6 +641,7 @@ fn match_api_routes(
 }
 
 /// API route manifest with ~50 filler routes for CodSpeed routing benchmarks.
+#[cfg(feature = "bench")]
 #[doc(hidden)]
 pub fn bench_api_route_manifest() -> ApiRouteManifest {
     let mut api_routes = Vec::with_capacity(53);
@@ -719,6 +721,7 @@ pub fn bench_api_route_manifest() -> ApiRouteManifest {
 }
 
 /// Match API routes without constructing a full `ApiRouteHandler` (CodSpeed benchmarks).
+#[cfg(feature = "bench")]
 #[doc(hidden)]
 pub fn bench_match_api_route(
     manifest: &ApiRouteManifest,

--- a/crates/rari/src/server/routing/app_router.rs
+++ b/crates/rari/src/server/routing/app_router.rs
@@ -6,7 +6,9 @@ use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use tokio::fs;
 
-use crate::server::routing::types::{ParamValue, RouteSegment, RouteSegmentType};
+#[cfg(any(test, feature = "bench"))]
+use crate::server::routing::types::RouteSegmentType;
+use crate::server::routing::types::{ParamValue, RouteSegment};
 
 fn parse_decoded_path_segments(path: &str) -> Vec<String> {
     path.split('/')
@@ -656,6 +658,7 @@ impl AppRouter {
 }
 
 /// Route manifest with ~50 filler routes for CodSpeed routing benchmarks.
+#[cfg(feature = "bench")]
 #[doc(hidden)]
 #[expect(clippy::too_many_lines)]
 pub fn bench_route_manifest() -> AppRouteManifest {

--- a/crates/rari/src/server/routing/app_router.rs
+++ b/crates/rari/src/server/routing/app_router.rs
@@ -6,9 +6,7 @@ use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use tokio::fs;
 
-#[cfg(test)]
-use crate::server::routing::types::RouteSegmentType;
-use crate::server::routing::types::{ParamValue, RouteSegment};
+use crate::server::routing::types::{ParamValue, RouteSegment, RouteSegmentType};
 
 fn parse_decoded_path_segments(path: &str) -> Vec<String> {
     path.split('/')
@@ -654,6 +652,127 @@ impl AppRouter {
         } else {
             Some(format!("/{}", result_segments.join("/")))
         }
+    }
+}
+
+/// Route manifest with ~50 filler routes for CodSpeed routing benchmarks.
+#[doc(hidden)]
+#[expect(clippy::too_many_lines)]
+pub fn bench_route_manifest() -> AppRouteManifest {
+    let mut routes = Vec::with_capacity(53);
+    for index in 0..50 {
+        routes.push(AppRouteEntry {
+            path: format!("/section-{index}"),
+            file_path: format!("section-{index}/page.tsx"),
+            component_id: None,
+            css: vec![],
+            segments: vec![RouteSegment {
+                segment_type: RouteSegmentType::Static,
+                value: format!("section-{index}"),
+                param: None,
+            }],
+            params: vec![],
+            is_dynamic: false,
+            static_params: None,
+        });
+    }
+
+    routes.extend([
+        AppRouteEntry {
+            path: "/".to_string(),
+            file_path: "page.tsx".to_string(),
+            component_id: None,
+            css: vec![],
+            segments: vec![],
+            params: vec![],
+            is_dynamic: false,
+            static_params: None,
+        },
+        AppRouteEntry {
+            path: "/about".to_string(),
+            file_path: "about/page.tsx".to_string(),
+            component_id: None,
+            css: vec![],
+            segments: vec![RouteSegment {
+                segment_type: RouteSegmentType::Static,
+                value: "about".to_string(),
+                param: None,
+            }],
+            params: vec![],
+            is_dynamic: false,
+            static_params: None,
+        },
+        AppRouteEntry {
+            path: "/blog/[slug]".to_string(),
+            file_path: "blog/[slug]/page.tsx".to_string(),
+            component_id: None,
+            css: vec![],
+            segments: vec![
+                RouteSegment {
+                    segment_type: RouteSegmentType::Static,
+                    value: "blog".to_string(),
+                    param: None,
+                },
+                RouteSegment {
+                    segment_type: RouteSegmentType::Dynamic,
+                    value: "[slug]".to_string(),
+                    param: Some("slug".to_string()),
+                },
+            ],
+            params: vec!["slug".to_string()],
+            is_dynamic: true,
+            static_params: None,
+        },
+        AppRouteEntry {
+            path: "/docs/[...slug]".to_string(),
+            file_path: "docs/[...slug]/page.tsx".to_string(),
+            component_id: None,
+            css: vec![],
+            segments: vec![
+                RouteSegment {
+                    segment_type: RouteSegmentType::Static,
+                    value: "docs".to_string(),
+                    param: None,
+                },
+                RouteSegment {
+                    segment_type: RouteSegmentType::CatchAll,
+                    value: "[...slug]".to_string(),
+                    param: Some("slug".to_string()),
+                },
+            ],
+            params: vec!["slug".to_string()],
+            is_dynamic: true,
+            static_params: None,
+        },
+    ]);
+
+    AppRouteManifest {
+        routes,
+        layouts: vec![
+            LayoutEntry {
+                path: "/".to_string(),
+                file_path: "layout.tsx".to_string(),
+                component_id: None,
+                css: vec![],
+                parent_path: None,
+                additional_paths: None,
+                is_root: false,
+            },
+            LayoutEntry {
+                path: "/blog".to_string(),
+                file_path: "blog/layout.tsx".to_string(),
+                component_id: None,
+                css: vec![],
+                parent_path: Some("/".to_string()),
+                additional_paths: None,
+                is_root: false,
+            },
+        ],
+        loading: vec![],
+        errors: vec![],
+        not_found: vec![],
+        templates: vec![],
+        generated: "2026-01-01T00:00:00.000Z".to_string(),
     }
 }
 

--- a/crates/rari_use_cache/Cargo.toml
+++ b/crates/rari_use_cache/Cargo.toml
@@ -31,7 +31,7 @@ sha2 = { workspace = true }
 napi-build = "2.3.2"
 
 [dev-dependencies]
-divan = { package = "codspeed-divan-compat", version = "5.0.1" }
+divan = { workspace = true }
 
 [[bench]]
 name = "transform"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance / Benchmarks (Chores)**
  * Updated the CodSpeed workflow to include a snapshot placeholder and expanded benchmark coverage for both `rari_use_cache` and `rari`, including the `rari/bench` feature and `hot_paths` benchmark.
  * Added a new `hot_paths` benchmark suite and additional benchmark fixtures/helpers for app routing, API routing, metadata injection, and in-memory cache behavior.

* **Dependency / Setup (Chores)**
  * Updated CodSpeed-related tooling configuration to use the workspace-provided `divan` dependency.
  * Adjusted the React ESM bundling action to support optional toolchain setup, and disabled it in CI/release bundle steps.

* **API Updates**
  * Expanded public layout utilities by re-exporting `create_component_id` and `generate_cache_key`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->