### PR TITLE
chore(eslint, vite): disable no-console rule for TypeScript files in bundle-react-esm directory

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -40,6 +40,12 @@ export default antfu(
       'unused-imports/no-unused-vars': 'off',
     },
   },
+  {
+    files: ['tools/bundle-react-esm/*.ts'],
+    rules: {
+      'no-console': 'off',
+    },
+  },
   deMorgan.configs.recommended,
   ...oxlint.buildFromOxlintConfigFile(join(import.meta.dirname, 'vite.config.ts')),
 )

--- a/packages/rari/src/runtime/flight/route-cache.ts
+++ b/packages/rari/src/runtime/flight/route-cache.ts
@@ -3,7 +3,6 @@ import type { SegmentPath } from './router-state'
 import {
   buildFlightRouterState,
   pathnameFromSegmentPath,
-
   segmentPathFromPathname,
 } from './router-state'
 

--- a/packages/rari/src/runtime/flight/serialize-router-state.ts
+++ b/packages/rari/src/runtime/flight/serialize-router-state.ts
@@ -1,7 +1,6 @@
 import type { FlightRouterState } from './router-state'
 import {
   buildFlightRouterState,
-
 } from './router-state'
 
 export interface RariRouterState {

--- a/tools/bundle-react-esm/bundle.ts
+++ b/tools/bundle-react-esm/bundle.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { Buffer } from 'node:buffer'
 import fs from 'node:fs'
 import { createRequire } from 'node:module'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -631,6 +631,14 @@ export default defineConfig({
       },
       {
         files: [
+          'tools/bundle-react-esm/*.ts',
+        ],
+        rules: {
+          'no-console': 'off',
+        },
+      },
+      {
+        files: [
           '**/*.js',
           '**/*.cjs',
         ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated linting configuration for bundling tools to allow console output.
  - Removed a redundant file-level lint suppression.
  - Standardized import formatting in internal runtime files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->