### PR TITLE
refactor(rendering): introduce renderer lock management for safe concurrent access and streamline rendering operations

### DIFF
--- a/crates/rari/src/rendering/base/mod.rs
+++ b/crates/rari/src/rendering/base/mod.rs
@@ -1,12 +1,14 @@
 pub mod constants;
 pub mod loader;
 pub mod renderer;
+pub mod renderer_lock;
 pub mod sanitizer;
 pub mod types;
 pub mod utils;
 
 pub use loader::{RscJsLoader, RscModuleOperation, StubType};
 pub use renderer::RscRenderer;
+pub use renderer_lock::{run_with_renderer, run_with_renderer_result};
 pub use sanitizer::sanitize_html_output;
 pub use types::{ResourceLimits, ResourceMetrics, ResourceTracker};
 

--- a/crates/rari/src/rendering/base/renderer_lock.rs
+++ b/crates/rari/src/rendering/base/renderer_lock.rs
@@ -1,0 +1,56 @@
+//! Cancel-correct exclusive access to the shared [`RscRenderer`].
+//!
+//! Holding a `tokio::sync::Mutex` across `.await` is cancel-unsafe: if the
+//! caller is cancelled mid-await, the guard drops and shared state can be left
+//! inconsistent. Drive critical sections on a spawned task so they run to
+//! completion even when the request future is cancelled.
+
+use std::{future::Future, sync::Arc};
+
+use rari_error::RariError;
+use tokio::sync::{Mutex, OwnedMutexGuard};
+
+use crate::RscRenderer;
+
+/// Run `f` with exclusive access to the renderer on a spawned task.
+///
+/// The spawned task is not cancelled when the caller is, so mutex critical
+/// sections that `.await` still complete and leave shared state consistent.
+///
+/// # Errors
+///
+/// Returns [`RariError`] if the spawned task panics or fails to join.
+pub async fn run_with_renderer<T, F, Fut>(
+    renderer: Arc<Mutex<RscRenderer>>,
+    f: F,
+) -> Result<T, RariError>
+where
+    T: Send + 'static,
+    F: FnOnce(OwnedMutexGuard<RscRenderer>) -> Fut + Send + 'static,
+    Fut: Future<Output = T> + Send + 'static,
+{
+    tokio::spawn(async move {
+        let guard = renderer.lock_owned().await;
+        f(guard).await
+    })
+    .await
+    .map_err(|e| RariError::js_runtime(format!("renderer task join failed: {e}")))
+}
+
+/// Like [`run_with_renderer`], but flattens an inner `Result`.
+///
+/// # Errors
+///
+/// Returns [`RariError`] if the spawned task fails to join, or if `f` returns
+/// an error.
+pub async fn run_with_renderer_result<T, F, Fut>(
+    renderer: Arc<Mutex<RscRenderer>>,
+    f: F,
+) -> Result<T, RariError>
+where
+    T: Send + 'static,
+    F: FnOnce(OwnedMutexGuard<RscRenderer>) -> Fut + Send + 'static,
+    Fut: Future<Output = Result<T, RariError>> + Send + 'static,
+{
+    run_with_renderer(renderer, f).await?
+}

