### PR TITLE
fix: resolve prod runtime, SSR, OG, and CSRF issues after 0.15.2

### DIFF
--- a/crates/rari/src/runtime/ext/node/resolvers.rs
+++ b/crates/rari/src/runtime/ext/node/resolvers.rs
@@ -406,42 +406,39 @@ impl NodeResolutionCache for NodeResolutionCacheImpl {
         }
     }
 }
+
 #[derive(Debug, Default, Clone)]
 pub struct NodeResolutionCacheInner {
-    cache: FxHashMap<PathBuf, (Option<PathBuf>, Option<FileType>)>,
+    canonicalized: FxHashMap<PathBuf, Option<PathBuf>>,
+    file_types: FxHashMap<PathBuf, Option<FileType>>,
 }
 impl NodeResolutionCacheInner {
     fn get_canonicalized(&self, path: &Path) -> Option<Result<PathBuf, io::Error>> {
-        self.cache.get(path).map(|(t, _)| {
-            t.clone().ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Not found."))
+        self.canonicalized.get(path).map(|item| match item {
+            Some(value) => Ok(value.clone()),
+            None => Err(io::Error::new(io::ErrorKind::NotFound, "Not found.")),
         })
     }
 
     fn set_canonicalized(&mut self, from: PathBuf, to: &io::Result<PathBuf>) {
-        let canon = match to {
-            Err(e) if e.kind() == io::ErrorKind::NotFound => None,
-            Ok(p) => Some(p.clone()),
-            _ => return,
-        };
-
-        if let Some((t, _)) = self.cache.get_mut(&from) {
-            *t = canon;
-        } else {
-            self.cache.insert(from, (canon, None));
+        match to {
+            Ok(to) => {
+                self.canonicalized.insert(from, Some(to.clone()));
+            }
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                self.canonicalized.insert(from, None);
+            }
+            Err(_) => {}
         }
     }
 
     #[expect(clippy::option_option)]
     fn get_file_type(&self, path: &Path) -> Option<Option<FileType>> {
-        self.cache.get(path).map(|(_, t)| *t)
+        self.file_types.get(path).copied()
     }
 
     fn set_file_type(&mut self, path: PathBuf, value: Option<FileType>) {
-        if let Some((_, t)) = self.cache.get_mut(&path) {
-            *t = value;
-        } else {
-            self.cache.insert(path, (None, value));
-        }
+        self.file_types.insert(path, value);
     }
 }
 

--- a/crates/rari/src/runtime/ext/runtime/node_console_scope.ts
+++ b/crates/rari/src/runtime/ext/runtime/node_console_scope.ts
@@ -1,0 +1,18 @@
+/**
+ * Residual `node:console` statically imports Deno's
+ * `ext:runtime/98_global_scope_shared.js`. rari filters Deno's real shared
+ * module and registers this file under that specifier instead so console can
+ * read `globalThis.console` (installed by init_console).
+ *
+ * Keep this file type-annotation-free: the extension specifier ends in `.js`.
+ */
+export const windowOrWorkerGlobalScope = {
+  console: {
+    get() {
+      return globalThis.console
+    },
+    value: undefined,
+  },
+}
+
+export const unstableForWindowOrWorkerGlobalScope = {}

--- a/crates/rari/src/runtime/ext/runtime/node_console_scope.ts
+++ b/crates/rari/src/runtime/ext/runtime/node_console_scope.ts
@@ -11,7 +11,6 @@ export const windowOrWorkerGlobalScope = {
     get() {
       return globalThis.console
     },
-    value: undefined,
   },
 }
 

--- a/crates/rari/src/runtime/module_loader/core.rs
+++ b/crates/rari/src/runtime/module_loader/core.rs
@@ -58,6 +58,8 @@ const FILE_PROTOCOL: &str = "file://";
 const NODE_PREFIX: &str = "node:";
 const FUNCTIONS_MODULE: &str = "functions";
 const VERSION_QUERY_PARAM: &str = "?v=";
+const DENO_GLOBAL_SCOPE_SHARED: &str = "ext:runtime/98_global_scope_shared.js";
+const NODE_CONSOLE_SCOPE_SOURCE: &str = include_str!("../ext/runtime/node_console_scope.ts");
 const RELATIVE_CURRENT_PATH: &str = "./";
 const RELATIVE_UP_PATH: &str = "../";
 const RARI_INTERNAL_PATH: &str = "/rari_internal/";
@@ -1116,6 +1118,15 @@ impl ModuleLoader for RariModuleLoader {
 
         if let Some(response) = self.handle_version_query(&specifier_str, module_specifier) {
             return response;
+        }
+
+        if specifier_str == DENO_GLOBAL_SCOPE_SHARED {
+            return ModuleLoadResponse::Sync(Ok(ModuleSource::new(
+                ModuleType::JavaScript,
+                ModuleSourceCode::String(NODE_CONSOLE_SCOPE_SOURCE.to_owned().into()),
+                module_specifier,
+                None,
+            )));
         }
 
         if let Some(response) = self.handle_rari_internal_modules(&specifier_str, module_specifier)

--- a/crates/rari/src/server/actions.rs
+++ b/crates/rari/src/server/actions.rs
@@ -121,7 +121,7 @@ fn check_origin(headers: &HeaderMap, allowed_origins: &[String]) -> Result<(), R
             return Err(RariError::forbidden("Referer not allowed"));
         }
 
-        tracing::error!("Missing origin and referer headers in server action request");
+        tracing::debug!("Missing origin and referer headers in server action request");
         return Err(RariError::forbidden("Origin or referer required"));
     }
 
