### PR TITLE
refactor(use-cache): remove quick-lru dependency and implement custom LRU cache

### DIFF
--- a/packages/use-cache/package.json
+++ b/packages/use-cache/package.json
@@ -62,9 +62,6 @@
   "peerDependencies": {
     "react-server-dom-webpack": "catalog:react"
   },
-  "dependencies": {
-    "quick-lru": "catalog:runtime"
-  },
   "optionalDependencies": {
     "@rari/use-cache-darwin-arm64": "workspace:*",
     "@rari/use-cache-darwin-x64": "workspace:*",

--- a/packages/use-cache/src/runtime/storage/lru.ts
+++ b/packages/use-cache/src/runtime/storage/lru.ts
@@ -1,0 +1,51 @@
+interface LruEntry<V> {
+  value: V
+  expiry?: number
+}
+
+export class LruCache<K, V> {
+  private readonly map = new Map<K, LruEntry<V>>()
+  private readonly maxSize: number
+
+  constructor(maxSize: number) {
+    if (!(maxSize > 0))
+      throw new TypeError('`maxSize` must be a number greater than 0')
+    this.maxSize = maxSize
+  }
+
+  get(key: K): V | undefined {
+    const entry = this.map.get(key)
+    if (!entry)
+      return undefined
+
+    if (entry.expiry !== undefined && entry.expiry <= Date.now()) {
+      this.map.delete(key)
+      return undefined
+    }
+
+    this.map.delete(key)
+    this.map.set(key, entry)
+    return entry.value
+  }
+
+  set(key: K, value: V, maxAge?: number): void {
+    if (this.map.has(key))
+      this.map.delete(key)
+
+    const entry: LruEntry<V> = { value }
+    if (typeof maxAge === 'number' && Number.isFinite(maxAge))
+      entry.expiry = Date.now() + maxAge
+
+    this.map.set(key, entry)
+
+    if (this.map.size > this.maxSize) {
+      const oldest = this.map.keys().next().value
+      if (oldest !== undefined)
+        this.map.delete(oldest)
+    }
+  }
+
+  delete(key: K): boolean {
+    return this.map.delete(key)
+  }
+}

--- a/packages/use-cache/src/runtime/storage/memory.ts
+++ b/packages/use-cache/src/runtime/storage/memory.ts
@@ -1,13 +1,12 @@
 import type { CacheStorage, CacheStorageEntry, CacheWriteOptions } from './types'
-import QuickLRU from 'quick-lru'
-
 import { registerUseCacheEntryTags } from '@/runtime/invalidation/cache-tag-registry'
+import { LruCache } from './lru'
 
 export class MemoryCacheStorage implements CacheStorage {
-  private readonly cache: QuickLRU<string, CacheStorageEntry>
+  private readonly cache: LruCache<string, CacheStorageEntry>
 
   constructor(maxEntries: number = 1000) {
-    this.cache = new QuickLRU<string, CacheStorageEntry>({ maxSize: maxEntries })
+    this.cache = new LruCache<string, CacheStorageEntry>(maxEntries)
   }
 
   async read(key: string) {
@@ -15,7 +14,7 @@ export class MemoryCacheStorage implements CacheStorage {
   }
 
   async write(key: string, value: unknown, options: CacheWriteOptions) {
-    this.cache.set(key, { value }, { maxAge: options.ttlMs })
+    this.cache.set(key, { value }, options.ttlMs)
     if (options.tags?.length)
       registerUseCacheEntryTags(key, options.tags)
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,10 +96,6 @@ catalogs:
     react-server-dom-webpack:
       specifier: ^19.2.7
       version: 19.2.7
-  runtime:
-    quick-lru:
-      specifier: ^7.3.0
-      version: 7.3.0
   tailwind:
     '@tailwindcss/vite':
       specifier: ^4.3.2
@@ -328,9 +324,6 @@ importers:
 
   packages/use-cache:
     dependencies:
-      quick-lru:
-        specifier: catalog:runtime
-        version: 7.3.0
       react-server-dom-webpack:
         specifier: catalog:react
         version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.107.2)
@@ -4382,10 +4375,6 @@ packages:
 
   query-selector-shadow-dom@1.0.1:
     resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
-
-  quick-lru@7.3.0:
-    resolution: {integrity: sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g==}
-    engines: {node: '>=18'}
 
   rari-darwin-arm64@0.14.12:
     resolution: {integrity: sha512-wmmhoqtLJ6EvEOiW/V5V7uFgILmTqCnkXXfUcJxDYxU8IuvA7hSoVBEqSt8ZVurKYGwi6SOugUHtmPZDNgw3fQ==}
@@ -9095,8 +9084,6 @@ snapshots:
   quansync@0.2.11: {}
 
   query-selector-shadow-dom@1.0.1: {}
-
-  quick-lru@7.3.0: {}
 
   rari-darwin-arm64@0.14.12:
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -77,8 +77,6 @@ catalogs:
     react: ^19.2.7
     react-dom: ^19.2.7
     react-server-dom-webpack: ^19.2.7
-  runtime:
-    quick-lru: ^7.3.0
   tailwind:
     '@tailwindcss/vite': ^4.3.2
     tailwindcss: ^4.3.2

--- a/test/unit/runtime/cache-wrapper.test.ts
+++ b/test/unit/runtime/cache-wrapper.test.ts
@@ -14,7 +14,7 @@ function uninstallOpsMock(): void {
 }
 
 const CACHE_LIMIT = 1000
-const FILL_COUNT = 2 * CACHE_LIMIT + 500
+const FILL_COUNT = CACHE_LIMIT + 1
 
 async function callCache<Args extends unknown[]>(
   kind: string,
@@ -154,7 +154,7 @@ describe('$$cache__', () => {
     expect(r2).toBe(10)
   })
 
-  it('evicts least recently used resolved entries after exceeding the relaxed LRU ceiling', async () => {
+  it('evicts least recently used resolved entries after exceeding the LRU max size', async () => {
     let callCount = 0
     const fn = (a: number) => {
       callCount++

--- a/test/unit/runtime/lru-cache.test.ts
+++ b/test/unit/runtime/lru-cache.test.ts
@@ -2,6 +2,11 @@ import { LruCache } from '@rari/use-cache/runtime/storage/lru'
 import { describe, expect, it } from 'vite-plus/test'
 
 describe('LruCache', () => {
+  it('throws TypeError when maxSize is zero or below', () => {
+    expect(() => new LruCache<string, number>(0)).toThrow(TypeError)
+    expect(() => new LruCache<string, number>(-1)).toThrow(TypeError)
+  })
+
   it('evicts the least recently used entry when max size is exceeded', () => {
     const cache = new LruCache<string, number>(2)
     cache.set('a', 1)
@@ -25,6 +30,25 @@ describe('LruCache', () => {
     expect(cache.get('c')).toBe(3)
   })
 
+  it('replaces the value when setting an existing key', () => {
+    const cache = new LruCache<string, number>(10)
+    cache.set('a', 1)
+    cache.set('a', 2)
+    expect(cache.get('a')).toBe(2)
+  })
+
+  it('refreshes recency when setting an existing key', () => {
+    const cache = new LruCache<string, number>(2)
+    cache.set('a', 1)
+    cache.set('b', 2)
+    cache.set('a', 10)
+    cache.set('c', 3)
+
+    expect(cache.get('b')).toBeUndefined()
+    expect(cache.get('a')).toBe(10)
+    expect(cache.get('c')).toBe(3)
+  })
+
   it('expires entries after maxAge', () => {
     const cache = new LruCache<string, number>(10)
     cache.set('a', 1, 0)
@@ -35,5 +59,15 @@ describe('LruCache', () => {
     const cache = new LruCache<string, number>(10)
     cache.set('a', 1, Number.POSITIVE_INFINITY)
     expect(cache.get('a')).toBe(1)
+  })
+
+  it('supersedes previous expiry when setting an existing key with a new maxAge', () => {
+    const cache = new LruCache<string, number>(10)
+    cache.set('a', 1, 0)
+    cache.set('a', 2, Number.POSITIVE_INFINITY)
+    expect(cache.get('a')).toBe(2)
+
+    cache.set('a', 3, 0)
+    expect(cache.get('a')).toBeUndefined()
   })
 })

--- a/test/unit/runtime/lru-cache.test.ts
+++ b/test/unit/runtime/lru-cache.test.ts
@@ -1,0 +1,39 @@
+import { LruCache } from '@rari/use-cache/runtime/storage/lru'
+import { describe, expect, it } from 'vite-plus/test'
+
+describe('LruCache', () => {
+  it('evicts the least recently used entry when max size is exceeded', () => {
+    const cache = new LruCache<string, number>(2)
+    cache.set('a', 1)
+    cache.set('b', 2)
+    cache.set('c', 3)
+
+    expect(cache.get('a')).toBeUndefined()
+    expect(cache.get('b')).toBe(2)
+    expect(cache.get('c')).toBe(3)
+  })
+
+  it('treats get as a use and delays eviction of that key', () => {
+    const cache = new LruCache<string, number>(2)
+    cache.set('a', 1)
+    cache.set('b', 2)
+    expect(cache.get('a')).toBe(1)
+    cache.set('c', 3)
+
+    expect(cache.get('b')).toBeUndefined()
+    expect(cache.get('a')).toBe(1)
+    expect(cache.get('c')).toBe(3)
+  })
+
+  it('expires entries after maxAge', () => {
+    const cache = new LruCache<string, number>(10)
+    cache.set('a', 1, 0)
+    expect(cache.get('a')).toBeUndefined()
+  })
+
+  it('does not expire when maxAge is infinite', () => {
+    const cache = new LruCache<string, number>(10)
+    cache.set('a', 1, Number.POSITIVE_INFINITY)
+    expect(cache.get('a')).toBe(1)
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-memory LRU cache with configurable max size, per-entry TTL, and recency refresh on reads/updates.
* **Bug Fixes**
  * Expired entries are no longer returned, including immediate expiration when TTL is set to `0`.
  * Eviction now follows strict LRU max-size behavior, including after repeated `set` calls with updated TTLs.
* **Tests**
  * Added unit tests for constructor validation, LRU eviction, recency updates, and expiration precedence.
  * Updated cache-wrapper eviction scenario setup to match the revised limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->