### PR TITLE
refactor(rendering): enhance HTML output formatting and introduce pretty-printing for development

### DIFF
--- a/crates/rari/src/rendering/static.rs
+++ b/crates/rari/src/rendering/static.rs
@@ -141,8 +141,8 @@ impl RscHtmlRenderer {
             let mut result = String::new();
             result.push_str(&html[..head_end]);
             result.push_str(
-                r#"    <script type="module" src="/@vite/client"></script>
-    <script type="module" src="/src/main.tsx"></script>
+                r#"<script type="module" src="/@vite/client"></script>
+<script type="module" src="/src/main.tsx"></script>
 "#,
             );
             result.push_str(&html[head_end..]);
@@ -153,8 +153,8 @@ impl RscHtmlRenderer {
             let mut result = String::new();
             result.push_str(&html[..body_end]);
             result.push_str(
-                r#"    <script type="module" src="/@vite/client"></script>
-    <script type="module" src="/src/main.tsx"></script>
+                r#"<script type="module" src="/@vite/client"></script>
+<script type="module" src="/src/main.tsx"></script>
 "#,
             );
             result.push_str(&html[body_end..]);

--- a/crates/rari/src/server/cache/warmup.rs
+++ b/crates/rari/src/server/cache/warmup.rs
@@ -151,14 +151,15 @@ async fn warm_route(
         _ => return Ok(()),
     };
 
-    let html = wrap_html_with_metadata(html, context.metadata.as_ref(), state);
-
     let html_cache_key = response::ResponseCache::generate_cache_key(path, None);
-    let etag = response::ResponseCache::generate_etag(html.as_bytes());
     let cache_control = state.config.get_cache_control_for_route(path);
     let cache_policy = response::RouteCachePolicy::from_cache_control(cache_control, path);
+    let for_response_cache = cache_policy.enabled && state.response_cache.config.enabled;
 
-    if cache_policy.enabled && state.response_cache.config.enabled {
+    let html = wrap_html_with_metadata(html, context.metadata.as_ref(), state);
+    let etag = response::ResponseCache::generate_etag(html.as_bytes());
+
+    if for_response_cache {
         let merged_tags = merge_warmup_cache_tags(state, cache_policy.tags.clone()).await;
         let body_bytes = bytes::Bytes::from(html);
 
@@ -221,7 +222,7 @@ async fn warm_route(
         let rsc_cache_key =
             response::ResponseCache::generate_cache_key_with_mode(path, None, Some("rsc"), None);
 
-        if cache_policy.enabled && state.response_cache.config.enabled {
+        if for_response_cache {
             let merged_tags = merge_warmup_cache_tags(state, cache_policy.tags.clone()).await;
             let mut cache_headers = HeaderMap::new();
 

--- a/crates/rari/src/server/config.rs
+++ b/crates/rari/src/server/config.rs
@@ -313,12 +313,11 @@ pub struct RscHtmlConfig {
     pub enabled: bool,
     pub timeout_ms: u64,
     pub cache_template: bool,
-    pub pretty_print: bool,
 }
 
 impl Default for RscHtmlConfig {
     fn default() -> Self {
-        Self { enabled: true, timeout_ms: 5000, cache_template: true, pretty_print: false }
+        Self { enabled: true, timeout_ms: 5000, cache_template: true }
     }
 }
 
@@ -433,10 +432,7 @@ impl Config {
                 ..default_config.vite
             },
             rsc: default_config.rsc,
-            rsc_html: RscHtmlConfig {
-                pretty_print: mode == Mode::Development,
-                ..default_config.rsc_html
-            },
+            rsc_html: default_config.rsc_html,
             caching: CacheControlConfig {
                 server_components: Self::server_components_cache_control_for_mode(mode),
                 ..default_config.caching
@@ -511,12 +507,6 @@ impl Config {
                 == "true"
                 || rsc_html_cache_template_str == "1"
                 || rsc_html_cache_template_str.cow_to_lowercase() == "yes";
-        }
-
-        if let Ok(rsc_html_pretty_print_str) = env::var("RARI_RSC_HTML_PRETTY_PRINT") {
-            config.rsc_html.pretty_print = rsc_html_pretty_print_str.cow_to_lowercase() == "true"
-                || rsc_html_pretty_print_str == "1"
-                || rsc_html_pretty_print_str.cow_to_lowercase() == "yes";
         }
 
         if let Ok(loading_enabled_str) = env::var("RARI_LOADING_ENABLED") {

--- a/crates/rari/src/server/rendering/metadata_injection.rs
+++ b/crates/rari/src/server/rendering/metadata_injection.rs
@@ -43,7 +43,7 @@ pub fn inject_metadata(
             result.insert_str(
                 head_end,
                 &format!(
-                    r#"    <meta name="description" content="{}" />
+                    r#"<meta name="description" content="{}" />
 "#,
                     escape_html(description)
                 ),
@@ -69,7 +69,7 @@ pub fn inject_metadata(
         if !result.contains(r"<meta charset") {
             critical_tags.push_str(
                 r#"
-    <meta charset="UTF-8" />"#,
+<meta charset="UTF-8" />"#,
             );
         }
 
@@ -80,7 +80,7 @@ pub fn inject_metadata(
             write!(
                 critical_tags,
                 r#"
-    <meta name="viewport" content="{}" />"#,
+<meta name="viewport" content="{}" />"#,
                 escape_html(viewport_content)
             )
             .unwrap();
@@ -93,7 +93,7 @@ pub fn inject_metadata(
             write!(
                 critical_tags,
                 r"
-    <title>{}</title>",
+<title>{}</title>",
                 escape_html(title)
             )
             .unwrap();
@@ -113,20 +113,15 @@ pub fn inject_metadata(
             let keywords_str =
                 keywords.iter().map(|k| escape_html(k)).collect::<Vec<_>>().join(", ");
             #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
-            writeln!(meta_tags, r#"    <meta name="keywords" content="{keywords_str}" />"#)
-                .unwrap();
+            writeln!(meta_tags, r#"<meta name="keywords" content="{keywords_str}" />"#).unwrap();
         }
 
         let alternates_canonical = metadata.alternates.as_ref().and_then(|a| a.canonical.as_ref());
         let effective_canonical = alternates_canonical.or(metadata.canonical.as_ref());
         if let Some(canonical) = effective_canonical {
             #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
-            writeln!(
-                meta_tags,
-                r#"    <link rel="canonical" href="{}" />"#,
-                escape_html(canonical)
-            )
-            .unwrap();
+            writeln!(meta_tags, r#"<link rel="canonical" href="{}" />"#, escape_html(canonical))
+                .unwrap();
         }
 
         if let Some(robots) = &metadata.robots {
@@ -146,7 +141,7 @@ pub fn inject_metadata(
                 #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                 writeln!(
                     meta_tags,
-                    r#"    <meta name="robots" content="{}" />"#,
+                    r#"<meta name="robots" content="{}" />"#,
                     robots_content.join(", ")
                 )
                 .unwrap();
@@ -158,7 +153,7 @@ pub fn inject_metadata(
                 #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                 writeln!(
                     meta_tags,
-                    r#"    <meta property="og:title" content="{}" />"#,
+                    r#"<meta property="og:title" content="{}" />"#,
                     escape_html(og_title)
                 )
                 .unwrap();
@@ -167,7 +162,7 @@ pub fn inject_metadata(
                 #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                 writeln!(
                     meta_tags,
-                    r#"    <meta property="og:description" content="{}" />"#,
+                    r#"<meta property="og:description" content="{}" />"#,
                     escape_html(og_description)
                 )
                 .unwrap();
@@ -176,7 +171,7 @@ pub fn inject_metadata(
                 #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                 writeln!(
                     meta_tags,
-                    r#"    <meta property="og:url" content="{}" />"#,
+                    r#"<meta property="og:url" content="{}" />"#,
                     escape_html(og_url)
                 )
                 .unwrap();
@@ -185,7 +180,7 @@ pub fn inject_metadata(
                 #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                 writeln!(
                     meta_tags,
-                    r#"    <meta property="og:site_name" content="{}" />"#,
+                    r#"<meta property="og:site_name" content="{}" />"#,
                     escape_html(og_site_name)
                 )
                 .unwrap();
@@ -194,7 +189,7 @@ pub fn inject_metadata(
                 #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                 writeln!(
                     meta_tags,
-                    r#"    <meta property="og:type" content="{}" />"#,
+                    r#"<meta property="og:type" content="{}" />"#,
                     escape_html(og_type)
                 )
                 .unwrap();
@@ -208,7 +203,7 @@ pub fn inject_metadata(
                     #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                     writeln!(
                         meta_tags,
-                        r#"    <meta property="og:image" content="{}" />"#,
+                        r#"<meta property="og:image" content="{}" />"#,
                         escape_html(image_url)
                     )
                     .unwrap();
@@ -218,7 +213,7 @@ pub fn inject_metadata(
                             #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                             writeln!(
                                 meta_tags,
-                                r#"    <meta property="og:image:width" content="{width}" />"#
+                                r#"<meta property="og:image:width" content="{width}" />"#
                             )
                             .unwrap();
                         }
@@ -226,7 +221,7 @@ pub fn inject_metadata(
                             #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                             writeln!(
                                 meta_tags,
-                                r#"    <meta property="og:image:height" content="{height}" />"#
+                                r#"<meta property="og:image:height" content="{height}" />"#
                             )
                             .unwrap();
                         }
@@ -234,7 +229,7 @@ pub fn inject_metadata(
                             #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                             writeln!(
                                 meta_tags,
-                                r#"    <meta property="og:image:alt" content="{}" />"#,
+                                r#"<meta property="og:image:alt" content="{}" />"#,
                                 escape_html(alt)
                             )
                             .unwrap();
@@ -249,7 +244,7 @@ pub fn inject_metadata(
                 #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                 writeln!(
                     meta_tags,
-                    r#"    <meta name="twitter:card" content="{}" />"#,
+                    r#"<meta name="twitter:card" content="{}" />"#,
                     escape_html(card)
                 )
                 .unwrap();
@@ -258,7 +253,7 @@ pub fn inject_metadata(
                 #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                 writeln!(
                     meta_tags,
-                    r#"    <meta name="twitter:site" content="{}" />"#,
+                    r#"<meta name="twitter:site" content="{}" />"#,
                     escape_html(site)
                 )
                 .unwrap();
@@ -267,7 +262,7 @@ pub fn inject_metadata(
                 #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                 writeln!(
                     meta_tags,
-                    r#"    <meta name="twitter:creator" content="{}" />"#,
+                    r#"<meta name="twitter:creator" content="{}" />"#,
                     escape_html(creator)
                 )
                 .unwrap();
@@ -276,7 +271,7 @@ pub fn inject_metadata(
                 #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                 writeln!(
                     meta_tags,
-                    r#"    <meta name="twitter:title" content="{}" />"#,
+                    r#"<meta name="twitter:title" content="{}" />"#,
                     escape_html(twitter_title)
                 )
                 .unwrap();
@@ -285,7 +280,7 @@ pub fn inject_metadata(
                 #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                 writeln!(
                     meta_tags,
-                    r#"    <meta name="twitter:description" content="{}" />"#,
+                    r#"<meta name="twitter:description" content="{}" />"#,
                     escape_html(twitter_description)
                 )
                 .unwrap();
@@ -295,7 +290,7 @@ pub fn inject_metadata(
                     #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                     writeln!(
                         meta_tags,
-                        r#"    <meta name="twitter:image" content="{}" />"#,
+                        r#"<meta name="twitter:image" content="{}" />"#,
                         escape_html(image)
                     )
                     .unwrap();
@@ -308,19 +303,15 @@ pub fn inject_metadata(
                 match icon_value {
                     IconValue::Single(url) => {
                         #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
-                        writeln!(
-                            meta_tags,
-                            r#"    <link rel="icon" href="{}" />"#,
-                            escape_html(url)
-                        )
-                        .unwrap();
+                        writeln!(meta_tags, r#"<link rel="icon" href="{}" />"#, escape_html(url))
+                            .unwrap();
                     }
                     IconValue::Multiple(urls) => {
                         for url in urls {
                             #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                             writeln!(
                                 meta_tags,
-                                r#"    <link rel="icon" href="{}" />"#,
+                                r#"<link rel="icon" href="{}" />"#,
                                 escape_html(url)
                             )
                             .unwrap();
@@ -350,7 +341,7 @@ pub fn inject_metadata(
                                 write!(&mut attrs, r#" sizes="{}""#, escape_html(sizes)).unwrap();
                             }
                             #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
-                            writeln!(&mut meta_tags, "    <link {attrs} />").unwrap();
+                            writeln!(&mut meta_tags, "<link {attrs} />").unwrap();
                         }
                     }
                 }
@@ -361,7 +352,7 @@ pub fn inject_metadata(
                         #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                         writeln!(
                             meta_tags,
-                            r#"    <link rel="apple-touch-icon" href="{}" />"#,
+                            r#"<link rel="apple-touch-icon" href="{}" />"#,
                             escape_html(url)
                         )
                         .unwrap();
@@ -371,7 +362,7 @@ pub fn inject_metadata(
                             #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                             writeln!(
                                 meta_tags,
-                                r#"    <link rel="apple-touch-icon" href="{}" />"#,
+                                r#"<link rel="apple-touch-icon" href="{}" />"#,
                                 escape_html(url)
                             )
                             .unwrap();
@@ -393,7 +384,7 @@ pub fn inject_metadata(
                                 write!(&mut attrs, r#" sizes="{}""#, escape_html(sizes)).unwrap();
                             }
                             #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
-                            writeln!(&mut meta_tags, "    <link {attrs} />").unwrap();
+                            writeln!(&mut meta_tags, "<link {attrs} />").unwrap();
                         }
                     }
                 }
@@ -416,14 +407,14 @@ pub fn inject_metadata(
                         write!(&mut attrs, r#" color="{}""#, escape_html(color)).unwrap();
                     }
                     #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
-                    writeln!(&mut meta_tags, "    <link {attrs} />").unwrap();
+                    writeln!(&mut meta_tags, "<link {attrs} />").unwrap();
                 }
             }
         }
 
         if let Some(manifest) = &metadata.manifest {
             #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
-            writeln!(meta_tags, r#"    <link rel="manifest" href="{}" />"#, escape_html(manifest))
+            writeln!(meta_tags, r#"<link rel="manifest" href="{}" />"#, escape_html(manifest))
                 .unwrap();
         }
 
@@ -433,7 +424,7 @@ pub fn inject_metadata(
                     #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                     writeln!(
                         meta_tags,
-                        r#"    <meta name="theme-color" content="{}" />"#,
+                        r#"<meta name="theme-color" content="{}" />"#,
                         escape_html(color)
                     )
                     .unwrap();
@@ -449,7 +440,7 @@ pub fn inject_metadata(
                             write!(&mut attrs, r#" media="{}""#, escape_html(media)).unwrap();
                         }
                         #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
-                        writeln!(&mut meta_tags, "    <meta {attrs} />").unwrap();
+                        writeln!(&mut meta_tags, "<meta {attrs} />").unwrap();
                     }
                 }
             }
@@ -460,7 +451,7 @@ pub fn inject_metadata(
                 #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                 writeln!(
                     meta_tags,
-                    r#"    <meta name="apple-mobile-web-app-title" content="{}" />"#,
+                    r#"<meta name="apple-mobile-web-app-title" content="{}" />"#,
                     escape_html(title)
                 )
                 .unwrap();
@@ -469,7 +460,7 @@ pub fn inject_metadata(
                 #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                 writeln!(
                     meta_tags,
-                    r#"    <meta name="apple-mobile-web-app-status-bar-style" content="{}" />"#,
+                    r#"<meta name="apple-mobile-web-app-status-bar-style" content="{}" />"#,
                     escape_html(status_bar_style)
                 )
                 .unwrap();
@@ -478,7 +469,7 @@ pub fn inject_metadata(
                 #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                 writeln!(
                     meta_tags,
-                    r#"    <meta name="mobile-web-app-capable" content="{}" />"#,
+                    r#"<meta name="mobile-web-app-capable" content="{}" />"#,
                     if capable { "yes" } else { "no" }
                 )
                 .unwrap();
@@ -491,7 +482,7 @@ pub fn inject_metadata(
                     #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                     writeln!(
                         meta_tags,
-                        r#"    <link rel="alternate" hreflang="{}" href="{}" />"#,
+                        r#"<link rel="alternate" hreflang="{}" href="{}" />"#,
                         escape_html(lang),
                         escape_html(url)
                     )
@@ -508,7 +499,7 @@ pub fn inject_metadata(
                     #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
                     writeln!(
                         meta_tags,
-                        r#"    <link rel="alternate" type="{}" href="{}" title="{}" />"#,
+                        r#"<link rel="alternate" type="{}" href="{}" title="{}" />"#,
                         escape_html(media_type),
                         escape_html(url),
                         escape_html(title)
@@ -530,7 +521,6 @@ pub fn inject_metadata(
         if !preload_links.is_empty() {
             let mut preload_html = String::new();
             for link in preload_links {
-                preload_html.push_str("    ");
                 preload_html.push_str(&link);
                 preload_html.push('\n');
             }

--- a/crates/rari/src/server/rendering/mod.rs
+++ b/crates/rari/src/server/rendering/mod.rs
@@ -1,4 +1,5 @@
 pub mod metadata;
 pub mod metadata_injection;
+pub mod pretty_html;
 pub mod streaming_response;
 pub mod utils;

--- a/crates/rari/src/server/rendering/pretty_html.rs
+++ b/crates/rari/src/server/rendering/pretty_html.rs
@@ -167,8 +167,10 @@ fn find_closing_tag(html: &str, from: usize, tag_name: &str) -> Option<usize> {
         if bytes[i] == b'<' && bytes[i + 1] == b'/' {
             let name_start = i + 2;
             let name_end = name_start + name_bytes.len();
+            // Compare on bytes — str slicing here can panic if name_end falls
+            // inside a multi-byte UTF-8 character (e.g. `</` + `€a日…`).
             if name_end <= bytes.len()
-                && html[name_start..name_end].eq_ignore_ascii_case(tag_name)
+                && bytes[name_start..name_end].eq_ignore_ascii_case(name_bytes)
                 && (name_end == bytes.len()
                     || bytes[name_end].is_ascii_whitespace()
                     || bytes[name_end] == b'>')
@@ -224,5 +226,15 @@ mod tests {
     fn empty_input() {
         assert_eq!(pretty_print_html(""), "");
         assert_eq!(pretty_print_html("   "), "");
+    }
+
+    #[test]
+    fn raw_text_multibyte_after_false_closing_slash_does_not_panic() {
+        // `</` + `€a日` makes a 6-byte window for "script" that ends mid-character.
+        // Byte comparison must not slice the &str at that range.
+        let input = "<script>const s = \"</€a日\";</script>";
+        let out = pretty_print_html(input);
+        assert!(out.contains("const s = \"</€a日\";"));
+        assert!(out.contains("</script>"));
     }
 }

--- a/crates/rari/src/server/rendering/pretty_html.rs
+++ b/crates/rari/src/server/rendering/pretty_html.rs
@@ -126,6 +126,17 @@ fn write_indent(out: &mut String, indent: usize) {
 }
 
 fn find_tag_end(bytes: &[u8], start: usize) -> Option<usize> {
+    if bytes[start..].starts_with(b"<!--") {
+        let mut i = start + 4;
+        while i + 2 < bytes.len() {
+            if bytes[i] == b'-' && bytes[i + 1] == b'-' && bytes[i + 2] == b'>' {
+                return Some(i + 2);
+            }
+            i += 1;
+        }
+        return None;
+    }
+
     let mut in_quote: Option<u8> = None;
     let mut i = start + 1;
     while i < bytes.len() {
@@ -236,5 +247,16 @@ mod tests {
         let out = pretty_print_html(input);
         assert!(out.contains("const s = \"</€a日\";"));
         assert!(out.contains("</script>"));
+    }
+
+    #[test]
+    fn preserves_comments_containing_gt() {
+        let input = "<div><!-- x > y --><span>hi</span></div>";
+        let out = pretty_print_html(input);
+        assert!(out.contains("<!-- x > y -->\n"));
+        assert!(out.contains("  <span>\n"));
+        assert!(out.contains("    hi\n"));
+        // Must not treat the `>` inside the comment as a tag terminator.
+        assert!(!out.contains("<!-- x >\n"));
     }
 }

--- a/crates/rari/src/server/rendering/pretty_html.rs
+++ b/crates/rari/src/server/rendering/pretty_html.rs
@@ -1,0 +1,228 @@
+//! Lightweight HTML pretty-printer for development View Source readability.
+//!
+//! Not a full HTML5 parser. Preserves content inside `script`, `style`, `pre`,
+//! and `textarea`. Safe to run after all head/asset/metadata injections.
+//! Production responses are left as-is (compression handles wire size).
+
+const VOID_ELEMENTS: &[&str] = &[
+    "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source",
+    "track", "wbr",
+];
+
+const RAW_TEXT_ELEMENTS: &[&str] = &["script", "style", "pre", "textarea"];
+
+/// Pretty-print HTML with 2-space indentation.
+///
+/// Returns the input unchanged when it is empty or does not look like HTML.
+pub fn pretty_print_html(html: &str) -> String {
+    let trimmed = html.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    let mut out = String::with_capacity(html.len() + html.len() / 8);
+    let mut indent: usize = 0;
+    let mut i = 0;
+    let bytes = trimmed.as_bytes();
+
+    // Preserve leading DOCTYPE / comments spacing via trim; rewrite body.
+    while i < bytes.len() {
+        if bytes[i] == b'<' {
+            let Some(tag_end) = find_tag_end(bytes, i) else {
+                out.push_str(&trimmed[i..]);
+                break;
+            };
+            let tag = &trimmed[i..=tag_end];
+            let tag_name = parse_tag_name(tag);
+
+            if tag.starts_with("<!--") {
+                write_indent(&mut out, indent);
+                out.push_str(tag);
+                out.push('\n');
+                i = tag_end + 1;
+                continue;
+            }
+
+            if tag.starts_with("<!") {
+                write_indent(&mut out, indent);
+                out.push_str(tag);
+                out.push('\n');
+                i = tag_end + 1;
+                continue;
+            }
+
+            if tag.starts_with("</") {
+                indent = indent.saturating_sub(1);
+                write_indent(&mut out, indent);
+                out.push_str(tag);
+                out.push('\n');
+                i = tag_end + 1;
+                continue;
+            }
+
+            let is_void = is_void_element(tag_name) || tag.ends_with("/>");
+            let is_raw = is_raw_text_element(tag_name);
+
+            write_indent(&mut out, indent);
+            out.push_str(tag);
+            out.push('\n');
+            i = tag_end + 1;
+
+            if is_void {
+                continue;
+            }
+
+            if is_raw {
+                let close_abs = find_closing_tag(trimmed, i, tag_name);
+                if let Some(close_abs) = close_abs {
+                    let content = &trimmed[i..close_abs];
+                    if !content.is_empty() {
+                        // Preserve raw text exactly (scripts/styles/pre/textarea).
+                        out.push_str(content);
+                        if !content.ends_with('\n') {
+                            out.push('\n');
+                        }
+                    }
+                    if let Some(close_end) = find_tag_end(bytes, close_abs) {
+                        write_indent(&mut out, indent);
+                        out.push_str(&trimmed[close_abs..=close_end]);
+                        out.push('\n');
+                        i = close_end + 1;
+                    } else {
+                        i = close_abs;
+                    }
+                }
+                continue;
+            }
+
+            indent += 1;
+            continue;
+        }
+
+        // Text node until next tag
+        let next_tag = trimmed[i..].find('<').map_or(trimmed.len(), |n| i + n);
+        let text = trimmed[i..next_tag].trim();
+        if !text.is_empty() {
+            write_indent(&mut out, indent);
+            out.push_str(text);
+            out.push('\n');
+        }
+        i = next_tag;
+    }
+
+    // Drop trailing newline for consistency with common formatters, keep one final newline.
+    if out.ends_with('\n') {
+        out
+    } else {
+        out.push('\n');
+        out
+    }
+}
+
+fn write_indent(out: &mut String, indent: usize) {
+    for _ in 0..indent {
+        out.push_str("  ");
+    }
+}
+
+fn find_tag_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut in_quote: Option<u8> = None;
+    let mut i = start + 1;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if let Some(q) = in_quote {
+            if b == q {
+                in_quote = None;
+            }
+        } else if b == b'"' || b == b'\'' {
+            in_quote = Some(b);
+        } else if b == b'>' {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+fn parse_tag_name(tag: &str) -> &str {
+    let rest = tag.trim_start_matches(['<', '/']).trim_start();
+    let end =
+        rest.find(|c: char| c.is_ascii_whitespace() || c == '>' || c == '/').unwrap_or(rest.len());
+    &rest[..end]
+}
+
+fn is_void_element(name: &str) -> bool {
+    VOID_ELEMENTS.iter().any(|v| v.eq_ignore_ascii_case(name))
+}
+
+fn is_raw_text_element(name: &str) -> bool {
+    RAW_TEXT_ELEMENTS.iter().any(|v| v.eq_ignore_ascii_case(name))
+}
+
+fn find_closing_tag(html: &str, from: usize, tag_name: &str) -> Option<usize> {
+    let bytes = html.as_bytes();
+    let name_bytes = tag_name.as_bytes();
+    let mut i = from;
+    while i + 2 + name_bytes.len() <= bytes.len() {
+        if bytes[i] == b'<' && bytes[i + 1] == b'/' {
+            let name_start = i + 2;
+            let name_end = name_start + name_bytes.len();
+            if name_end <= bytes.len()
+                && html[name_start..name_end].eq_ignore_ascii_case(tag_name)
+                && (name_end == bytes.len()
+                    || bytes[name_end].is_ascii_whitespace()
+                    || bytes[name_end] == b'>')
+            {
+                return Some(i);
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pretty_prints_nested_elements() {
+        let input = "<!DOCTYPE html><html><head><title>t</title></head><body><div id=\"root\"><p>Hi</p></div></body></html>";
+        let out = pretty_print_html(input);
+        // DOCTYPE is a sibling of <html>, not a parent — both at indent 0.
+        assert!(out.contains("<!DOCTYPE html>\n<html>\n"));
+        assert!(out.contains("  <head>\n"));
+        assert!(out.contains("    <title>\n"));
+        assert!(out.contains("      t\n"));
+        assert!(out.contains("    </title>\n"));
+        assert!(out.contains("  </head>\n"));
+        assert!(out.contains("    <div id=\"root\">\n"));
+        assert!(out.contains("      <p>\n"));
+        assert!(out.contains("        Hi\n"));
+    }
+
+    #[test]
+    fn preserves_script_contents() {
+        let input = "<html><head><script>const x = 1;\nif (x) { console.log(x); }</script></head><body></body></html>";
+        let out = pretty_print_html(input);
+        assert!(out.contains("const x = 1;"));
+        assert!(out.contains("if (x) { console.log(x); }"));
+        assert!(out.contains("</script>"));
+    }
+
+    #[test]
+    fn handles_void_elements_without_extra_indent() {
+        let input = "<html><head><meta charset=\"utf-8\"><link rel=\"stylesheet\" href=\"/a.css\"></head><body></body></html>";
+        let out = pretty_print_html(input);
+        assert!(out.contains("    <meta charset=\"utf-8\">\n"));
+        assert!(out.contains("    <link rel=\"stylesheet\" href=\"/a.css\">\n"));
+        // head children should be at same indent; body follows head close
+        assert!(out.contains("  </head>\n  <body>\n"));
+    }
+
+    #[test]
+    fn empty_input() {
+        assert_eq!(pretty_print_html(""), "");
+        assert_eq!(pretty_print_html("   "), "");
+    }
+}

--- a/crates/rari/src/server/rendering/utils.rs
+++ b/crates/rari/src/server/rendering/utils.rs
@@ -17,7 +17,6 @@ pub async fn extract_asset_links_from_index_html() -> Option<String> {
             let mut in_inline_script = false;
             let mut in_body = false;
             let mut script_base_indent = 0;
-            let mut is_first_line = true;
 
             for line in content.lines() {
                 let trimmed = line.trim();
@@ -37,12 +36,8 @@ pub async fn extract_asset_links_from_index_html() -> Option<String> {
                 if (trimmed.starts_with("<script") && trimmed.contains("/assets/"))
                     || (trimmed.starts_with("<link") && trimmed.contains("/assets/"))
                 {
-                    if !is_first_line {
-                        asset_links.push_str("    ");
-                    }
                     asset_links.push_str(trimmed);
                     asset_links.push('\n');
-                    is_first_line = false;
                     continue;
                 }
 
@@ -50,12 +45,8 @@ pub async fn extract_asset_links_from_index_html() -> Option<String> {
                     in_inline_script = true;
 
                     script_base_indent = line.len() - line.trim_start().len();
-                    if !is_first_line {
-                        asset_links.push_str("    ");
-                    }
                     asset_links.push_str(trimmed);
                     asset_links.push('\n');
-                    is_first_line = false;
 
                     if trimmed.contains("</script>") {
                         in_inline_script = false;
@@ -66,16 +57,10 @@ pub async fn extract_asset_links_from_index_html() -> Option<String> {
                 if in_inline_script {
                     let current_indent = line.len() - line.trim_start().len();
                     if current_indent >= script_base_indent {
-                        let relative_indent = current_indent - script_base_indent;
-                        asset_links.push_str("    ");
-                        asset_links.push_str(&" ".repeat(relative_indent));
-                        asset_links.push_str(trimmed);
-                    } else {
-                        asset_links.push_str("    ");
-                        asset_links.push_str(trimmed);
+                        asset_links.push_str(&" ".repeat(current_indent - script_base_indent));
                     }
+                    asset_links.push_str(trimmed);
                     asset_links.push('\n');
-                    is_first_line = false;
 
                     if trimmed.contains("</script>") {
                         in_inline_script = false;
@@ -86,12 +71,8 @@ pub async fn extract_asset_links_from_index_html() -> Option<String> {
                 if trimmed.starts_with("<link")
                     && (trimmed.contains("preconnect") || trimmed.contains("dns-prefetch"))
                 {
-                    if !is_first_line {
-                        asset_links.push_str("    ");
-                    }
                     asset_links.push_str(trimmed);
                     asset_links.push('\n');
-                    is_first_line = false;
                 }
             }
 
@@ -115,7 +96,6 @@ pub async fn extract_body_scripts_from_index_html() -> Option<String> {
             let mut in_inline_script = false;
             let mut in_body = false;
             let mut script_base_indent = 0;
-            let mut is_first_line = true;
 
             for line in content.lines() {
                 let trimmed = line.trim();
@@ -136,12 +116,8 @@ pub async fn extract_body_scripts_from_index_html() -> Option<String> {
                     in_inline_script = true;
 
                     script_base_indent = line.len() - line.trim_start().len();
-                    if !is_first_line {
-                        body_scripts.push_str("    ");
-                    }
                     body_scripts.push_str(trimmed);
                     body_scripts.push('\n');
-                    is_first_line = false;
 
                     if trimmed.contains("</script>") {
                         in_inline_script = false;
@@ -152,16 +128,10 @@ pub async fn extract_body_scripts_from_index_html() -> Option<String> {
                 if in_inline_script {
                     let current_indent = line.len() - line.trim_start().len();
                     if current_indent >= script_base_indent {
-                        let relative_indent = current_indent - script_base_indent;
-                        body_scripts.push_str("    ");
-                        body_scripts.push_str(&" ".repeat(relative_indent));
-                        body_scripts.push_str(trimmed);
-                    } else {
-                        body_scripts.push_str("    ");
-                        body_scripts.push_str(trimmed);
+                        body_scripts.push_str(&" ".repeat(current_indent - script_base_indent));
                     }
+                    body_scripts.push_str(trimmed);
                     body_scripts.push('\n');
-                    is_first_line = false;
 
                     if trimmed.contains("</script>") {
                         in_inline_script = false;
@@ -538,10 +508,10 @@ pub fn inject_vite_client(html: &str, vite_port: u16) -> String {
         #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
         write!(
             result,
-            r#"  <script type="module" src="http://localhost:{vite_port}/@vite/client"></script>
-  <script type="module">
-    import 'http://localhost:{vite_port}/@id/virtual:rari-entry-client';
-  </script>
+            r#"<script type="module" src="http://localhost:{vite_port}/@vite/client"></script>
+<script type="module">
+import 'http://localhost:{vite_port}/@id/virtual:rari-entry-client';
+</script>
 "#
         )
         .unwrap();
@@ -555,10 +525,10 @@ pub fn inject_vite_client(html: &str, vite_port: u16) -> String {
         #[expect(clippy::unwrap_used, reason = "write! to String never fails")]
         write!(
             result,
-            r#"  <script type="module" src="http://localhost:{vite_port}/@vite/client"></script>
-  <script type="module">
-    import 'http://localhost:{vite_port}/@id/virtual:rari-entry-client';
-  </script>
+            r#"<script type="module" src="http://localhost:{vite_port}/@vite/client"></script>
+<script type="module">
+import 'http://localhost:{vite_port}/@id/virtual:rari-entry-client';
+</script>
 "#
         )
         .unwrap();
@@ -569,7 +539,7 @@ pub fn inject_vite_client(html: &str, vite_port: u16) -> String {
     format!(
         r#"<script type="module" src="http://localhost:{vite_port}/@vite/client"></script>
 <script type="module">
-  import 'http://localhost:{vite_port}/@id/virtual:rari-entry-client';
+import 'http://localhost:{vite_port}/@id/virtual:rari-entry-client';
 </script>
 {html}"#
     )

--- a/crates/rari/src/server/routing/app.rs
+++ b/crates/rari/src/server/routing/app.rs
@@ -55,6 +55,7 @@ use crate::{
         middleware::request_context::RequestContext,
         rendering::{
             metadata_injection::inject_metadata,
+            pretty_html::pretty_print_html,
             utils::{inject_assets_into_html, inject_vite_client},
         },
         routing::app_router::AppRouteMatch,
@@ -187,7 +188,7 @@ pub(crate) fn wrap_html_with_metadata(
     let trimmed_lower = trimmed.cow_to_lowercase();
     let is_complete = trimmed_lower.starts_with("<!doctype") || trimmed_lower.starts_with("<html");
 
-    if is_complete {
+    let html = if is_complete {
         if let Some(metadata) = metadata {
             inject_metadata(&html_content, metadata, state.image_optimizer.as_deref())
         } else {
@@ -195,7 +196,9 @@ pub(crate) fn wrap_html_with_metadata(
         }
     } else {
         html_content
-    }
+    };
+
+    if state.config.is_development() { pretty_print_html(&html) } else { html }
 }
 
 fn should_use_streaming(route_match: &AppRouteMatch, config: &Config) -> bool {
@@ -873,11 +876,15 @@ pub async fn render_fallback_html(
         }
 
         if let Ok(html_content) = fs::read_to_string(&index_path).await {
-            let final_html = if state.config.is_development() {
+            let mut final_html = if state.config.is_development() {
                 inject_vite_client(&html_content, state.config.vite.port)
             } else {
                 html_content
             };
+
+            if state.config.is_development() {
+                final_html = pretty_print_html(&final_html);
+            }
 
             if state.config.is_production() {
                 state.html_cache.insert(path.to_string(), final_html.clone());
@@ -900,7 +907,7 @@ pub async fn render_fallback_html(
 
     if state.config.is_development() {
         let vite_port = state.config.vite.port;
-        let html_shell = format!(
+        let mut html_shell = format!(
             r#"<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -917,6 +924,10 @@ pub async fn render_fallback_html(
 </body>
 </html>"#
         );
+
+        if state.config.is_development() {
+            html_shell = pretty_print_html(&html_shell);
+        }
 
         let status_code = if is_not_found { StatusCode::NOT_FOUND } else { StatusCode::OK };
 
@@ -1503,6 +1514,11 @@ pub async fn handle_app_route(
                 }
             };
 
+            let cache_control_value = state.config.get_cache_control_for_route(path);
+            let cache_policy =
+                response::RouteCachePolicy::from_cache_control(cache_control_value, path);
+            let for_response_cache = should_store_response_cache(&state, &cache_policy).await;
+
             let (final_html, etag) = match render_result {
                 RenderResult::Static(html_content) => {
                     let html_with_assets =
@@ -1574,7 +1590,6 @@ pub async fn handle_app_route(
                 .header("vary", static_html_vary_header(cookie_header))
                 .header("x-cache", "MISS");
 
-            let cache_control_value = state.config.get_cache_control_for_route(path);
             let mut response_headers = HeaderMap::new();
 
             response_builder = response_builder.header("cache-control", cache_control_value);
@@ -1583,10 +1598,7 @@ pub async fn handle_app_route(
             }
             insert_response_cache_vary_header(&mut response_headers, cookie_header, true);
 
-            let cache_policy =
-                response::RouteCachePolicy::from_cache_control(cache_control_value, path);
-
-            if should_store_response_cache(&state, &cache_policy).await {
+            if for_response_cache {
                 let response_cache_tags =
                     merge_response_cache_tags(&state, cache_policy.tags.clone()).await;
                 let body_bytes = Bytes::from(final_html.clone());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added development-only HTML pretty-printing for more consistently indented rendered output, including fallback pages.
  - Improved formatting robustness for preformatted content (e.g., `script`, `style`, `pre`, `textarea`) during pretty-printing.

- **Bug Fixes**
  - Normalized whitespace/indentation for injected Vite client scripts and metadata blocks.
  - Updated inline asset/script extraction and preload formatting to avoid inconsistent indentation.
  - Refined cache warmup/route caching decisions for more consistent behavior.

- **Breaking Changes**
  - Removed the `RARI_RSC_HTML_PRETTY_PRINT` environment setting and `pretty_print` configuration; formatting is now handled automatically in development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->