### PR TITLE
feat(release): add support for manual release notes and improve changelog generation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -450,7 +450,7 @@ cp .github/release-notes/_template.md .github/release-notes/0.15.0.md
 just release
 ```
 
-Lookup order: `--notes-file` / `RELEASE_NOTES_FILE` → `<tag>.md` → `<version>.md`.
+Lookup order: `--notes-file` / `RELEASE_NOTES_FILE` → `<tag>.md` (scoped `/` → `-`) → `<version>.md`.
 
 Manual notes are prepended to the GitHub release body (above the auto-generated commit list) and injected into `CHANGELOG.md` under the new version heading. Patch releases can skip this and stay cliff-only.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -440,6 +440,20 @@ The release process:
 4. Publishes to npm
 5. Uploads binaries to GitHub releases
 
+### Manual release notes (hybrid)
+
+For minors/majors, add curated notes under `.github/release-notes/` before releasing:
+
+```bash
+cp .github/release-notes/_template.md .github/release-notes/0.15.0.md
+# edit Highlights / Breaking Changes, then:
+just release
+```
+
+Lookup order: `--notes-file` / `RELEASE_NOTES_FILE` → `<tag>.md` → `<version>.md`.
+
+Manual notes are prepended to the GitHub release body (above the auto-generated commit list) and injected into `CHANGELOG.md` under the new version heading. Patch releases can skip this and stay cliff-only.
+
 ## Pull Request Guidelines
 
 ### Before Submitting

--- a/.github/release-notes/_template.md
+++ b/.github/release-notes/_template.md
@@ -1,0 +1,22 @@
+## Highlights
+
+- Short, user-facing summary of the most important changes
+- Prefer outcomes over commit subjects
+
+## Breaking Changes
+
+- List removals, renames, and required upgrades
+- Include migration hints when possible
+
+<!--
+File naming (checked in order):
+  1. --notes-file / RELEASE_NOTES_FILE
+  2. .github/release-notes/<tag>.md
+     e.g. rari@0.15.0.md, v0.15.0.md, use-cache-binaries@0.15.0.md
+  3. .github/release-notes/<version>.md
+     e.g. 0.15.0.md (shared across release units)
+
+Copy this template to one of those names before running `just release`.
+Manual notes are prepended to git-cliff output for GitHub releases and
+injected under the version heading in CHANGELOG.md.
+-->

--- a/.github/release-notes/_template.md
+++ b/.github/release-notes/_template.md
@@ -12,7 +12,8 @@
 File naming (checked in order):
   1. --notes-file / RELEASE_NOTES_FILE
   2. .github/release-notes/<tag>.md
-     e.g. rari@0.15.0.md, v0.15.0.md, use-cache-binaries@0.15.0.md
+     `/` in scoped tags is replaced with `-` for the filename
+     e.g. rari@0.15.0.md, v0.15.0.md, @rari-use-cache@0.15.0.md
   3. .github/release-notes/<version>.md
      e.g. 0.15.0.md (shared across release units)
 

--- a/.github/templates/readme/use-cache.md
+++ b/.github/templates/readme/use-cache.md
@@ -1,0 +1,48 @@
+# @rari/use-cache
+
+> Native `"use cache"` directive transform and runtime for [rari](https://github.com/rari-build/rari)
+
+High-performance `"use cache"` support for React Server Components, powered by a Rust NAPI addon.
+
+## Installation
+
+Usually installed automatically with [rari](https://www.npmjs.com/package/rari). To install directly:
+
+```bash
+npm install @rari/use-cache
+```
+
+Enable caching in your rari Vite config:
+
+```ts
+import rari from 'rari/vite'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [
+    rari({
+      experimental: {
+        useCache: true,
+      },
+    }),
+  ],
+})
+```
+
+## What This Does
+
+- Transforms `"use cache"` directives at build time via a native Rust addon
+- Provides cache runtime helpers (`cacheLife`, `cacheTag`, revalidation APIs)
+- Ships platform-specific optional dependencies for macOS, Linux, and Windows
+
+You typically don't need to import this package in app code. rari loads the transform when `experimental.useCache` (or `experimental.useCacheRemote`) is enabled.
+
+## Links
+
+- **Documentation:** [rari.build/docs](https://rari.build/docs)
+- **GitHub:** [github.com/rari-build/rari](https://github.com/rari-build/rari)
+- **Discord:** [Join our community](https://discord.gg/GSh2Ak3b8Q)
+
+## License
+
+MIT License - see [LICENSE](https://github.com/rari-build/rari/blob/main/LICENSE) for details.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -682,8 +682,10 @@ jobs:
       - name: Build package
         run: pnpm --filter "@rari/use-cache" build
 
-      - name: Copy LICENSE
-        run: cp LICENSE packages/use-cache/LICENSE
+      - name: Copy LICENSE and README
+        run: |
+          cp LICENSE packages/use-cache/LICENSE
+          cp .github/templates/readme/use-cache.md packages/use-cache/README.md
 
       - name: Publish to npm
         run: |

--- a/tools/release/src/app.rs
+++ b/tools/release/src/app.rs
@@ -6,7 +6,7 @@ use ratatui::Frame;
 
 use crate::{
     changelog, git,
-    package::{Package, ReleaseType, ReleaseUnit, ReleasedPackage},
+    package::{Package, ReleaseType, ReleaseUnit, ReleasedPackage, release_tag},
     ui,
 };
 
@@ -517,15 +517,5 @@ impl App {
                 ui::render_complete(frame, &self.released_packages, self.dry_run);
             }
         }
-    }
-}
-
-fn release_tag(unit_name: &str, version: &str) -> String {
-    if unit_name == "rari-binaries" {
-        format!("v{version}")
-    } else if unit_name == "@rari/use-cache-binaries" {
-        format!("use-cache-binaries@{version}")
-    } else {
-        format!("{unit_name}@{version}")
     }
 }

--- a/tools/release/src/app.rs
+++ b/tools/release/src/app.rs
@@ -319,9 +319,20 @@ impl App {
                             let package_path = unit.paths()[0];
                             changelog::generate(&tag, unit_name, package_path).await?;
                             if let Some((_, body)) = &manual_notes {
-                                changelog::inject_manual_notes(package_path, version, body).await?;
-                                self.status_messages
-                                    .push("* Injected manual notes into CHANGELOG.md".to_string());
+                                if changelog::inject_manual_notes(package_path, &tag, version, body)
+                                    .await?
+                                {
+                                    self.status_messages.push(
+                                        "* Injected manual notes into CHANGELOG.md".to_string(),
+                                    );
+                                } else {
+                                    let expected =
+                                        changelog::expected_changelog_headings(&tag, version)
+                                            .join("` or `");
+                                    self.status_messages.push(format!(
+                                        "⚠ Could not inject manual notes: missing heading `{expected}` in CHANGELOG.md"
+                                    ));
+                                }
                             }
                         }
                         self.status_messages.push("* Generated changelog".to_string());
@@ -414,7 +425,7 @@ impl App {
                         self.notes_file.as_deref(),
                     )
                     .await
-                    .unwrap_or_else(|_| "See CHANGELOG.md for details.".to_string());
+                    .unwrap_or_else(|_| changelog::CHANGELOG_FALLBACK_NOTES.to_string());
                     self.released_packages.push(ReleasedPackage {
                         name: unit.name().to_string(),
                         version: version.clone(),

--- a/tools/release/src/app.rs
+++ b/tools/release/src/app.rs
@@ -53,11 +53,16 @@ pub struct App {
     pub released_packages: Vec<ReleasedPackage>,
     pub error_message: Option<String>,
     pub dry_run: bool,
+    pub notes_file: Option<PathBuf>,
     pub post_release_messages: Vec<String>,
 }
 
 impl App {
-    pub async fn new(only: Option<Vec<String>>, dry_run: bool) -> Result<Self> {
+    pub async fn new(
+        only: Option<Vec<String>>,
+        dry_run: bool,
+        notes_file: Option<PathBuf>,
+    ) -> Result<Self> {
         use crate::package::{PackageGroup, ReleaseUnit};
 
         let rari_pkg = Package::load("rari", "packages/rari").await?;
@@ -102,6 +107,7 @@ impl App {
             released_packages: vec![],
             error_message: None,
             dry_run,
+            notes_file,
             post_release_messages: vec![],
         })
     }
@@ -286,16 +292,37 @@ impl App {
                     let unit_name = unit.name();
                     let generates_changelog =
                         matches!(unit_name, "rari" | "create-rari-app" | "@rari/use-cache");
+                    let tag = release_tag(unit_name, version);
+                    let notes_override = self.notes_file.as_deref();
+                    let manual_notes =
+                        changelog::load_manual_notes(&tag, version, notes_override).await?;
+
+                    if let Some((path, _)) = &manual_notes {
+                        self.status_messages.push(format!("* Manual notes: {}", path.display()));
+                    } else {
+                        self.status_messages
+                            .push("ℹ No manual release notes found (cliff-only)".to_string());
+                    }
 
                     if generates_changelog {
                         if self.dry_run {
                             self.status_messages
                                 .push("[DRY RUN] Would generate changelog...".to_string());
+                            if manual_notes.is_some() {
+                                self.status_messages.push(
+                                    "[DRY RUN] Would inject manual notes into CHANGELOG.md"
+                                        .to_string(),
+                                );
+                            }
                         } else {
                             self.status_messages.push("Generating changelog...".to_string());
-                            let tag = format!("{unit_name}@{version}");
                             let package_path = unit.paths()[0];
                             changelog::generate(&tag, unit_name, package_path).await?;
+                            if let Some((_, body)) = &manual_notes {
+                                changelog::inject_manual_notes(package_path, version, body).await?;
+                                self.status_messages
+                                    .push("* Injected manual notes into CHANGELOG.md".to_string());
+                            }
                         }
                         self.status_messages.push("* Generated changelog".to_string());
                     } else if self.dry_run {
@@ -310,13 +337,7 @@ impl App {
                 }
                 PublishStep::Committing => {
                     let message = format!("release: {}@{}", unit.name(), version);
-                    let tag = if unit.name() == "rari-binaries" {
-                        format!("v{version}")
-                    } else if unit.name() == "@rari/use-cache-binaries" {
-                        format!("use-cache-binaries@{version}")
-                    } else {
-                        format!("{}@{}", unit.name(), version)
-                    };
+                    let tag = release_tag(unit.name(), version);
                     if self.dry_run {
                         self.status_messages
                             .push(format!("[DRY RUN] Would commit with message: {message}"));
@@ -384,17 +405,13 @@ impl App {
                     self.publish_step = PublishStep::Done;
                     self.publish_progress = 1.0;
 
-                    let tag = if unit.name() == "rari-binaries" {
-                        format!("v{version}")
-                    } else if unit.name() == "@rari/use-cache-binaries" {
-                        format!("use-cache-binaries@{version}")
-                    } else {
-                        format!("{}@{}", unit.name(), version)
-                    };
+                    let tag = release_tag(unit.name(), version);
                     let release_notes = changelog::generate_release_notes(
                         &tag,
                         unit.name(),
                         self.previous_tag.as_deref(),
+                        version,
+                        self.notes_file.as_deref(),
                     )
                     .await
                     .unwrap_or_else(|_| "See CHANGELOG.md for details.".to_string());
@@ -500,5 +517,15 @@ impl App {
                 ui::render_complete(frame, &self.released_packages, self.dry_run);
             }
         }
+    }
+}
+
+fn release_tag(unit_name: &str, version: &str) -> String {
+    if unit_name == "rari-binaries" {
+        format!("v{version}")
+    } else if unit_name == "@rari/use-cache-binaries" {
+        format!("use-cache-binaries@{version}")
+    } else {
+        format!("{unit_name}@{version}")
     }
 }

--- a/tools/release/src/changelog.rs
+++ b/tools/release/src/changelog.rs
@@ -1,7 +1,9 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
-use tokio::process::Command;
+use tokio::{fs, process::Command};
+
+const NOTES_DIR: &str = ".github/release-notes";
 
 pub async fn generate(tag: &str, package_name: &str, package_path: &Path) -> Result<()> {
     let changelog_path = package_path.join("CHANGELOG.md");
@@ -37,7 +39,101 @@ pub async fn generate(tag: &str, package_name: &str, package_path: &Path) -> Res
     Ok(())
 }
 
+/// Resolve manual release notes path.
+///
+/// Lookup order:
+/// 1. Explicit `--notes-file` / override
+/// 2. `.github/release-notes/<tag>.md` (e.g. `rari@0.15.0.md`, `v0.15.0.md`)
+/// 3. `.github/release-notes/<version>.md` (shared across units, e.g. `0.15.0.md`)
+pub fn resolve_notes_path(
+    tag: &str,
+    version: &str,
+    override_path: Option<&Path>,
+) -> Option<PathBuf> {
+    if let Some(path) = override_path {
+        return path.exists().then(|| path.to_path_buf());
+    }
+
+    let dir = Path::new(NOTES_DIR);
+    let candidates = [dir.join(format!("{tag}.md")), dir.join(format!("{version}.md"))];
+    candidates.into_iter().find(|path| path.exists())
+}
+
+pub async fn load_manual_notes(
+    tag: &str,
+    version: &str,
+    override_path: Option<&Path>,
+) -> Result<Option<(PathBuf, String)>> {
+    let Some(path) = resolve_notes_path(tag, version, override_path) else {
+        return Ok(None);
+    };
+
+    let content = fs::read_to_string(&path).await?;
+    let content = content.trim().to_string();
+    if content.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some((path, content)))
+}
+
+pub fn compose_release_notes(manual: Option<&str>, auto: &str) -> String {
+    let manual = manual.map(str::trim).filter(|s| !s.is_empty());
+    let auto = auto.trim();
+
+    match manual {
+        Some(manual) if auto.is_empty() || auto == "See CHANGELOG.md for details." => {
+            manual.to_string()
+        }
+        Some(manual) => format!("{manual}\n\n---\n\n{auto}"),
+        None => auto.to_string(),
+    }
+}
+
+/// Insert manual notes under the newly generated version heading in CHANGELOG.md.
+pub async fn inject_manual_notes(package_path: &Path, version: &str, manual: &str) -> Result<()> {
+    let manual = manual.trim();
+    if manual.is_empty() {
+        return Ok(());
+    }
+
+    let path = package_path.join("CHANGELOG.md");
+    let content = fs::read_to_string(&path).await?;
+    let marker = format!("## [{version}]");
+
+    let Some(idx) = content.find(&marker) else {
+        return Ok(());
+    };
+
+    let line_end = content[idx..].find('\n').map_or(content.len(), |i| idx + i + 1);
+    let mut insert_at = line_end;
+    if content[insert_at..].starts_with('\n') {
+        insert_at += 1;
+    }
+
+    let mut new_content = String::with_capacity(content.len() + manual.len() + 2);
+    new_content.push_str(&content[..insert_at]);
+    new_content.push_str(manual);
+    new_content.push_str("\n\n");
+    new_content.push_str(&content[insert_at..]);
+    fs::write(&path, new_content).await?;
+
+    Ok(())
+}
+
 pub async fn generate_release_notes(
+    tag: &str,
+    package_name: &str,
+    previous_tag: Option<&str>,
+    version: &str,
+    notes_file: Option<&Path>,
+) -> Result<String> {
+    let manual = load_manual_notes(tag, version, notes_file).await?;
+    let auto = generate_auto_release_notes(tag, package_name, previous_tag).await?;
+    Ok(compose_release_notes(manual.as_ref().map(|(_, body)| body.as_str()), &auto))
+}
+
+async fn generate_auto_release_notes(
     tag: &str,
     package_name: &str,
     previous_tag: Option<&str>,
@@ -115,4 +211,30 @@ pub async fn generate_release_notes(
 
     let _ = tag;
     Ok("See CHANGELOG.md for details.".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compose_prepends_manual_with_separator() {
+        let out =
+            compose_release_notes(Some("## Highlights\n\n- big thing"), "### Features\n\n- x");
+        assert!(out.starts_with("## Highlights"));
+        assert!(out.contains("\n\n---\n\n### Features"));
+    }
+
+    #[test]
+    fn compose_manual_only_when_auto_placeholder() {
+        let out =
+            compose_release_notes(Some("## Highlights\n\n- only"), "See CHANGELOG.md for details.");
+        assert_eq!(out, "## Highlights\n\n- only");
+    }
+
+    #[test]
+    fn compose_auto_only_without_manual() {
+        let out = compose_release_notes(None, "### Features\n\n- x");
+        assert_eq!(out, "### Features\n\n- x");
+    }
 }

--- a/tools/release/src/changelog.rs
+++ b/tools/release/src/changelog.rs
@@ -42,21 +42,30 @@ pub async fn generate(tag: &str, package_name: &str, package_path: &Path) -> Res
 /// Resolve manual release notes path.
 ///
 /// Lookup order:
-/// 1. Explicit `--notes-file` / override
-/// 2. `.github/release-notes/<tag>.md` (e.g. `rari@0.15.0.md`, `v0.15.0.md`)
+/// 1. Explicit `--notes-file` / override (if the path exists)
+/// 2. `.github/release-notes/<tag>.md` with `/` in the tag replaced by `-`
+///    (e.g. `rari@0.15.0.md`, `v0.15.0.md`, `@rari-use-cache@0.15.0.md`)
 /// 3. `.github/release-notes/<version>.md` (shared across units, e.g. `0.15.0.md`)
 pub fn resolve_notes_path(
     tag: &str,
     version: &str,
     override_path: Option<&Path>,
 ) -> Option<PathBuf> {
-    if let Some(path) = override_path {
-        return path.exists().then(|| path.to_path_buf());
+    if let Some(path) = override_path
+        && path.exists()
+    {
+        return Some(path.to_path_buf());
     }
 
     let dir = Path::new(NOTES_DIR);
-    let candidates = [dir.join(format!("{tag}.md")), dir.join(format!("{version}.md"))];
+    let candidates = [dir.join(tag_notes_filename(tag)), dir.join(format!("{version}.md"))];
     candidates.into_iter().find(|path| path.exists())
+}
+
+/// Flat filename for a release tag. Scoped tags contain `/`, which must not be
+/// passed to `Path::join` or it becomes a subdirectory on Unix.
+fn tag_notes_filename(tag: &str) -> String {
+    format!("{}.md", tag.replace('/', "-"))
 }
 
 pub async fn load_manual_notes(
@@ -211,30 +220,4 @@ async fn generate_auto_release_notes(
 
     let _ = tag;
     Ok("See CHANGELOG.md for details.".to_string())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn compose_prepends_manual_with_separator() {
-        let out =
-            compose_release_notes(Some("## Highlights\n\n- big thing"), "### Features\n\n- x");
-        assert!(out.starts_with("## Highlights"));
-        assert!(out.contains("\n\n---\n\n### Features"));
-    }
-
-    #[test]
-    fn compose_manual_only_when_auto_placeholder() {
-        let out =
-            compose_release_notes(Some("## Highlights\n\n- only"), "See CHANGELOG.md for details.");
-        assert_eq!(out, "## Highlights\n\n- only");
-    }
-
-    #[test]
-    fn compose_auto_only_without_manual() {
-        let out = compose_release_notes(None, "### Features\n\n- x");
-        assert_eq!(out, "### Features\n\n- x");
-    }
 }

--- a/tools/release/src/changelog.rs
+++ b/tools/release/src/changelog.rs
@@ -5,6 +5,8 @@ use tokio::{fs, process::Command};
 
 const NOTES_DIR: &str = ".github/release-notes";
 
+pub const CHANGELOG_FALLBACK_NOTES: &str = "See CHANGELOG.md for details.";
+
 pub async fn generate(tag: &str, package_name: &str, package_path: &Path) -> Result<()> {
     let changelog_path = package_path.join("CHANGELOG.md");
 
@@ -91,27 +93,32 @@ pub fn compose_release_notes(manual: Option<&str>, auto: &str) -> String {
     let auto = auto.trim();
 
     match manual {
-        Some(manual) if auto.is_empty() || auto == "See CHANGELOG.md for details." => {
-            manual.to_string()
-        }
+        Some(manual) if auto.is_empty() || auto == CHANGELOG_FALLBACK_NOTES => manual.to_string(),
         Some(manual) => format!("{manual}\n\n---\n\n{auto}"),
         None => auto.to_string(),
     }
 }
 
 /// Insert manual notes under the newly generated version heading in CHANGELOG.md.
-pub async fn inject_manual_notes(package_path: &Path, version: &str, manual: &str) -> Result<()> {
+///
+/// Returns `Ok(true)` when notes were injected, or `Ok(false)` when no matching
+/// heading was found (caller should warn; this is not treated as a hard error).
+pub async fn inject_manual_notes(
+    package_path: &Path,
+    tag: &str,
+    version: &str,
+    manual: &str,
+) -> Result<bool> {
     let manual = manual.trim();
     if manual.is_empty() {
-        return Ok(());
+        return Ok(true);
     }
 
     let path = package_path.join("CHANGELOG.md");
     let content = fs::read_to_string(&path).await?;
-    let marker = format!("## [{version}]");
 
-    let Some(idx) = content.find(&marker) else {
-        return Ok(());
+    let Some(idx) = find_changelog_heading(&content, tag, version) else {
+        return Ok(false);
     };
 
     let line_end = content[idx..].find('\n').map_or(content.len(), |i| idx + i + 1);
@@ -127,7 +134,27 @@ pub async fn inject_manual_notes(package_path: &Path, version: &str, manual: &st
     new_content.push_str(&content[insert_at..]);
     fs::write(&path, new_content).await?;
 
-    Ok(())
+    Ok(true)
+}
+
+/// Headings `inject_manual_notes` looks for, for warning messages.
+pub fn expected_changelog_headings(tag: &str, version: &str) -> Vec<String> {
+    let cliff_heading = format!("## [{}]", tag.trim_start_matches('v'));
+    let version_heading = format!("## [{version}]");
+    if cliff_heading == version_heading {
+        vec![cliff_heading]
+    } else {
+        vec![cliff_heading, version_heading]
+    }
+}
+
+fn find_changelog_heading(content: &str, tag: &str, version: &str) -> Option<usize> {
+    let cliff_heading = format!("## [{}]", tag.trim_start_matches('v'));
+    let version_heading = format!("## [{version}]");
+
+    content.find(&cliff_heading).or_else(|| {
+        if cliff_heading == version_heading { None } else { content.find(&version_heading) }
+    })
 }
 
 pub async fn generate_release_notes(
@@ -219,5 +246,5 @@ async fn generate_auto_release_notes(
     }
 
     let _ = tag;
-    Ok("See CHANGELOG.md for details.".to_string())
+    Ok(CHANGELOG_FALLBACK_NOTES.to_string())
 }

--- a/tools/release/src/main.rs
+++ b/tools/release/src/main.rs
@@ -22,7 +22,9 @@ use crossterm::{
 };
 use ratatui::{Terminal, backend::CrosstermBackend};
 
-use crate::package::{Package, PackageGroup, ReleaseType, ReleaseUnit, ReleasedPackage};
+use crate::package::{
+    Package, PackageGroup, ReleaseType, ReleaseUnit, ReleasedPackage, release_tag,
+};
 
 #[derive(Parser, Debug)]
 #[command(name = "release")]
@@ -233,13 +235,7 @@ async fn run_non_interactive(
 
         let generates_changelog =
             matches!(unit_name, "rari" | "create-rari-app" | "@rari/use-cache");
-        let tag = if unit_name == "rari-binaries" {
-            format!("v{new_version}")
-        } else if unit_name == "@rari/use-cache-binaries" {
-            format!("use-cache-binaries@{new_version}")
-        } else {
-            format!("{unit_name}@{new_version}")
-        };
+        let tag = release_tag(unit_name, &new_version);
         let notes_override = notes_file.as_deref();
         let manual_notes = changelog::load_manual_notes(&tag, &new_version, notes_override).await?;
 

--- a/tools/release/src/main.rs
+++ b/tools/release/src/main.rs
@@ -39,6 +39,9 @@ struct Args {
 
     #[arg(long)]
     no_push: bool,
+
+    #[arg(long)]
+    notes_file: Option<PathBuf>,
 }
 
 #[expect(clippy::print_stdout)]
@@ -62,9 +65,20 @@ async fn main() -> Result<()> {
 
     let env_version = env::var("RELEASE_VERSION").ok();
     let env_type = env::var("RELEASE_TYPE").ok();
+    let notes_file = args.notes_file.or_else(|| {
+        env::var("RELEASE_NOTES_FILE").ok().filter(|s| !s.is_empty()).map(PathBuf::from)
+    });
 
     if args.non_interactive || env_version.is_some() || env_type.is_some() {
-        return run_non_interactive(only, args.dry_run, args.no_push, env_version, env_type).await;
+        return run_non_interactive(
+            only,
+            args.dry_run,
+            args.no_push,
+            env_version,
+            env_type,
+            notes_file,
+        )
+        .await;
     }
 
     if !args.dry_run {
@@ -79,7 +93,7 @@ async fn main() -> Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let mut app = App::new(only, args.dry_run).await?;
+    let mut app = App::new(only, args.dry_run, notes_file).await?;
 
     let result = run_app(&mut terminal, &mut app).await;
 
@@ -118,6 +132,7 @@ async fn run_non_interactive(
     no_push: bool,
     env_version: Option<String>,
     env_type: Option<String>,
+    notes_file: Option<PathBuf>,
 ) -> Result<()> {
     println!("{}", "rari Release Script".cyan().bold());
     if dry_run {
@@ -218,9 +233,31 @@ async fn run_non_interactive(
 
         let generates_changelog =
             matches!(unit_name, "rari" | "create-rari-app" | "@rari/use-cache");
+        let tag = if unit_name == "rari-binaries" {
+            format!("v{new_version}")
+        } else if unit_name == "@rari/use-cache-binaries" {
+            format!("use-cache-binaries@{new_version}")
+        } else {
+            format!("{unit_name}@{new_version}")
+        };
+        let notes_override = notes_file.as_deref();
+        let manual_notes = changelog::load_manual_notes(&tag, &new_version, notes_override).await?;
+
+        if let Some((path, _)) = &manual_notes {
+            println!("  {} Manual notes: {}", "✓".green(), path.display());
+        } else {
+            println!("  {} No manual release notes (cliff-only)", "ℹ".blue());
+        }
+
         if dry_run {
             if generates_changelog {
                 println!("  {} Would generate changelog...", "[DRY RUN]".yellow());
+                if manual_notes.is_some() {
+                    println!(
+                        "  {} Would inject manual notes into CHANGELOG.md",
+                        "[DRY RUN]".yellow()
+                    );
+                }
             } else {
                 println!(
                     "  {} Would skip changelog generation (binary packages)",
@@ -229,22 +266,18 @@ async fn run_non_interactive(
             }
         } else if generates_changelog {
             println!("  {} Generating changelog...", "→".cyan());
-            let tag = format!("{unit_name}@{new_version}");
             let package_path = unit.paths()[0];
             changelog::generate(&tag, unit_name, package_path).await?;
+            if let Some((_, body)) = &manual_notes {
+                changelog::inject_manual_notes(package_path, &new_version, body).await?;
+                println!("  {} Injected manual notes into CHANGELOG.md", "✓".green());
+            }
             println!("  {} Generated changelog", "✓".green());
         } else {
             println!("  {} Skipping changelog generation", "ℹ".blue());
         }
 
         let message = format!("release: {unit_name}@{new_version}");
-        let tag = if unit_name == "rari-binaries" {
-            format!("v{new_version}")
-        } else if unit_name == "@rari/use-cache-binaries" {
-            format!("use-cache-binaries@{new_version}")
-        } else {
-            format!("{unit_name}@{new_version}")
-        };
         if dry_run {
             println!("  {} Would commit: {}", "[DRY RUN]".yellow(), message);
             println!("  {} Would create tag: {}", "[DRY RUN]".yellow(), tag);
@@ -320,6 +353,8 @@ async fn run_non_interactive(
                 &tag,
                 unit_name,
                 previous_tag.as_deref(),
+                &new_version,
+                notes_file.as_deref(),
             )
             .await
             .unwrap_or_else(|_| "See CHANGELOG.md for details.".to_string()),

--- a/tools/release/src/main.rs
+++ b/tools/release/src/main.rs
@@ -265,8 +265,16 @@ async fn run_non_interactive(
             let package_path = unit.paths()[0];
             changelog::generate(&tag, unit_name, package_path).await?;
             if let Some((_, body)) = &manual_notes {
-                changelog::inject_manual_notes(package_path, &new_version, body).await?;
-                println!("  {} Injected manual notes into CHANGELOG.md", "✓".green());
+                if changelog::inject_manual_notes(package_path, &tag, &new_version, body).await? {
+                    println!("  {} Injected manual notes into CHANGELOG.md", "✓".green());
+                } else {
+                    let expected =
+                        changelog::expected_changelog_headings(&tag, &new_version).join("` or `");
+                    println!(
+                        "  {} Could not inject manual notes: missing heading `{expected}` in CHANGELOG.md",
+                        "⚠".yellow()
+                    );
+                }
             }
             println!("  {} Generated changelog", "✓".green());
         } else {
@@ -353,7 +361,7 @@ async fn run_non_interactive(
                 notes_file.as_deref(),
             )
             .await
-            .unwrap_or_else(|_| "See CHANGELOG.md for details.".to_string()),
+            .unwrap_or_else(|_| changelog::CHANGELOG_FALLBACK_NOTES.to_string()),
             previous_tag,
         });
     }

--- a/tools/release/src/package.rs
+++ b/tools/release/src/package.rs
@@ -83,6 +83,16 @@ pub struct ReleasedPackage {
     pub previous_tag: Option<String>,
 }
 
+pub fn release_tag(unit_name: &str, version: &str) -> String {
+    if unit_name == "rari-binaries" {
+        format!("v{version}")
+    } else if unit_name == "@rari/use-cache-binaries" {
+        format!("use-cache-binaries@{version}")
+    } else {
+        format!("{unit_name}@{version}")
+    }
+}
+
 impl Package {
     pub async fn load(name: &str, path: &str) -> Result<Self> {
         let pkg_path = PathBuf::from(path);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release workflows now support curated manual release notes via an optional `--notes_file` flag (with `RELEASE_NOTES_FILE` fallback), merged with auto-generated notes.
  * Manual notes are used for both GitHub release notes and (when enabled) injection into `CHANGELOG.md`, with clear success/warning messaging when headings don’t match.
  * Standardized release tagging is now used when generating release notes.
* **Documentation**
  * Added a GitHub release-notes template and expanded contributing/release-process documentation for manual notes lookup and merge behavior.
  * Updated the `use-cache` README template and ensured it’s copied into the packaged README during release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->