--- a/crates/rari/src/rendering/layout/core.rs
+++ b/crates/rari/src/rendering/layout/core.rs
@@ -303,36 +303,7 @@ impl LayoutRenderer {
         context: &LayoutRenderContext,
         request_context: Option<Arc<RequestContext>>,
     ) -> Result<String, RariError> {
-        let loading_enabled = Config::get().map(|c| c.loading.enabled).unwrap_or(true);
-        let loading_component_id = if loading_enabled {
-            route_match.loading.as_ref().map(|e| {
-                e.component_id.clone().unwrap_or_else(|| utils::create_component_id(&e.file_path))
-            })
-        } else {
-            None
-        };
-
-        let composition_script = self.build_composition_script(
-            route_match,
-            context,
-            loading_component_id.as_deref(),
-            loading_component_id.is_some(),
-            false,
-        )?;
-
-        let renderer = Arc::clone(&self.renderer);
-        run_with_renderer_result(renderer, move |renderer| async move {
-            let render_operation = async {
-                Self::execute_composition_and_serialize(&renderer, composition_script).await
-            };
-
-            if let Some(ctx) = request_context {
-                renderer.runtime.execute_with_request_context(ctx, render_operation).await
-            } else {
-                render_operation.await
-            }
-        })
-        .await
+        self.render_route_with_mode_internal(route_match, context, request_context).await
     }
 
     async fn render_route_with_mode_internal(

--- a/crates/rari/src/rendering/layout/core.rs
+++ b/crates/rari/src/rendering/layout/core.rs
@@ -18,7 +18,7 @@ use super::{
 use crate::{
     RscHtmlRenderer,
     rendering::{
-        base::RscRenderer,
+        base::{RscRenderer, run_with_renderer_result},
         layout::{
             LayoutInfo, RouteComposer,
             route_composer::{ErrorBoundaryInfo, TemplateInfo},
@@ -320,15 +320,19 @@ impl LayoutRenderer {
             false,
         )?;
 
-        let renderer = self.renderer.lock().await;
+        let renderer = Arc::clone(&self.renderer);
+        run_with_renderer_result(renderer, move |renderer| async move {
+            let render_operation = async {
+                Self::execute_composition_and_serialize(&renderer, composition_script).await
+            };
 
-        let flight_result: Result<String, RariError> =
-            async { Self::execute_composition_and_serialize(&renderer, composition_script).await }
-                .await;
-
-        drop(request_context);
-
-        flight_result
+            if let Some(ctx) = request_context {
+                renderer.runtime.execute_with_request_context(ctx, render_operation).await
+            } else {
+                render_operation.await
+            }
+        })
+        .await
     }
 
     async fn render_route_with_mode_internal(
@@ -361,16 +365,19 @@ impl LayoutRenderer {
             false,
         )?;
 
-        let renderer = self.renderer.lock().await;
+        let renderer = Arc::clone(&self.renderer);
+        run_with_renderer_result(renderer, move |renderer| async move {
+            let render_operation = async {
+                Self::execute_composition_and_serialize(&renderer, composition_script).await
+            };
 
-        let render_operation =
-            async { Self::execute_composition_and_serialize(&renderer, composition_script).await };
-
-        if let Some(ctx) = request_context {
-            renderer.runtime.execute_with_request_context(ctx, render_operation).await
-        } else {
-            render_operation.await
-        }
+            if let Some(ctx) = request_context {
+                renderer.runtime.execute_with_request_context(ctx, render_operation).await
+            } else {
+                render_operation.await
+            }
+        })
+        .await
     }
 
     pub async fn render_route_by_mode(
@@ -409,16 +416,19 @@ impl LayoutRenderer {
             true,
         )?;
 
-        let renderer = self.renderer.lock().await;
-        let compose_operation = async {
-            renderer
-                .runtime
-                .execute_script("action_refresh_compose".to_string(), composition_script)
-                .await?;
-            Ok(())
-        };
+        let renderer = Arc::clone(&self.renderer);
+        run_with_renderer_result(renderer, move |renderer| async move {
+            let compose_operation = async {
+                renderer
+                    .runtime
+                    .execute_script("action_refresh_compose".to_string(), composition_script)
+                    .await?;
+                Ok(())
+            };
 
-        renderer.runtime.execute_with_request_context(request_context, compose_operation).await
+            renderer.runtime.execute_with_request_context(request_context, compose_operation).await
+        })
+        .await
     }
 
     #[expect(clippy::too_many_lines)]
@@ -471,11 +481,12 @@ impl LayoutRenderer {
 
                 let (chunk_sender, chunk_receiver) = mpsc::channel::<Result<Vec<u8>, String>>(32);
 
-                let runtime = {
-                    let renderer = self.renderer.lock().await;
-                    renderer.ensure_streaming_pipeline().await?;
-                    Arc::clone(&renderer.runtime)
-                };
+                let runtime =
+                    run_with_renderer_result(Arc::clone(&self.renderer), |renderer| async move {
+                        renderer.ensure_streaming_pipeline().await?;
+                        Ok(Arc::clone(&renderer.runtime))
+                    })
+                    .await?;
 
                 let script = format!(
                     r"(async function() {{
@@ -528,35 +539,35 @@ impl LayoutRenderer {
                 });
             }
 
-            let rsc_payload = {
-                let renderer = self.renderer.lock().await;
+            let composition_script = self.build_composition_script(
+                route_match,
+                context,
+                loading_component_id.as_deref(),
+                loading_component_id.is_some(),
+                false,
+            )?;
 
-                let composition_script = self.build_composition_script(
-                    route_match,
-                    context,
-                    loading_component_id.as_deref(),
-                    loading_component_id.is_some(),
-                    false,
-                )?;
+            let rsc_payload =
+                run_with_renderer_result(Arc::clone(&self.renderer), move |renderer| async move {
+                    let render_and_capture = async {
+                        let result = Self::run_composition(&renderer, composition_script).await?;
 
-                let render_and_capture = async {
-                    let result = Self::run_composition(&renderer, composition_script).await?;
+                        if let Some(bytes) = Self::capture_last_rsc_binary(&renderer).await?
+                            && !bytes.is_empty()
+                        {
+                            return Ok(RscNavPayload::Binary(bytes));
+                        }
 
-                    if let Some(bytes) = Self::capture_last_rsc_binary(&renderer).await?
-                        && !bytes.is_empty()
-                    {
-                        return Ok(RscNavPayload::Binary(bytes));
+                        Ok(RscNavPayload::Text(Self::extract_flight_text(&result)?))
+                    };
+
+                    if let Some(ctx) = request_context {
+                        renderer.runtime.execute_with_request_context(ctx, render_and_capture).await
+                    } else {
+                        render_and_capture.await
                     }
-
-                    Ok(RscNavPayload::Text(Self::extract_flight_text(&result)?))
-                };
-
-                if let Some(ctx) = request_context {
-                    renderer.runtime.execute_with_request_context(ctx, render_and_capture).await?
-                } else {
-                    render_and_capture.await?
-                }
-            };
+                })
+                .await?;
 
             match rsc_payload {
                 RscNavPayload::Binary(bytes) => Ok(RenderResult::StaticBinary(bytes)),
@@ -575,11 +586,12 @@ impl LayoutRenderer {
                     true,
                 )?;
 
-                let runtime = {
-                    let renderer = self.renderer.lock().await;
-                    renderer.ensure_streaming_pipeline().await?;
-                    Arc::clone(&renderer.runtime)
-                };
+                let runtime =
+                    run_with_renderer_result(Arc::clone(&self.renderer), |renderer| async move {
+                        renderer.ensure_streaming_pipeline().await?;
+                        Ok(Arc::clone(&renderer.runtime))
+                    })
+                    .await?;
 
                 let html_renderer = RscHtmlRenderer::new(Arc::clone(&runtime));
                 let css_links = RscHtmlRenderer::css_links_for_route(route_match);
@@ -676,9 +688,6 @@ impl LayoutRenderer {
             }
 
             let html = {
-                let renderer = self.renderer.lock().await;
-                renderer.ensure_streaming_pipeline().await?;
-
                 let composition_script = self.build_composition_script(
                     route_match,
                     context,
@@ -687,24 +696,33 @@ impl LayoutRenderer {
                     true,
                 )?;
 
-                let html_renderer = RscHtmlRenderer::new(Arc::clone(&renderer.runtime));
-                let css_links = RscHtmlRenderer::css_links_for_route(route_match);
-                let cache_template = config.rsc_html.cache_template;
-                let is_dev_mode = config.is_development();
-                let template = html_renderer.load_template(cache_template, is_dev_mode).await?;
-                let template = RscHtmlRenderer::inject_css_links(&template, &css_links);
+                let route_match = route_match.clone();
+                let config = config.clone();
+                let request_context = request_context.clone();
 
-                let head_content = template
-                    .find("<head>")
-                    .and_then(|start| template.find("</head>").map(|end| &template[start + 6..end]))
-                    .unwrap_or("")
-                    .to_string();
+                run_with_renderer_result(Arc::clone(&self.renderer), move |renderer| async move {
+                    renderer.ensure_streaming_pipeline().await?;
 
-                let head_content_json =
-                    serde_json::to_string(&head_content).unwrap_or_else(|_| "\"\"".to_string());
+                    let html_renderer = RscHtmlRenderer::new(Arc::clone(&renderer.runtime));
+                    let css_links = RscHtmlRenderer::css_links_for_route(&route_match);
+                    let cache_template = config.rsc_html.cache_template;
+                    let is_dev_mode = config.is_development();
+                    let template = html_renderer.load_template(cache_template, is_dev_mode).await?;
+                    let template = RscHtmlRenderer::inject_css_links(&template, &css_links);
 
-                let script = format!(
-                    r"(async function() {{
+                    let head_content = template
+                        .find("<head>")
+                        .and_then(|start| {
+                            template.find("</head>").map(|end| &template[start + 6..end])
+                        })
+                        .unwrap_or("")
+                        .to_string();
+
+                    let head_content_json =
+                        serde_json::to_string(&head_content).unwrap_or_else(|_| "\"\"".to_string());
+
+                    let script = format!(
+                        r"(async function() {{
                         let caughtErrors = [];
                         try {{
                             try {{ await ({composition_script}); }} catch(e) {{
@@ -732,35 +750,41 @@ impl LayoutRenderer {
                             return {{ ok: false, error: String(e?.message || e) }};
                         }}
                     }})()",
-                );
+                    );
 
-                let render_operation = async {
-                    let result = renderer
-                        .runtime
-                        .execute_script("static_document_render".to_string(), script)
-                        .await?;
+                    let render_operation = async {
+                        let result = renderer
+                            .runtime
+                            .execute_script("static_document_render".to_string(), script)
+                            .await?;
 
-                    let ok = result.get("ok").and_then(Value::as_bool).unwrap_or(false);
-                    if !ok {
-                        let err = result.get("error").and_then(|v| v.as_str()).unwrap_or("unknown");
-                        return Err(RariError::internal(format!(
-                            "Static document render failed: {err}"
-                        )));
+                        let ok = result.get("ok").and_then(Value::as_bool).unwrap_or(false);
+                        if !ok {
+                            let err =
+                                result.get("error").and_then(|v| v.as_str()).unwrap_or("unknown");
+                            return Err(RariError::internal(format!(
+                                "Static document render failed: {err}"
+                            )));
+                        }
+
+                        let html = result
+                            .get("html")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default()
+                            .to_string();
+
+                        html_renderer
+                            .assemble_document(html, cache_template, is_dev_mode, &css_links)
+                            .await
+                    };
+
+                    if let Some(ctx) = request_context {
+                        renderer.runtime.execute_with_request_context(ctx, render_operation).await
+                    } else {
+                        render_operation.await
                     }
-
-                    let html =
-                        result.get("html").and_then(|v| v.as_str()).unwrap_or_default().to_string();
-
-                    html_renderer
-                        .assemble_document(html, cache_template, is_dev_mode, &css_links)
-                        .await
-                };
-
-                if let Some(ctx) = request_context.clone() {
-                    renderer.runtime.execute_with_request_context(ctx, render_operation).await?
-                } else {
-                    render_operation.await?
-                }
+                })
+                .await?
             };
 
             if layout_cache_enabled && route_match.not_found.is_none() {
@@ -1036,8 +1060,10 @@ impl LayoutRenderer {
     ) -> Result<String, RariError> {
         let component_id = utils::get_component_id(loading_path);
 
-        let renderer = self.renderer.lock().await;
-        renderer.render_to_string(&component_id, None).await
+        run_with_renderer_result(Arc::clone(&self.renderer), move |renderer| async move {
+            renderer.render_to_string(&component_id, None).await
+        })
+        .await
     }
 
     pub async fn render_error(
@@ -1058,8 +1084,10 @@ impl LayoutRenderer {
         let props_json = serde_json::to_string(&props)
             .map_err(|e| RariError::internal(format!("Failed to serialize error props: {e}")))?;
 
-        let renderer = self.renderer.lock().await;
-        renderer.render_to_string(&component_id, Some(&props_json)).await
+        run_with_renderer_result(Arc::clone(&self.renderer), move |renderer| async move {
+            renderer.render_to_string(&component_id, Some(&props_json)).await
+        })
+        .await
     }
 
     pub async fn render_not_found(
@@ -1069,8 +1097,10 @@ impl LayoutRenderer {
     ) -> Result<String, RariError> {
         let component_id = utils::get_component_id(not_found_path);
 
-        let renderer = self.renderer.lock().await;
-        renderer.render_to_string(&component_id, None).await
+        run_with_renderer_result(Arc::clone(&self.renderer), move |renderer| async move {
+            renderer.render_to_string(&component_id, None).await
+        })
+        .await
     }
 
     pub async fn component_exists(&self, component_id: &str) -> bool {
@@ -1083,7 +1113,12 @@ impl LayoutRenderer {
         component_id: &str,
         component_code: &str,
     ) -> Result<(), RariError> {
-        self.renderer.lock().await.register_component(component_id, component_code).await
+        let component_id = component_id.to_string();
+        let component_code = component_code.to_string();
+        run_with_renderer_result(Arc::clone(&self.renderer), move |renderer| async move {
+            renderer.register_component(&component_id, &component_code).await
+        })
+        .await
     }
 }
 

--- a/crates/rari/src/server/cache/warmup.rs
+++ b/crates/rari/src/server/cache/warmup.rs
@@ -34,6 +34,9 @@ const WARMUP_CONCURRENCY: usize = 10;
 /// The RSC+Fizz pipeline shares V8 globals between the mutex-protected
 /// RSC render and the non-mutex Fizz render. Without serialization,
 /// concurrent warmup tasks interleave and produce wrong HTML.
+///
+/// The guard must cover both the HTML/Fizz render and the follow-up RSC
+/// render in [`warm_route`], not only the first call.
 static WARMUP_RENDER_LOCK: OnceCell<Arc<Mutex<()>>> = OnceCell::const_new();
 
 async fn warmup_render_lock() -> Arc<Mutex<()>> {
@@ -116,33 +119,21 @@ async fn warm_route(
         Arc::clone(&state.renderer),
         Arc::clone(&state.layout_html_cache),
     );
-    let layout_renderer_for_rsc = LayoutRenderer::with_shared_cache(
-        Arc::clone(&state.renderer),
-        Arc::clone(&state.layout_html_cache),
-    );
 
     let request_context =
         Arc::new(RequestContext::new(route_match.route.path.clone()).without_layout_html_cache());
 
-    let render_lock = warmup_render_lock().await;
-    let route_match_for_render = route_match.clone();
-    let context_for_render = context.clone();
-    let request_context_for_render = Arc::clone(&request_context);
+    let _render_guard = warmup_render_lock().await.lock_owned().await;
 
-    let render_result = tokio::spawn(async move {
-        let _guard = render_lock.lock_owned().await;
-        layout_renderer
-            .render_route_with_streaming(
-                &route_match_for_render,
-                &context_for_render,
-                Some(request_context_for_render),
-                false,
-            )
-            .await
-    })
-    .await
-    .map_err(|e| format!("Warmup render task join failed: {e}"))?
-    .map_err(|e| format!("Render failed: {e}"))?;
+    let render_result = layout_renderer
+        .render_route_with_streaming(
+            &route_match,
+            &context,
+            Some(Arc::clone(&request_context)),
+            false,
+        )
+        .await
+        .map_err(|e| format!("Render failed: {e}"))?;
 
     context.metadata = collect_page_metadata(state, &route_match, &context).await;
 
@@ -227,9 +218,8 @@ async fn warm_route(
         state.response_cache.set(html_cache_key, cached_response).await;
     }
 
-    let rsc_result = layout_renderer_for_rsc
-        .render_route_by_mode(&route_match, &context, Some(request_context))
-        .await;
+    let rsc_result =
+        layout_renderer.render_route_by_mode(&route_match, &context, Some(request_context)).await;
 
     if let Ok(rsc_flight_protocol) = rsc_result {
         let rsc_cache_key =

--- a/crates/rari/src/server/cache/warmup.rs
+++ b/crates/rari/src/server/cache/warmup.rs
@@ -34,10 +34,10 @@ const WARMUP_CONCURRENCY: usize = 10;
 /// The RSC+Fizz pipeline shares V8 globals between the mutex-protected
 /// RSC render and the non-mutex Fizz render. Without serialization,
 /// concurrent warmup tasks interleave and produce wrong HTML.
-static WARMUP_RENDER_LOCK: OnceCell<Mutex<()>> = OnceCell::const_new();
+static WARMUP_RENDER_LOCK: OnceCell<Arc<Mutex<()>>> = OnceCell::const_new();
 
-async fn warmup_render_lock() -> &'static Mutex<()> {
-    WARMUP_RENDER_LOCK.get_or_init(|| async { Mutex::new(()) }).await
+async fn warmup_render_lock() -> Arc<Mutex<()>> {
+    Arc::clone(WARMUP_RENDER_LOCK.get_or_init(|| async { Arc::new(Mutex::new(())) }).await)
 }
 
 async fn merge_warmup_cache_tags(state: &ServerState, base_tags: Vec<String>) -> Vec<String> {
@@ -116,21 +116,33 @@ async fn warm_route(
         Arc::clone(&state.renderer),
         Arc::clone(&state.layout_html_cache),
     );
+    let layout_renderer_for_rsc = LayoutRenderer::with_shared_cache(
+        Arc::clone(&state.renderer),
+        Arc::clone(&state.layout_html_cache),
+    );
 
     let request_context =
         Arc::new(RequestContext::new(route_match.route.path.clone()).without_layout_html_cache());
 
-    let _render_guard = warmup_render_lock().await.lock().await;
+    let render_lock = warmup_render_lock().await;
+    let route_match_for_render = route_match.clone();
+    let context_for_render = context.clone();
+    let request_context_for_render = Arc::clone(&request_context);
 
-    let render_result = layout_renderer
-        .render_route_with_streaming(
-            &route_match,
-            &context,
-            Some(Arc::clone(&request_context)),
-            false,
-        )
-        .await
-        .map_err(|e| format!("Render failed: {e}"))?;
+    let render_result = tokio::spawn(async move {
+        let _guard = render_lock.lock_owned().await;
+        layout_renderer
+            .render_route_with_streaming(
+                &route_match_for_render,
+                &context_for_render,
+                Some(request_context_for_render),
+                false,
+            )
+            .await
+    })
+    .await
+    .map_err(|e| format!("Warmup render task join failed: {e}"))?
+    .map_err(|e| format!("Render failed: {e}"))?;
 
     context.metadata = collect_page_metadata(state, &route_match, &context).await;
 
@@ -215,8 +227,9 @@ async fn warm_route(
         state.response_cache.set(html_cache_key, cached_response).await;
     }
 
-    let rsc_result =
-        layout_renderer.render_route_by_mode(&route_match, &context, Some(request_context)).await;
+    let rsc_result = layout_renderer_for_rsc
+        .render_route_by_mode(&route_match, &context, Some(request_context))
+        .await;
 
     if let Ok(rsc_flight_protocol) = rsc_result {
         let rsc_cache_key =

--- a/crates/rari/src/server/middleware/proxy.rs
+++ b/crates/rari/src/server/middleware/proxy.rs
@@ -20,7 +20,14 @@ use serde::{Deserialize, Serialize};
 use tokio::fs;
 use tower::{Layer, Service};
 
-use crate::{server::core::types::ServerState, utils::path::path_to_file_url};
+use crate::{
+    runtime::JsExecutionRuntime, server::core::types::ServerState, utils::path::path_to_file_url,
+};
+
+async fn clone_renderer_runtime(state: &ServerState) -> Arc<JsExecutionRuntime> {
+    let renderer = state.renderer.lock().await;
+    Arc::clone(&renderer.runtime)
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 struct ProxyResult {
@@ -72,10 +79,7 @@ async fn execute_proxy(
         "headers": headers,
     });
 
-    let runtime = {
-        let renderer = state.renderer.lock().await;
-        Arc::clone(&renderer.runtime)
-    };
+    let runtime = clone_renderer_runtime(state).await;
 
     let result_json = runtime.execute_function("~rariExecuteProxy", vec![request_data]).await?;
 
@@ -278,10 +282,7 @@ pub async fn initialize_proxy(state: &ServerState) -> Result<(), Box<dyn Error>>
     };
     let proxy_specifier = path_to_file_url(&proxy_absolute);
 
-    let runtime = {
-        let renderer = state.renderer.lock().await;
-        Arc::clone(&renderer.runtime)
-    };
+    let runtime = clone_renderer_runtime(state).await;
 
     let init_script = format!(
         r#"(async function() {{

--- a/crates/rari/src/server/middleware/proxy.rs
+++ b/crates/rari/src/server/middleware/proxy.rs
@@ -3,6 +3,7 @@ use std::{
     error::Error,
     fs as std_fs, mem,
     path::{Path, PathBuf},
+    sync::Arc,
     task::{Context, Poll},
 };
 
@@ -61,13 +62,8 @@ async fn execute_proxy(
     uri: String,
     headers: FxHashMap<String, String>,
 ) -> Result<ProxyResult, Box<dyn Error + Send + Sync>> {
-    let renderer = state.renderer.lock().await;
-    let runtime = &renderer.runtime;
-
     let scheme = headers.get("x-forwarded-proto").cloned().unwrap_or_else(|| "http".to_string());
-
     let host = headers.get("host").cloned().unwrap_or_else(|| "localhost".to_string());
-
     let url = format!("{scheme}://{host}{uri}");
 
     let request_data = serde_json::json!({
@@ -75,6 +71,11 @@ async fn execute_proxy(
         "method": method,
         "headers": headers,
     });
+
+    let runtime = {
+        let renderer = state.renderer.lock().await;
+        Arc::clone(&renderer.runtime)
+    };
 
     let result_json = runtime.execute_function("~rariExecuteProxy", vec![request_data]).await?;
 
@@ -247,9 +248,6 @@ pub async fn initialize_proxy(state: &ServerState) -> Result<(), Box<dyn Error>>
         return Ok(());
     }
 
-    let renderer = state.renderer.lock().await;
-    let runtime = &renderer.runtime;
-
     let Some(rari_pkg_dir) = resolve_rari_package_dir().await else {
         tracing::debug!("Proxy: rari package directory not found in node_modules");
         return Ok(());
@@ -279,6 +277,11 @@ pub async fn initialize_proxy(state: &ServerState) -> Result<(), Box<dyn Error>>
         Err(_) => env::current_dir()?.join(proxy_file_path),
     };
     let proxy_specifier = path_to_file_url(&proxy_absolute);
+
+    let runtime = {
+        let renderer = state.renderer.lock().await;
+        Arc::clone(&renderer.runtime)
+    };
 
     let init_script = format!(
         r#"(async function() {{

--- a/crates/rari/src/server/middleware/request_context.rs
+++ b/crates/rari/src/server/middleware/request_context.rs
@@ -82,6 +82,30 @@ static GLOBAL_FETCH_CACHE: LazyLock<Arc<Mutex<LruCache<String, CachedFetchResult
 static GLOBAL_IN_FLIGHT_FETCHES: LazyLock<InFlightFetches> =
     LazyLock::new(|| Arc::new(DashMap::new()));
 
+struct FetchCleanupGuard {
+    in_flight_fetches: InFlightFetches,
+    cache_key: String,
+    armed: bool,
+}
+
+impl FetchCleanupGuard {
+    fn new(in_flight_fetches: InFlightFetches, cache_key: String) -> Self {
+        Self { in_flight_fetches, cache_key, armed: true }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for FetchCleanupGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            self.in_flight_fetches.remove(&self.cache_key);
+        }
+    }
+}
+
 pub struct RequestContext {
     fetch_cache: Arc<Mutex<LruCache<String, CachedFetchResult>>>,
     in_flight_fetches: InFlightFetches,
@@ -244,10 +268,20 @@ impl RequestContext {
         let cache_key_for_task = cache_key.clone();
 
         tokio::spawn(async move {
+            let mut cleanup =
+                FetchCleanupGuard::new(Arc::clone(&in_flight_fetches), cache_key_for_task.clone());
             let mut guard = fetch_lock.lock().await;
 
             if let Some(result) = guard.as_ref() {
-                return result.clone();
+                let mut result = result.clone();
+                if let Ok(ref mut cached) = result {
+                    cached.tags = Self::merge_and_sort_tags(mem::take(&mut cached.tags), tags);
+                    *guard = Some(Ok(cached.clone()));
+                    let mut cache = fetch_cache.lock();
+                    cache.put(cache_key_for_task, cached.clone());
+                }
+                cleanup.disarm();
+                return result;
             }
 
             let mut fetch_result = Self::perform_fetch_standalone(&url, &options).await;
@@ -260,12 +294,10 @@ impl RequestContext {
 
             if let Ok(ref cached_result) = fetch_result {
                 let mut cache = fetch_cache.lock();
-                cache.put(cache_key_for_task.clone(), cached_result.clone());
+                cache.put(cache_key_for_task, cached_result.clone());
             }
 
             drop(guard);
-            in_flight_fetches.remove(&cache_key_for_task);
-
             fetch_result
         })
         .await

--- a/crates/rari/src/server/middleware/request_context.rs
+++ b/crates/rari/src/server/middleware/request_context.rs
@@ -301,7 +301,7 @@ impl RequestContext {
             fetch_result
         })
         .await
-        .map_err(|e| RariError::network(format!("fetch singleflight join failed: {e}")))?
+        .map_err(|e| RariError::internal(format!("fetch singleflight join failed: {e}")))?
     }
 
     async fn perform_fetch_standalone(

--- a/crates/rari/src/server/middleware/request_context.rs
+++ b/crates/rari/src/server/middleware/request_context.rs
@@ -273,6 +273,7 @@ impl RequestContext {
             let mut guard = fetch_lock.lock().await;
 
             if let Some(result) = guard.as_ref() {
+                cleanup.disarm();
                 let mut result = result.clone();
                 if let Ok(ref mut cached) = result {
                     cached.tags = Self::merge_and_sort_tags(mem::take(&mut cached.tags), tags);
@@ -280,7 +281,6 @@ impl RequestContext {
                     let mut cache = fetch_cache.lock();
                     cache.put(cache_key_for_task, cached.clone());
                 }
-                cleanup.disarm();
                 return result;
             }
 

--- a/crates/rari/src/server/middleware/request_context.rs
+++ b/crates/rari/src/server/middleware/request_context.rs
@@ -82,17 +82,6 @@ static GLOBAL_FETCH_CACHE: LazyLock<Arc<Mutex<LruCache<String, CachedFetchResult
 static GLOBAL_IN_FLIGHT_FETCHES: LazyLock<InFlightFetches> =
     LazyLock::new(|| Arc::new(DashMap::new()));
 
-struct FetchCleanupGuard<'a> {
-    in_flight_fetches: &'a InFlightFetches,
-    cache_key: String,
-}
-
-impl Drop for FetchCleanupGuard<'_> {
-    fn drop(&mut self) {
-        self.in_flight_fetches.remove(&self.cache_key);
-    }
-}
-
 pub struct RequestContext {
     fetch_cache: Arc<Mutex<LruCache<String, CachedFetchResult>>>,
     in_flight_fetches: InFlightFetches,
@@ -249,47 +238,41 @@ impl RequestContext {
             entry.or_insert_with(|| Arc::new(TokioMutex::new(None))).clone()
         };
 
-        let mut guard = fetch_lock.lock().await;
+        let url = url.to_string();
+        let fetch_cache = Arc::clone(&self.fetch_cache);
+        let in_flight_fetches = Arc::clone(&self.in_flight_fetches);
+        let cache_key_for_task = cache_key.clone();
 
-        if let Some(result) = guard.as_ref() {
-            let mut cloned_result = result.clone()?;
-            cloned_result.tags = Self::merge_and_sort_tags(cloned_result.tags, tags);
+        tokio::spawn(async move {
+            let mut guard = fetch_lock.lock().await;
 
-            {
-                let mut cache = self.fetch_cache.lock();
-                cache.put(cache_key.clone(), cloned_result.clone());
+            if let Some(result) = guard.as_ref() {
+                return result.clone();
             }
 
-            *guard = Some(Ok(cloned_result.clone()));
+            let mut fetch_result = Self::perform_fetch_standalone(&url, &options).await;
 
-            return Ok(cloned_result);
-        }
+            if let Ok(ref mut result) = fetch_result {
+                result.tags = Self::merge_and_sort_tags(mem::take(&mut result.tags), tags);
+            }
 
-        let _cleanup = FetchCleanupGuard {
-            in_flight_fetches: &self.in_flight_fetches,
-            cache_key: cache_key.clone(),
-        };
+            *guard = Some(fetch_result.clone());
 
-        let mut fetch_result = self.perform_fetch(url, &options).await;
+            if let Ok(ref cached_result) = fetch_result {
+                let mut cache = fetch_cache.lock();
+                cache.put(cache_key_for_task.clone(), cached_result.clone());
+            }
 
-        if let Ok(ref mut result) = fetch_result {
-            result.tags = Self::merge_and_sort_tags(mem::take(&mut result.tags), tags);
-        }
+            drop(guard);
+            in_flight_fetches.remove(&cache_key_for_task);
 
-        *guard = Some(fetch_result.clone());
-
-        if let Ok(ref cached_result) = fetch_result {
-            let mut cache = self.fetch_cache.lock();
-            cache.put(cache_key.clone(), cached_result.clone());
-        }
-
-        drop(guard);
-
-        fetch_result
+            fetch_result
+        })
+        .await
+        .map_err(|e| RariError::network(format!("fetch singleflight join failed: {e}")))?
     }
 
-    async fn perform_fetch(
-        &self,
+    async fn perform_fetch_standalone(
         url: &str,
         options: &FxHashMap<String, String>,
     ) -> Result<CachedFetchResult, RariError> {

--- a/crates/rari/src/server/vite/hmr.rs
+++ b/crates/rari/src/server/vite/hmr.rs
@@ -3,6 +3,7 @@
 use std::{
     env,
     path::PathBuf,
+    sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -14,6 +15,7 @@ use serde_json::Value;
 use tokio::{fs, time};
 
 use crate::{
+    rendering::base::run_with_renderer_result,
     rsc::extract_dependencies,
     server::{
         ServerState,
@@ -263,20 +265,21 @@ async fn handle_invalidate(
     _file_path: Option<String>,
 ) -> Result<Json<Value>, StatusCode> {
     let result = {
-        let renderer = state.renderer.lock().await;
+        let renderer = Arc::clone(&state.renderer);
+        let component_id = component_id.clone();
+        run_with_renderer_result(renderer, move |renderer| async move {
+            {
+                let mut registry = renderer.component_registry.lock();
+                registry.mark_module_stale(&component_id);
+            }
 
-        {
-            let mut registry = renderer.component_registry.lock();
-            registry.mark_module_stale(&component_id);
-        }
+            renderer.clear_component_cache(&component_id);
 
-        renderer.clear_component_cache(&component_id);
+            if let Err(e) = renderer.runtime.clear_module_loader_caches(&component_id).await {
+                tracing::error!("Failed to clear module loader caches for {}: {}", component_id, e);
+            }
 
-        if let Err(e) = renderer.runtime.clear_module_loader_caches(&component_id).await {
-            tracing::error!("Failed to clear module loader caches for {}: {}", component_id, e);
-        }
-
-        let clear_script = format!(
+            let clear_script = format!(
             r#"
             (function() {{
                 let clearedCount = 0;
@@ -339,13 +342,15 @@ async fn handle_invalidate(
             "#
         );
 
-        renderer
-            .runtime
-            .execute_script(
-                format!("hmr_clear_cache_{}.js", component_id.cow_replace('/', "_")),
-                clear_script,
-            )
-            .await
+            renderer
+                .runtime
+                .execute_script(
+                    format!("hmr_clear_cache_{}.js", component_id.cow_replace('/', "_")),
+                    clear_script,
+                )
+                .await
+        })
+        .await
     };
 
     match result {
@@ -431,8 +436,15 @@ async fn handle_reload(
         }
     };
 
-    let result =
-        { state.renderer.lock().await.register_component(&component_id, &transpiled_code).await };
+    let result = {
+        let renderer = Arc::clone(&state.renderer);
+        let component_id = component_id.clone();
+        let code = transpiled_code.clone();
+        run_with_renderer_result(renderer, move |renderer| async move {
+            renderer.register_component(&component_id, &code).await
+        })
+        .await
+    };
 
     match result {
         Ok(()) => Ok(Json(serde_json::json!({
@@ -517,49 +529,46 @@ async fn handle_reload_component(
         })));
     }
 
-    if let Err(e) = {
-        let renderer = state.renderer.lock().await;
-        renderer.runtime.invalidate_component(&component_id).await
-    } {
-        tracing::error!("Failed to invalidate component {}: {}", component_id, e);
-    }
-
     let load_result = {
-        let renderer = state.renderer.lock().await;
-        renderer.runtime.load_component_code(&component_id, &bundle_code).await
+        let renderer = Arc::clone(&state.renderer);
+        let component_id = component_id.clone();
+        run_with_renderer_result(renderer, move |renderer| async move {
+            if let Err(e) = renderer.runtime.invalidate_component(&component_id).await {
+                tracing::error!("Failed to invalidate component {}: {}", component_id, e);
+            }
+
+            renderer.runtime.load_component_code(&component_id, &bundle_code).await?;
+
+            let mut registry = renderer.component_registry.lock();
+            registry.remove_component(&component_id);
+
+            let dependencies = extract_dependencies(&bundle_code);
+
+            match registry.register_component(
+                &component_id,
+                &bundle_code,
+                bundle_code.clone(),
+                dependencies.into_iter().collect(),
+            ) {
+                Ok(()) => {
+                    registry.mark_component_loaded(&component_id);
+                    registry.mark_component_initially_loaded(&component_id);
+                    Ok(())
+                }
+                Err(e) => {
+                    tracing::error!("Failed to register component {}: {}", component_id, e);
+                    registry.remove_component(&component_id);
+                    Err(rari_error::RariError::internal(format!(
+                        "Failed to register component: {e}"
+                    )))
+                }
+            }
+        })
+        .await
     };
 
     match load_result {
         Ok(()) => {
-            {
-                let renderer = state.renderer.lock().await;
-                let mut registry = renderer.component_registry.lock();
-
-                registry.remove_component(&component_id);
-
-                let dependencies = extract_dependencies(&bundle_code);
-
-                match registry.register_component(
-                    &component_id,
-                    &bundle_code,
-                    bundle_code.clone(),
-                    dependencies.into_iter().collect(),
-                ) {
-                    Ok(()) => {
-                        registry.mark_component_loaded(&component_id);
-                        registry.mark_component_initially_loaded(&component_id);
-                    }
-                    Err(e) => {
-                        tracing::error!("Failed to register component {}: {}", component_id, e);
-                        registry.remove_component(&component_id);
-                        return Ok(Json(serde_json::json!({
-                            "success": false,
-                            "message": format!("Failed to register component: {}", e)
-                        })));
-                    }
-                }
-            }
-
             invalidate_component_cache(&state.response_cache, &component_id).await;
 
             Ok(Json(serde_json::json!({

--- a/crates/rari/src/server/vite/rsc.rs
+++ b/crates/rari/src/server/vite/rsc.rs
@@ -3,6 +3,7 @@
 use std::{
     error::Error,
     path::Path,
+    sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -12,6 +13,7 @@ use serde_json::Value;
 use tokio::{fs, time};
 
 use crate::{
+    rendering::base::{run_with_renderer, run_with_renderer_result},
     rsc::extract_dependencies,
     server::{
         RegisterClientRequest, RegisterRequest, ServerState,
@@ -33,44 +35,64 @@ pub async fn register_component(
     }
 
     let result = {
-        let renderer = state.renderer.lock().await;
-        renderer.register_component(&request.component_id, &request.component_code).await
+        let renderer = Arc::clone(&state.renderer);
+        let component_id = request.component_id.clone();
+        let component_code = request.component_code.clone();
+        run_with_renderer_result(renderer, move |renderer| async move {
+            renderer.register_component(&component_id, &component_code).await
+        })
+        .await
     };
 
     match result {
         Ok(()) => {
-            let renderer = state.renderer.lock().await;
-            let is_client = {
-                let registry = renderer.component_registry.lock();
-                registry.is_client_reference(&request.component_id)
-            };
+            let mark_result = {
+                let renderer = Arc::clone(&state.renderer);
+                let component_id = request.component_id.clone();
+                run_with_renderer_result(renderer, move |renderer| async move {
+                    let is_client = {
+                        let registry = renderer.component_registry.lock();
+                        registry.is_client_reference(&component_id)
+                    };
 
-            if is_client {
-                let mark_script = format!(
-                    r#"(function() {{
-                        const comp = globalThis["{}"];
+                    if is_client {
+                        let mark_script = format!(
+                            r#"(function() {{
+                        const comp = globalThis["{component_id}"];
                         if (comp && typeof comp === 'function') {{
                             comp['~isClientComponent'] = true;
-                            comp['~clientComponentId'] = "{}";
+                            comp['~clientComponentId'] = "{component_id}";
                         }}
-                    }})()"#,
-                    request.component_id, request.component_id
-                );
+                    }})()"#
+                        );
 
-                if let Err(e) = renderer
-                    .runtime
-                    .execute_script(
-                        format!("mark_client_{}.js", request.component_id.cow_replace('/', "_")),
-                        mark_script,
-                    )
-                    .await
-                {
-                    tracing::error!(
-                        "Failed to mark {} as client component: {}",
-                        request.component_id,
-                        e
-                    );
-                }
+                        if let Err(e) = renderer
+                            .runtime
+                            .execute_script(
+                                format!("mark_client_{}.js", component_id.cow_replace('/', "_")),
+                                mark_script,
+                            )
+                            .await
+                        {
+                            tracing::error!(
+                                "Failed to mark {} as client component: {}",
+                                component_id,
+                                e
+                            );
+                        }
+                    }
+
+                    Ok(())
+                })
+                .await
+            };
+
+            if let Err(e) = mark_result {
+                tracing::error!(
+                    "Failed post-register client mark for {}: {}",
+                    request.component_id,
+                    e
+                );
             }
 
             Ok(Json(serde_json::json!({
@@ -220,52 +242,57 @@ pub async fn reload_component_from_dist(
         || dist_code.contains("export\n")
         || dist_code.contains("export\r");
 
-    let renderer = state.renderer.lock().await;
+    let dist_path_display = dist_path.display().to_string();
+    let component_id = component_id.to_string();
+    let renderer = Arc::clone(&state.renderer);
 
-    if is_esm {
-        renderer.clear_component_cache(component_id);
+    run_with_renderer(renderer, move |renderer| async move {
+        if is_esm {
+            renderer.clear_component_cache(&component_id);
 
-        if let Err(e) = renderer.runtime.clear_module_loader_caches(component_id).await {
-            tracing::error!("Failed to clear module loader caches for {}: {}", component_id, e);
-        }
+            if let Err(e) = renderer.runtime.clear_module_loader_caches(&component_id).await {
+                tracing::error!("Failed to clear module loader caches for {}: {}", component_id, e);
+            }
 
-        let timestamp =
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis();
+            let timestamp =
+                SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis();
 
-        let hmr_specifier = format!("file:///rari_hmr/server/{component_id}.js?v={timestamp}");
+            let hmr_specifier = format!("file:///rari_hmr/server/{component_id}.js?v={timestamp}");
 
-        renderer.runtime.add_module_to_loader(&hmr_specifier, dist_code.clone()).await.map_err(
-            |e| {
+            renderer
+                .runtime
+                .add_module_to_loader(&hmr_specifier, dist_code.clone())
+                .await
+                .map_err(|e| {
+                    tracing::error!(
+                        component_id = component_id.as_str(),
+                        error = %e,
+                        "Failed to add HMR module to loader"
+                    );
+                    format!("Failed to add HMR module to loader: {e}")
+                })?;
+
+            let module_id = renderer.runtime.load_es_module(&component_id).await.map_err(|e| {
                 tracing::error!(
-                    component_id = component_id,
+                    component_id = component_id.as_str(),
                     error = %e,
-                    "Failed to add HMR module to loader"
+                    "Failed to load ES module during HMR"
                 );
-                format!("Failed to add HMR module to loader: {e}")
-            },
-        )?;
+                format!("Failed to load ES module: {e}")
+            })?;
 
-        let module_id = renderer.runtime.load_es_module(component_id).await.map_err(|e| {
-            tracing::error!(
-                component_id = component_id,
-                error = %e,
-                "Failed to load ES module during HMR"
-            );
-            format!("Failed to load ES module: {e}")
-        })?;
+            renderer.runtime.evaluate_module(module_id).await.map_err(|e| {
+                tracing::error!(
+                    component_id = component_id.as_str(),
+                    module_id = module_id,
+                    error = %e,
+                    "Failed to evaluate module during HMR"
+                );
+                format!("Failed to evaluate module: {e}")
+            })?;
 
-        renderer.runtime.evaluate_module(module_id).await.map_err(|e| {
-            tracing::error!(
-                component_id = component_id,
-                module_id = module_id,
-                error = %e,
-                "Failed to evaluate module during HMR"
-            );
-            format!("Failed to evaluate module: {e}")
-        })?;
-
-        let clear_script = format!(
-            r#"(function() {{
+            let clear_script = format!(
+                r#"(function() {{
                 const componentId = "{component_id}";
 
                 delete globalThis[componentId];
@@ -276,26 +303,26 @@ pub async fn reload_component_from_dist(
 
                 return {{ success: true }};
             }})()"#
-        );
+            );
 
-        renderer
-            .runtime
-            .execute_script(
-                format!("clear_old_{}.js", component_id.cow_replace('/', "_")),
-                clear_script,
-            )
-            .await
-            .map_err(|e| {
-                tracing::error!(
-                    component_id = component_id,
-                    error = %e,
-                    "Failed to clear old component"
-                );
-                format!("Failed to clear old component: {e}")
-            })?;
+            renderer
+                .runtime
+                .execute_script(
+                    format!("clear_old_{}.js", component_id.cow_replace('/', "_")),
+                    clear_script,
+                )
+                .await
+                .map_err(|e| {
+                    tracing::error!(
+                        component_id = component_id.as_str(),
+                        error = %e,
+                        "Failed to clear old component"
+                    );
+                    format!("Failed to clear old component: {e}")
+                })?;
 
-        let registration_script = format!(
-            r#"(async function() {{
+            let registration_script = format!(
+                r#"(async function() {{
                 try {{
                     const moduleNamespace = await import("{hmr_specifier}");
                     const componentId = "{component_id}";
@@ -334,71 +361,70 @@ pub async fn reload_component_from_dist(
                     return {{ success: false, error: error.message }};
                 }}
             }})()"#
-        );
+            );
 
-        renderer
-            .runtime
-            .execute_script(
-                format!("register_esm_{}.js", component_id.cow_replace('/', "_")),
-                registration_script,
-            )
-            .await
-            .map_err(|e| {
-                tracing::error!(
-                    component_id = component_id,
-                    error = %e,
-                    "Failed to register ESM module exports to globalThis"
+            renderer
+                .runtime
+                .execute_script(
+                    format!("register_esm_{}.js", component_id.cow_replace('/', "_")),
+                    registration_script,
+                )
+                .await
+                .map_err(|e| {
+                    tracing::error!(
+                        component_id = component_id.as_str(),
+                        error = %e,
+                        "Failed to register ESM module exports to globalThis"
+                    );
+                    format!("Failed to register ESM module: {e}")
+                })?;
+
+            renderer.clear_script_cache();
+
+            let dependencies = extract_dependencies(&dist_code);
+
+            {
+                let mut registry = renderer.component_registry.lock();
+
+                registry.remove_component(&component_id);
+
+                let _ = registry.register_component(
+                    &component_id,
+                    &dist_code,
+                    dist_code.clone(),
+                    dependencies.into_iter().collect(),
                 );
-                format!("Failed to register ESM module: {e}")
-            })?;
 
-        renderer.clear_script_cache();
+                registry.mark_component_loaded(&component_id);
+                registry.mark_component_initially_loaded(&component_id);
+            }
+        } else {
+            let wrapped_code = wrap_server_action_module(&dist_code, &component_id);
 
-        let dependencies = extract_dependencies(&dist_code);
+            let execution_result = renderer
+                .runtime
+                .execute_script(
+                    format!("hmr_reload_{}.js", component_id.cow_replace('/', "_")),
+                    wrapped_code.clone(),
+                )
+                .await;
 
-        {
-            let mut registry = renderer.component_registry.lock();
-
-            registry.remove_component(component_id);
-
-            let _ = registry.register_component(
-                component_id,
-                &dist_code,
-                dist_code.clone(),
-                dependencies.into_iter().collect(),
-            );
-
-            registry.mark_component_loaded(component_id);
-            registry.mark_component_initially_loaded(component_id);
+            if let Err(e) = execution_result {
+                tracing::error!(
+                    component_id = component_id.as_str(),
+                    dist_path = %dist_path_display,
+                    error = %e,
+                    code_length = dist_code.len(),
+                    "Failed to execute component code during reload. Last known good version will be preserved."
+                );
+                return Err(format!(
+                    "Failed to execute component code: {e}. Last known good version will be preserved."
+                ));
+            }
         }
-    } else {
-        let wrapped_code = wrap_server_action_module(&dist_code, component_id);
 
-        let execution_result = renderer
-            .runtime
-            .execute_script(
-                format!("hmr_reload_{}.js", component_id.cow_replace('/', "_")),
-                wrapped_code.clone(),
-            )
-            .await;
-
-        if let Err(e) = execution_result {
-            tracing::error!(
-                component_id = component_id,
-                dist_path = %dist_path.display(),
-                error = %e,
-                code_length = dist_code.len(),
-                "Failed to execute component code during reload. Last known good version will be preserved."
-            );
-            return Err(format!(
-                "Failed to execute component code: {e}. Last known good version will be preserved."
-            )
-            .into());
-        }
-    }
-
-    let verification_script = format!(
-        r"(function() {{
+        let verification_script = format!(
+            r"(function() {{
             const expectedKey = '{component_id}';
             const exists = typeof globalThis[expectedKey] !== 'undefined';
             const type = typeof globalThis[expectedKey];
@@ -417,65 +443,74 @@ pub async fn reload_component_from_dist(
                 actualKeys: allKeys
             }};
         }})()"
-    );
-
-    let result_json = match renderer
-        .runtime
-        .execute_script(
-            format!("verify_{}.js", component_id.cow_replace('/', "_")),
-            verification_script,
-        )
-        .await
-    {
-        Ok(json) => json,
-        Err(e) => {
-            tracing::error!(
-                component_id = component_id,
-                error = %e,
-                "Failed to execute verification script. Last known good version will be preserved."
-            );
-            return Err(format!(
-                "Failed to verify component reload: {e}. Last known good version will be preserved."
-            )
-            .into());
-        }
-    };
-
-    if let Some(success) = result_json.get("success").and_then(serde_json::Value::as_bool) {
-        if success {
-            Ok(())
-        } else {
-            let actual_keys = result_json
-                .get("actualKeys")
-                .and_then(|v| v.as_array())
-                .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>().join(", "))
-                .unwrap_or_else(|| "unknown".to_string());
-
-            let expected_key =
-                result_json.get("expectedKey").and_then(|v| v.as_str()).unwrap_or(component_id);
-
-            tracing::error!(
-                component_id = component_id,
-                expected_key = expected_key,
-                actual_keys = actual_keys,
-                verification_result = ?result_json,
-                "Component not found in globalThis after reload. Expected key '{}' not found. Available keys: [{}]. Last known good version will be preserved.",
-                expected_key,
-                actual_keys
-            );
-            Err(format!(
-                "Component '{component_id}' not found in globalThis after reload. Expected key '{expected_key}' but found keys: [{actual_keys}]. Last known good version will be preserved."
-            )
-            .into())
-        }
-    } else {
-        tracing::error!(
-            component_id = component_id,
-            verification_result = ?result_json,
-            "Invalid verification result format. Last known good version will be preserved."
         );
-        Err("Invalid verification result format. Last known good version will be preserved.".into())
-    }
+
+        let result_json = match renderer
+            .runtime
+            .execute_script(
+                format!("verify_{}.js", component_id.cow_replace('/', "_")),
+                verification_script,
+            )
+            .await
+        {
+            Ok(json) => json,
+            Err(e) => {
+                tracing::error!(
+                    component_id = component_id.as_str(),
+                    error = %e,
+                    "Failed to execute verification script. Last known good version will be preserved."
+                );
+                return Err(format!(
+                    "Failed to verify component reload: {e}. Last known good version will be preserved."
+                ));
+            }
+        };
+
+        if let Some(success) = result_json.get("success").and_then(serde_json::Value::as_bool) {
+            if success {
+                Ok(())
+            } else {
+                let actual_keys = result_json
+                    .get("actualKeys")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>().join(", ")
+                    })
+                    .unwrap_or_else(|| "unknown".to_string());
+
+                let expected_key = result_json
+                    .get("expectedKey")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(&component_id);
+
+                tracing::error!(
+                    component_id = component_id.as_str(),
+                    expected_key = expected_key,
+                    actual_keys = actual_keys,
+                    verification_result = ?result_json,
+                    "Component not found in globalThis after reload. Expected key '{}' not found. Available keys: [{}]. Last known good version will be preserved.",
+                    expected_key,
+                    actual_keys
+                );
+                Err(format!(
+                    "Component '{component_id}' not found in globalThis after reload. Expected key '{expected_key}' but found keys: [{actual_keys}]. Last known good version will be preserved."
+                ))
+            }
+        } else {
+            tracing::error!(
+                component_id = component_id.as_str(),
+                verification_result = ?result_json,
+                "Invalid verification result format. Last known good version will be preserved."
+            );
+            Err(
+                "Invalid verification result format. Last known good version will be preserved."
+                    .to_string(),
+            )
+        }
+    })
+    .await
+    .map_err(|e| -> Box<dyn Error + Send + Sync> { e.to_string().into() })?
+    .map_err(|e| -> Box<dyn Error + Send + Sync> { e.into() })
 }
 
 pub async fn immediate_component_reregistration(
@@ -501,12 +536,22 @@ pub async fn immediate_component_reregistration(
         path.file_stem().and_then(|stem| stem.to_str()).unwrap_or("UnknownComponent");
 
     {
-        let mut renderer = state.renderer.lock().await;
-        renderer.clear_script_cache();
+        let renderer = Arc::clone(&state.renderer);
+        let component_name = component_name.to_string();
+        run_with_renderer_result(renderer, move |mut renderer| async move {
+            renderer.clear_script_cache();
 
-        if let Err(e) = renderer.clear_component_module_cache(component_name).await {
-            tracing::error!("Failed to clear component module cache for {}: {}", component_name, e);
-        }
+            if let Err(e) = renderer.clear_component_module_cache(&component_name).await {
+                tracing::error!(
+                    "Failed to clear component module cache for {}: {}",
+                    component_name,
+                    e
+                );
+            }
+            Ok(())
+        })
+        .await
+        .map_err(|e| -> Box<dyn Error + Send + Sync> { e.to_string().into() })?;
     }
 
     let content = match fs::read_to_string(file_path).await {
@@ -523,49 +568,59 @@ pub async fn immediate_component_reregistration(
         }
     };
 
+    let component_name = component_name.to_string();
+    let renderer = Arc::clone(&state.renderer);
+    let content_for_register = content.clone();
+    let name_for_register = component_name.clone();
+
+    if let Err(e) = run_with_renderer_result(renderer, move |renderer| async move {
+        renderer.register_component(&name_for_register, &content_for_register).await
+    })
+    .await
     {
-        if let Err(e) =
-            state.renderer.lock().await.register_component(component_name, &content).await
-        {
-            tracing::error!(
-                component_name = component_name,
-                error = %e,
-                "Failed to register component directly, preserving last known good version"
-            );
-            Err(format!("Failed to register component: {e}").into())
-        } else {
-            time::sleep(time::Duration::from_millis(100)).await;
-
-            let mut renderer = state.renderer.lock().await;
-            if let Err(e) = renderer.clear_component_module_cache(component_name).await {
-                tracing::error!(
-                    "Failed to clear component module cache for {}: {}",
-                    component_name,
-                    e
-                );
-            }
-            drop(renderer);
-
-            time::sleep(time::Duration::from_millis(200)).await;
-
-            if let Err(e) =
-                state.renderer.lock().await.register_component(component_name, &content).await
-            {
-                tracing::error!(
-                    component_name = component_name,
-                    error = %e,
-                    "Failed to re-register component after cache clear, preserving last known good version"
-                );
-                return Err(
-                    format!("Failed to re-register component after cache clear: {e}").into()
-                );
-            }
-
-            time::sleep(time::Duration::from_millis(200)).await;
-
-            Ok(())
-        }
+        tracing::error!(
+            component_name = component_name.as_str(),
+            error = %e,
+            "Failed to register component directly, preserving last known good version"
+        );
+        return Err(format!("Failed to register component: {e}").into());
     }
+
+    time::sleep(time::Duration::from_millis(100)).await;
+
+    {
+        let renderer = Arc::clone(&state.renderer);
+        let name = component_name.clone();
+        run_with_renderer_result(renderer, move |mut renderer| async move {
+            if let Err(e) = renderer.clear_component_module_cache(&name).await {
+                tracing::error!("Failed to clear component module cache for {}: {}", name, e);
+            }
+            Ok(())
+        })
+        .await
+        .map_err(|e| -> Box<dyn Error + Send + Sync> { e.to_string().into() })?;
+    }
+
+    time::sleep(time::Duration::from_millis(200)).await;
+
+    let renderer = Arc::clone(&state.renderer);
+    let name_for_reregister = component_name.clone();
+    if let Err(e) = run_with_renderer_result(renderer, move |renderer| async move {
+        renderer.register_component(&name_for_reregister, &content).await
+    })
+    .await
+    {
+        tracing::error!(
+            component_name = component_name.as_str(),
+            error = %e,
+            "Failed to re-register component after cache clear, preserving last known good version"
+        );
+        return Err(format!("Failed to re-register component after cache clear: {e}").into());
+    }
+
+    time::sleep(time::Duration::from_millis(200)).await;
+
+    Ok(())
 }
 
 #[axum::debug_handler]

--- a/crates/rari/src/server/vite/rsc.rs
+++ b/crates/rari/src/server/vite/rsc.rs
@@ -39,67 +39,46 @@ pub async fn register_component(
         let component_id = request.component_id.clone();
         let component_code = request.component_code.clone();
         run_with_renderer_result(renderer, move |renderer| async move {
-            renderer.register_component(&component_id, &component_code).await
-        })
-        .await
-    };
+            renderer.register_component(&component_id, &component_code).await?;
 
-    match result {
-        Ok(()) => {
-            let mark_result = {
-                let renderer = Arc::clone(&state.renderer);
-                let component_id = request.component_id.clone();
-                run_with_renderer_result(renderer, move |renderer| async move {
-                    let is_client = {
-                        let registry = renderer.component_registry.lock();
-                        registry.is_client_reference(&component_id)
-                    };
+            let is_client = {
+                let registry = renderer.component_registry.lock();
+                registry.is_client_reference(&component_id)
+            };
 
-                    if is_client {
-                        let mark_script = format!(
-                            r#"(function() {{
+            if is_client {
+                let mark_script = format!(
+                    r#"(function() {{
                         const comp = globalThis["{component_id}"];
                         if (comp && typeof comp === 'function') {{
                             comp['~isClientComponent'] = true;
                             comp['~clientComponentId'] = "{component_id}";
                         }}
                     }})()"#
-                        );
-
-                        if let Err(e) = renderer
-                            .runtime
-                            .execute_script(
-                                format!("mark_client_{}.js", component_id.cow_replace('/', "_")),
-                                mark_script,
-                            )
-                            .await
-                        {
-                            tracing::error!(
-                                "Failed to mark {} as client component: {}",
-                                component_id,
-                                e
-                            );
-                        }
-                    }
-
-                    Ok(())
-                })
-                .await
-            };
-
-            if let Err(e) = mark_result {
-                tracing::error!(
-                    "Failed post-register client mark for {}: {}",
-                    request.component_id,
-                    e
                 );
+
+                if let Err(e) = renderer
+                    .runtime
+                    .execute_script(
+                        format!("mark_client_{}.js", component_id.cow_replace('/', "_")),
+                        mark_script,
+                    )
+                    .await
+                {
+                    tracing::error!("Failed to mark {} as client component: {}", component_id, e);
+                }
             }
 
-            Ok(Json(serde_json::json!({
-                "success": true,
-                "component_id": request.component_id
-            })))
-        }
+            Ok(())
+        })
+        .await
+    };
+
+    match result {
+        Ok(()) => Ok(Json(serde_json::json!({
+            "success": true,
+            "component_id": request.component_id
+        }))),
         Err(e) => {
             tracing::error!("Failed to register component {}: {}", request.component_id, e);
             Err(StatusCode::INTERNAL_SERVER_ERROR)
@@ -388,15 +367,26 @@ pub async fn reload_component_from_dist(
 
                 registry.remove_component(&component_id);
 
-                let _ = registry.register_component(
+                match registry.register_component(
                     &component_id,
                     &dist_code,
                     dist_code.clone(),
                     dependencies.into_iter().collect(),
-                );
-
-                registry.mark_component_loaded(&component_id);
-                registry.mark_component_initially_loaded(&component_id);
+                ) {
+                    Ok(()) => {
+                        registry.mark_component_loaded(&component_id);
+                        registry.mark_component_initially_loaded(&component_id);
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            component_id = component_id.as_str(),
+                            error = %e,
+                            "Failed to register component during HMR reload"
+                        );
+                        registry.remove_component(&component_id);
+                        return Err(format!("Failed to register component: {e}"));
+                    }
+                }
             }
         } else {
             let wrapped_code = wrap_server_action_module(&dist_code, &component_id);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability under concurrent requests by routing renderer operations through new “run with renderer” helpers to avoid unsafe lock holding across async awaits.
  * Enhanced streaming and layout rendering correctness by executing compose/serialize work inside the safe renderer flow.
  * Improved warmup serialization locking by switching to a shareable, owned lock handle.
  * Strengthened request-context caching by making in-flight singleflight cleanup conditional and more robust.
  * Improved HMR/RSC reload behavior with more consistent registration, cache invalidation, and clearer reload verification errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->