@@ -152,7 +152,7 @@ fn check_origin(headers: &HeaderMap, allowed_origins: &[String]) -> Result<(), R
         return Err(RariError::forbidden("Referer not allowed"));
     }
 
-    tracing::error!("Missing Origin and Referer headers with non-empty allowed_origins");
+    tracing::debug!("Missing Origin and Referer headers with non-empty allowed_origins");
     Err(RariError::forbidden("Origin or referer required"))
 }
 

--- a/crates/rari/src/server/og/generator.rs
+++ b/crates/rari/src/server/og/generator.rs
@@ -21,7 +21,8 @@ use super::{
 use crate::{
     runtime::JsExecutionRuntime,
     server::{
-        cache::handler::CacheError, loader::SERVER_MANIFEST_PATH, routing::types::ParamValue,
+        cache::handler::CacheError, core::utils::component::extract_component_id,
+        loader::SERVER_MANIFEST_PATH, routing::types::ParamValue,
     },
     utils::{float, path::path_to_file_url},
 };
@@ -300,24 +301,8 @@ impl OgImageGenerator {
         route_path: &str,
         params: &FxHashMap<String, ParamValue>,
     ) -> Result<JsxElement, OgImageError> {
-        let component_id = {
-            let path = entry.file_path.as_str();
-            let path = path.cow_replace(".tsx", "");
-            let path = path.cow_replace(".ts", "");
-            let path = path.cow_replace(".jsx", "");
-            let path = path.cow_replace(".js", "");
-            let path =
-                path.chars()
-                    .map(|c| {
-                        if c.is_alphanumeric() || c == '/' || c == '-' || c == '_' {
-                            c
-                        } else {
-                            '_'
-                        }
-                    })
-                    .collect::<String>();
-            format!("app/{path}")
-        };
+        let component_id = extract_component_id(&format!("app/{}", entry.file_path))
+            .map_err(|e| OgImageError::ExecutionError(format!("Invalid OG component path: {e}")))?;
 
         let server_manifest = self.server_manifest.read().await;
         let bundle_path = server_manifest
@@ -452,6 +437,23 @@ mod tests {
     use std::env;
 
     use super::*;
+    use crate::server::core::utils::component::extract_component_id;
+
+    #[test]
+    fn test_og_component_id_matches_hashed_manifest_keys() {
+        assert_eq!(
+            extract_component_id("app/opengraph-image.tsx").unwrap(),
+            "app/opengraph-image_7c956ddc"
+        );
+        assert_eq!(
+            extract_component_id("app/docs/[...slug]/opengraph-image.tsx").unwrap(),
+            "app/docs/____slug_/opengraph-image_ef4094d1"
+        );
+        assert_eq!(
+            extract_component_id("app/blog/[slug]/opengraph-image.tsx").unwrap(),
+            "app/blog/_slug_/opengraph-image_2ade8d39"
+        );
+    }
 
     #[tokio::test]
     async fn test_find_og_image_for_static_route() {

--- a/packages/rari/src/vite/analysis/component-ids.ts
+++ b/packages/rari/src/vite/analysis/component-ids.ts
@@ -8,8 +8,6 @@ import {
   TSX_EXT_REGEX,
 } from '@/shared/regex-constants'
 
-const PATH_OUTSIDE_ROOT_REGEX = /^\.\.(?:[/\\]|$)/
-
 export function hashString(value: string, length = 8): string {
   return crypto.createHash('sha256').update(value).digest('hex').slice(0, length)
 }
@@ -20,10 +18,13 @@ export function getProjectRelativePath(filePath: string, projectRoot = process.c
     : path.resolve(projectRoot, filePath)
   const relativePath = path.relative(projectRoot, absolutePath)
 
-  return (PATH_OUTSIDE_ROOT_REGEX.test(relativePath) || path.isAbsolute(relativePath)
-    ? filePath
-    : relativePath)
-    .replace(BACKSLASH_REGEX, '/')
+  // Always prefer a path relative to the project root — including `../…` for
+  // workspace packages outside the app. Absolute paths become
+  // `dist/server/Users/...` and break runtime module resolution.
+  if (path.isAbsolute(relativePath))
+    return absolutePath.replace(BACKSLASH_REGEX, '/')
+
+  return relativePath.replace(BACKSLASH_REGEX, '/')
 }
 
 export function getReadableComponentId(projectRelativePath: string): string {

--- a/packages/rari/src/vite/server/build.ts
+++ b/packages/rari/src/vite/server/build.ts
@@ -3,6 +3,7 @@ import type { ModuleAnalysis } from '../analysis/directives'
 import type { MdxPluginOptions } from '../mdx/registry'
 import type { ServerCacheConfig, ServerCacheControlConfig, ServerCacheLayerConfig, ServerConfig, ServerCSPConfig } from './config'
 import fs from 'node:fs'
+import { createRequire } from 'node:module'
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath, pathToFileURL } from 'node:url'
@@ -36,6 +37,37 @@ const SPECIAL_FILE_REGEX = /^(?:robots|sitemap|feed)\.(?:tsx?|jsx?)$/
 const RSC_REFERENCES_IMPORT = 'react-server-dom-rari/server'
 const NODE_PROTOCOL_REGEX = /^node:/
 export const RARI_CSS_MODULES_PATTERN = '[hash]_[local]'
+
+/** Bare package name including scope (e.g. `markdown-it`, `@scope/pkg`). */
+function barePackageName(source: string): string {
+  if (source.startsWith('@')) {
+    const parts = source.split('/')
+    return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : source
+  }
+
+  return source.split('/')[0] ?? source
+}
+
+/**
+ * True when BYONM/Node would find the package by walking `node_modules` from
+ * the app root. Avoid createRequire here — pnpm bin shims set NODE_PATH, which
+ * is baked into Module.globalPaths and makes transitive workspace deps look
+ * like app installs (then incorrectly get externalized).
+ */
+function isInstalledFromAppRoot(projectRoot: string, source: string): boolean {
+  const packageName = barePackageName(source)
+  let dir = projectRoot
+  while (true) {
+    const candidate = path.join(dir, 'node_modules', ...packageName.split('/'))
+    if (fs.existsSync(path.join(candidate, 'package.json')))
+      return true
+
+    const parent = path.dirname(dir)
+    if (parent === dir)
+      return false
+    dir = parent
+  }
+}
 
 const EXTERNAL_CLIENT_COMPONENT_MANIFESTS: Array<{
   componentId: string
@@ -1067,7 +1099,7 @@ export default registerClientReference(null, ${JSON.stringify(componentId)}, "de
       } satisfies Plugin,
       {
         name: 'externalize-deps',
-        resolveId: (source: string) => {
+        resolveId: (source: string, importer: string | undefined) => {
           if (source.startsWith('\0'))
             return null
 
@@ -1100,8 +1132,30 @@ export default registerClientReference(null, ${JSON.stringify(componentId)}, "de
           if (resolveAlias(source, this.options.alias || {}, this.projectRoot))
             return null
 
-          if (!source.startsWith('.') && !source.startsWith('/'))
-            return { id: source, external: true }
+          if (!source.startsWith('.') && !source.startsWith('/')) {
+            // App-visible installs stay external for runtime BYONM. Deps that only
+            // exist under a workspace package (e.g. markdown-it in shared/) must be
+            // force-resolved and bundled — Rolldown's platform:'node' otherwise
+            // leaves them as unresolved externals.
+            if (isInstalledFromAppRoot(this.projectRoot, source))
+              return { id: source, external: true }
+
+            const resolveFrom = [
+              importer && !importer.startsWith('\0') ? importer : null,
+              inputPath,
+            ].filter((value): value is string => Boolean(value))
+
+            for (const from of resolveFrom) {
+              try {
+                return { id: createRequire(from).resolve(source) }
+              }
+              catch {
+                // try next candidate
+              }
+            }
+
+            return null
+          }
 
           return null
         },

--- a/packages/rari/src/vite/server/build.ts
+++ b/packages/rari/src/vite/server/build.ts
@@ -1150,7 +1150,13 @@ export default registerClientReference(null, ${JSON.stringify(componentId)}, "de
                 return { id: createRequire(from).resolve(source) }
               }
               catch {
-                // try next candidate
+                try {
+                  const resolved = import.meta.resolve(source, pathToFileURL(from).href)
+                  return { id: fileURLToPath(resolved) }
+                }
+                catch {
+                  // try next candidate
+                }
               }
             }
 

--- a/tools/bundle-react-esm/bundle.ts
+++ b/tools/bundle-react-esm/bundle.ts
@@ -46,10 +46,40 @@ function createReactDomShimSource(): string {
   return null
 }`).join('\n\n')
 
-  const defaultFields = REACT_DOM_CLIENT_STUBS.join(',\n  ')
+  const defaultFields = [
+    ...REACT_DOM_CLIENT_STUBS,
+    '__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE: Internals',
+  ].join(',\n  ')
 
-  return `/** Client-only APIs - safe no-ops during SSR module evaluation. */
+  // Must match react-dom.production.js Internals so Flight Hint (`H`) rows and
+  // react-dom-server can share one `.d` dispatcher. Fizz replaces `.d` with
+  // real prefetch/preconnect implementations at module init.
+  return `function noop() {}
+
+const Internals = {
+  d: {
+    f: noop,
+    r() {
+      throw new Error(
+        'The current dispatcher does not support this form action operation.',
+      )
+    },
+    D: noop,
+    C: noop,
+    L: noop,
+    m: noop,
+    X: noop,
+    S: noop,
+    M: noop,
+  },
+  p: 0,
+  findDOMNode: null,
+}
+
+/** Client-only APIs - safe no-ops during SSR module evaluation. */
 ${stubExports}
+
+export const __DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE = Internals
 
 export default {
   ${defaultFields},
@@ -141,13 +171,13 @@ const entries: BundleEntry[] = [
     name: 'react-dom-server',
     cjsFile: resolveReactCjs('react-dom', 'react-dom-server.browser'),
     namedExports: ['renderToReadableStream', 'renderToString', 'renderToStaticMarkup', 'resume', 'version'],
-    // `react` is externalized to 'ext:rari/react/vendor/react.js' so the server renderer
-    // and the client-component SSR bundles share ONE React instance. React's
-    // hook dispatcher and context state are per-instance, so this is required
-    // for real useState/useContext/createContext to work during SSR.
-    // `react-dom` stays inlined (its own require('react') is also redirected
-    // to the shared ext:rari/react/vendor/react.js by the external pattern below).
-    externals: { react: 'ext:rari/react/vendor/react.js' },
+    // Share one React + react-dom Internals instance with Flight client / SSR
+    // client components so Fizz can install Hint dispatchers on Internals.d
+    // that processFullBinaryRow (H rows) will call.
+    externals: {
+      'react': 'ext:rari/react/vendor/react.js',
+      'react-dom': 'ext:rari/react/vendor/react-dom.js',
+    },
   },
   {
     name: 'react-dom',


### PR DESCRIPTION
Stabilize module resolution (pnpm cache, app-local externals, workspace paths), restore node:console / ReactDOM Internals for Fizz, look up hashed OG component IDs, and downgrade missing Origin/Referer action rejections from ERROR spam.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Node-like `console` access in supported runtime environments.
  - Improved dependency resolution for `externalize-deps` during builds.
  - Enhanced React server-rendering compatibility for React/ReactDOM.

- **Bug Fixes**
  - Improved Open Graph component ID derivation, including dynamic catch-all routes.
  - Strengthened component ID path handling and module lookup behavior.
  - Reduced origin-check log severity from error to debug when headers are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->