### PR TITLE
feat: add dormant JS runtime pool and shared component load ops

### DIFF
--- a/crates/rari/src/runtime/factory/component_ops.rs
+++ b/crates/rari/src/runtime/factory/component_ops.rs
@@ -1,0 +1,231 @@
+use std::{
+    sync::OnceLock,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use cow_utils::CowUtils;
+use rari_error::RariError;
+use regex::Regex;
+use serde_json::Value;
+
+use super::interface::JsRuntimeInterface;
+
+fn escape_js_string(s: &str) -> String {
+    s.cow_replace('\\', "\\\\")
+        .cow_replace('"', r#"\""#)
+        .cow_replace('\n', "\\n")
+        .cow_replace('\r', "\\r")
+        .into_owned()
+}
+
+pub fn is_esm_code(code: &str) -> bool {
+    static ESM_REGEX: OnceLock<Regex> = OnceLock::new();
+    #[expect(clippy::expect_used, reason = "Infallible operation with valid inputs")]
+    let regex = ESM_REGEX
+        .get_or_init(|| Regex::new(r"(?m)^\s*export[\s{]").expect("Valid ESM detection regex"));
+
+    regex.is_match(code)
+}
+
+pub fn invalidate_script_name(component_id: &str) -> String {
+    format!("invalidate_{}", component_id.cow_replace('/', "_"))
+}
+
+pub fn build_invalidate_script(component_id: &str) -> String {
+    let escaped_component_id = escape_js_string(component_id);
+    format!(
+        r#"
+            (function() {{
+                const componentId = "{escaped_component_id}";
+                let deleted = false;
+
+                if (globalThis[componentId]) {{
+                    delete globalThis[componentId];
+                    deleted = true;
+                }}
+
+                const moduleNamespace = globalThis['~rsc']?.modules?.[componentId];
+                if (moduleNamespace) {{
+                    for (const key in moduleNamespace) {{
+                        if (key !== 'default' && typeof moduleNamespace[key] === 'function' && globalThis[key] === moduleNamespace[key]) {{
+                            delete globalThis[key];
+                            deleted = true;
+                        }}
+                    }}
+                }}
+
+                if (globalThis['~rsc']?.functions?.[componentId]) {{
+                    delete globalThis['~rsc'].functions[componentId];
+                    deleted = true;
+                }}
+
+                if (globalThis['~rari']?.ssrModules) {{
+                    const colonPrefix = componentId + ':';
+                    const hashPrefix = componentId + '#';
+                    for (const key in globalThis['~rari'].ssrModules) {{
+                        if (key === componentId || key.startsWith(colonPrefix) || key.startsWith(hashPrefix)) {{
+                            delete globalThis['~rari'].ssrModules[key];
+                            deleted = true;
+                        }}
+                    }}
+                }}
+
+                if (globalThis['~rari']?.serverManifest) {{
+                    const colonPrefix = componentId + ':';
+                    const hashPrefix = componentId + '#';
+                    for (const key in globalThis['~rari'].serverManifest) {{
+                        if (key === componentId || key.startsWith(colonPrefix) || key.startsWith(hashPrefix)) {{
+                            delete globalThis['~rari'].serverManifest[key];
+                            deleted = true;
+                        }}
+                    }}
+                }}
+
+                if (globalThis['~rari']?.registeredServerFunctions) {{
+                    const colonPrefix = componentId + ':';
+                    const hashPrefix = componentId + '#';
+                    for (const key of globalThis['~rari'].registeredServerFunctions) {{
+                        if (key === componentId || key.startsWith(colonPrefix) || key.startsWith(hashPrefix)) {{
+                            globalThis['~rari'].registeredServerFunctions.delete(key);
+                            deleted = true;
+                        }}
+                    }}
+                }}
+
+                if (globalThis['~rsc']?.modules?.[componentId]) {{
+                    delete globalThis['~rsc'].modules[componentId];
+                    deleted = true;
+                }}
+
+                if (globalThis.RscModuleManager && globalThis.RscModuleManager.unregister) {{
+                    try {{
+                        globalThis.RscModuleManager.unregister(componentId);
+                        deleted = true;
+                    }} catch (e) {{
+                        console.warn('Failed to unregister from RscModuleManager:', e);
+                    }}
+                }}
+
+                return {{ success: true, deleted: deleted }};
+            }})()
+            "#
+    )
+}
+
+pub async fn load_component_code(
+    runtime: &dyn JsRuntimeInterface,
+    component_id: &str,
+    component_code: &str,
+) -> Result<(), RariError> {
+    let is_esm = is_esm_code(component_code);
+
+    if is_esm {
+        let timestamp =
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis();
+
+        let hmr_specifier = format!("file:///rari_hmr/server/{component_id}.js?v={timestamp}");
+
+        if let Err(e) = runtime.clear_module_loader_caches(component_id).await {
+            tracing::warn!("Failed to clear module loader caches for {}: {}", component_id, e);
+        }
+
+        runtime.add_module_to_loader(&hmr_specifier, component_code.to_string()).await.map_err(
+            |e| {
+                let error_msg =
+                    format!("Failed to add component module to loader for {component_id}: {e}");
+                tracing::error!("{}", error_msg);
+                RariError::js_execution(error_msg)
+            },
+        )?;
+
+        let module_id = runtime.load_es_module(component_id).await.map_err(|e| {
+            let error_msg = format!("Failed to load ES module for {component_id}: {e}");
+            tracing::error!("{}", error_msg);
+            RariError::js_execution(error_msg)
+        })?;
+
+        runtime.evaluate_module(module_id).await.map_err(|e| {
+            let error_msg = format!("Failed to evaluate ES module for {component_id}: {e}");
+            tracing::error!("{}", error_msg);
+            RariError::js_execution(error_msg)
+        })?;
+
+        let escaped_component_id = escape_js_string(component_id);
+        let escaped_hmr_specifier = escape_js_string(&hmr_specifier);
+
+        let registration_script = format!(
+            r#"(async function() {{
+                    try {{
+                        const moduleNamespace = await import("{escaped_hmr_specifier}");
+                        const componentId = "{escaped_component_id}";
+
+                        if (!globalThis['~rsc']) globalThis['~rsc'] = {{}};
+                        if (!globalThis['~rsc'].modules) globalThis['~rsc'].modules = {{}};
+                        if (!globalThis['~rsc'].functions) globalThis['~rsc'].functions = {{}};
+
+                        globalThis['~rsc'].modules[componentId] = moduleNamespace;
+
+                        if (moduleNamespace.default) {{
+                            globalThis[componentId] = moduleNamespace.default;
+                        }} else {{
+                            const exports = Object.values(moduleNamespace).filter(v => typeof v === 'function');
+                            if (exports.length > 0) {{
+                                globalThis[componentId] = exports[0];
+                            }}
+                        }}
+
+                        const namedExports = {{}};
+                        for (const [key, value] of Object.entries(moduleNamespace)) {{
+                            if (key !== 'default' && typeof value === 'function') {{
+                                namedExports[key] = value;
+                            }}
+                        }}
+
+                        if (Object.keys(namedExports).length > 0) {{
+                            globalThis['~rsc'].functions[componentId] = namedExports;
+                        }}
+
+                        return {{ success: true }};
+                    }} catch (error) {{
+                        console.error('[rari] Failed to register component {escaped_component_id}:', error);
+                        return {{ success: false, error: error.message }};
+                    }}
+                }})()"#
+        );
+
+        let result = runtime
+            .execute_script(
+                format!("register_component_{}.js", component_id.cow_replace('/', "_")),
+                registration_script,
+            )
+            .await
+            .map_err(|e| {
+                let error_msg =
+                    format!("Failed to register component {component_id} to globalThis: {e}");
+                tracing::error!("{}", error_msg);
+                RariError::js_execution(error_msg)
+            })?;
+
+        let success = result.get("success").and_then(Value::as_bool).unwrap_or(false);
+
+        if !success {
+            let error_msg = result.get("error").and_then(|v| v.as_str()).unwrap_or("Unknown error");
+            tracing::error!("Component registration failed for {}: {}", component_id, error_msg);
+            return Err(RariError::js_execution(format!(
+                "Component registration failed for {component_id}: {error_msg}"
+            )));
+        }
+
+        Ok(())
+    } else {
+        let script_name = format!("load_component_{}", component_id.cow_replace('/', "_"));
+        match runtime.execute_script(script_name, component_code.to_string()).await {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                let error_msg = format!("Failed to execute component code for {component_id}: {e}");
+                tracing::error!("{}", error_msg);
+                Err(RariError::js_execution(error_msg))
+            }
+        }
+    }
+}

--- a/crates/rari/src/runtime/factory/component_ops.rs
+++ b/crates/rari/src/runtime/factory/component_ops.rs
@@ -307,14 +307,14 @@ async fn load_esm_component_code_atomic(
     if let Err(e) = runtime.clear_module_loader_caches(component_id).await {
         tracing::warn!("Failed to clear module loader caches for {}: {}", component_id, e);
     }
-    runtime.add_module_to_loader(&live_specifier, component_code.to_string()).await.map_err(
-        |e| {
-            let error_msg =
-                format!("Failed to promote live component module for {component_id}: {e}");
-            tracing::error!("{}", error_msg);
-            RariError::js_execution(error_msg)
-        },
-    )?;
+    if let Err(e) = runtime.add_module_to_loader(&live_specifier, component_code.to_string()).await
+    {
+        tracing::warn!(
+            "Failed to promote live component module for {} after successful swap: {}",
+            component_id,
+            e
+        );
+    }
 
     Ok(())
 }

--- a/crates/rari/src/runtime/factory/component_ops.rs
+++ b/crates/rari/src/runtime/factory/component_ops.rs
@@ -31,6 +31,10 @@ pub fn invalidate_script_name(component_id: &str) -> String {
     format!("invalidate_{}", component_id.cow_replace('/', "_"))
 }
 
+pub fn pending_component_id(component_id: &str) -> String {
+    format!("__rari_hmr_pending__:{component_id}")
+}
+
 pub fn build_invalidate_script(component_id: &str) -> String {
     let escaped_component_id = escape_js_string(component_id);
     format!(
@@ -112,65 +116,25 @@ pub fn build_invalidate_script(component_id: &str) -> String {
     )
 }
 
-pub async fn load_component_code(
-    runtime: &dyn JsRuntimeInterface,
-    component_id: &str,
-    component_code: &str,
-) -> Result<(), RariError> {
-    let is_esm = is_esm_code(component_code);
-
-    if is_esm {
-        let timestamp =
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis();
-
-        let hmr_specifier = format!("file:///rari_hmr/server/{component_id}.js?v={timestamp}");
-
-        if let Err(e) = runtime.clear_module_loader_caches(component_id).await {
-            tracing::warn!("Failed to clear module loader caches for {}: {}", component_id, e);
-        }
-
-        runtime.add_module_to_loader(&hmr_specifier, component_code.to_string()).await.map_err(
-            |e| {
-                let error_msg =
-                    format!("Failed to add component module to loader for {component_id}: {e}");
-                tracing::error!("{}", error_msg);
-                RariError::js_execution(error_msg)
-            },
-        )?;
-
-        let module_id = runtime.load_es_module(component_id).await.map_err(|e| {
-            let error_msg = format!("Failed to load ES module for {component_id}: {e}");
-            tracing::error!("{}", error_msg);
-            RariError::js_execution(error_msg)
-        })?;
-
-        runtime.evaluate_module(module_id).await.map_err(|e| {
-            let error_msg = format!("Failed to evaluate ES module for {component_id}: {e}");
-            tracing::error!("{}", error_msg);
-            RariError::js_execution(error_msg)
-        })?;
-
-        let escaped_component_id = escape_js_string(component_id);
-        let escaped_hmr_specifier = escape_js_string(&hmr_specifier);
-
-        let registration_script = format!(
-            r#"(async function() {{
+fn build_pending_registration_script(component_id: &str, hmr_specifier: &str) -> String {
+    let escaped_component_id = escape_js_string(component_id);
+    let escaped_hmr_specifier = escape_js_string(hmr_specifier);
+    format!(
+        r#"(async function() {{
+                    const componentId = "{escaped_component_id}";
                     try {{
                         const moduleNamespace = await import("{escaped_hmr_specifier}");
-                        const componentId = "{escaped_component_id}";
 
                         if (!globalThis['~rsc']) globalThis['~rsc'] = {{}};
-                        if (!globalThis['~rsc'].modules) globalThis['~rsc'].modules = {{}};
-                        if (!globalThis['~rsc'].functions) globalThis['~rsc'].functions = {{}};
+                        if (!globalThis['~rsc'].hmrPending) globalThis['~rsc'].hmrPending = {{}};
 
-                        globalThis['~rsc'].modules[componentId] = moduleNamespace;
-
+                        let defaultExport = null;
                         if (moduleNamespace.default) {{
-                            globalThis[componentId] = moduleNamespace.default;
+                            defaultExport = moduleNamespace.default;
                         }} else {{
                             const exports = Object.values(moduleNamespace).filter(v => typeof v === 'function');
                             if (exports.length > 0) {{
-                                globalThis[componentId] = exports[0];
+                                defaultExport = exports[0];
                             }}
                         }}
 
@@ -181,51 +145,196 @@ pub async fn load_component_code(
                             }}
                         }}
 
-                        if (Object.keys(namedExports).length > 0) {{
-                            globalThis['~rsc'].functions[componentId] = namedExports;
-                        }}
+                        globalThis['~rsc'].hmrPending[componentId] = {{
+                            moduleNamespace,
+                            defaultExport,
+                            namedExports,
+                        }};
 
-                        return {{ success: true }};
+                        return {{ success: true, hasDefault: defaultExport != null }};
                     }} catch (error) {{
-                        console.error('[rari] Failed to register component {escaped_component_id}:', error);
+                        console.error('[rari] Failed to stage pending component ' + componentId + ':', error);
                         return {{ success: false, error: error.message }};
                     }}
                 }})()"#
-        );
+    )
+}
 
-        let result = runtime
-            .execute_script(
-                format!("register_component_{}.js", component_id.cow_replace('/', "_")),
-                registration_script,
-            )
-            .await
-            .map_err(|e| {
-                let error_msg =
-                    format!("Failed to register component {component_id} to globalThis: {e}");
-                tracing::error!("{}", error_msg);
-                RariError::js_execution(error_msg)
-            })?;
+fn build_atomic_swap_script(component_id: &str) -> String {
+    let escaped_component_id = escape_js_string(component_id);
+    format!(
+        r#"(function() {{
+                    const componentId = "{escaped_component_id}";
+                    const pending = globalThis['~rsc']?.hmrPending?.[componentId];
+                    if (!pending) {{
+                        return {{ success: false, error: 'No pending HMR payload for ' + componentId }};
+                    }}
 
-        let success = result.get("success").and_then(Value::as_bool).unwrap_or(false);
+                    if (!globalThis['~rsc']) globalThis['~rsc'] = {{}};
+                    if (!globalThis['~rsc'].modules) globalThis['~rsc'].modules = {{}};
+                    if (!globalThis['~rsc'].functions) globalThis['~rsc'].functions = {{}};
 
-        if !success {
-            let error_msg = result.get("error").and_then(|v| v.as_str()).unwrap_or("Unknown error");
-            tracing::error!("Component registration failed for {}: {}", component_id, error_msg);
-            return Err(RariError::js_execution(format!(
-                "Component registration failed for {component_id}: {error_msg}"
-            )));
+                    globalThis['~rsc'].modules[componentId] = pending.moduleNamespace;
+                    if (pending.defaultExport) {{
+                        globalThis[componentId] = pending.defaultExport;
+                    }}
+                    if (pending.namedExports && Object.keys(pending.namedExports).length > 0) {{
+                        globalThis['~rsc'].functions[componentId] = pending.namedExports;
+                    }} else {{
+                        delete globalThis['~rsc'].functions[componentId];
+                    }}
+
+                    delete globalThis['~rsc'].hmrPending[componentId];
+                    return {{
+                        success: typeof globalThis[componentId] !== 'undefined',
+                        componentId,
+                    }};
+                }})()"#
+    )
+}
+
+fn build_discard_pending_script(component_id: &str) -> String {
+    let escaped_component_id = escape_js_string(component_id);
+    format!(
+        r#"(function() {{
+                    const componentId = "{escaped_component_id}";
+                    if (globalThis['~rsc']?.hmrPending?.[componentId]) {{
+                        delete globalThis['~rsc'].hmrPending[componentId];
+                    }}
+                    return {{ success: true }};
+                }})()"#
+    )
+}
+
+async fn discard_pending_component(
+    runtime: &dyn JsRuntimeInterface,
+    component_id: &str,
+) -> Result<(), RariError> {
+    let _ = runtime
+        .execute_script(
+            format!("discard_pending_{}.js", component_id.cow_replace('/', "_")),
+            build_discard_pending_script(component_id),
+        )
+        .await;
+    Ok(())
+}
+
+async fn load_esm_component_code_atomic(
+    runtime: &dyn JsRuntimeInterface,
+    component_id: &str,
+    component_code: &str,
+) -> Result<(), RariError> {
+    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis();
+
+    let pending_specifier = format!("file:///rari_hmr/pending/{component_id}.js?v={timestamp}");
+    let live_specifier = format!("file:///rari_hmr/server/{component_id}.js?v={timestamp}");
+    let pending_id = pending_component_id(component_id);
+
+    runtime.add_module_to_loader(&pending_specifier, component_code.to_string()).await.map_err(
+        |e| {
+            let error_msg =
+                format!("Failed to add pending component module for {component_id}: {e}");
+            tracing::error!("{}", error_msg);
+            RariError::js_execution(error_msg)
+        },
+    )?;
+
+    let module_id = runtime.load_es_module(&pending_id).await.map_err(|e| {
+        let error_msg = format!("Failed to load pending ES module for {component_id}: {e}");
+        tracing::error!("{}", error_msg);
+        RariError::js_execution(error_msg)
+    })?;
+
+    if let Err(e) = runtime.evaluate_module(module_id).await {
+        let _ = discard_pending_component(runtime, component_id).await;
+        let error_msg = format!("Failed to evaluate pending ES module for {component_id}: {e}");
+        tracing::error!("{}", error_msg);
+        return Err(RariError::js_execution(error_msg));
+    }
+
+    let stage_result = match runtime
+        .execute_script(
+            format!("stage_pending_{}.js", component_id.cow_replace('/', "_")),
+            build_pending_registration_script(component_id, &pending_specifier),
+        )
+        .await
+    {
+        Ok(json) => json,
+        Err(e) => {
+            let _ = discard_pending_component(runtime, component_id).await;
+            let error_msg =
+                format!("Failed to stage pending component {component_id} to globalThis: {e}");
+            tracing::error!("{}", error_msg);
+            return Err(RariError::js_execution(error_msg));
         }
+    };
 
-        Ok(())
-    } else {
-        let script_name = format!("load_component_{}", component_id.cow_replace('/', "_"));
-        match runtime.execute_script(script_name, component_code.to_string()).await {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                let error_msg = format!("Failed to execute component code for {component_id}: {e}");
-                tracing::error!("{}", error_msg);
-                Err(RariError::js_execution(error_msg))
-            }
+    if !stage_result.get("success").and_then(Value::as_bool).unwrap_or(false) {
+        let _ = discard_pending_component(runtime, component_id).await;
+        let error_msg =
+            stage_result.get("error").and_then(|v| v.as_str()).unwrap_or("Unknown error");
+        tracing::error!("Pending component staging failed for {}: {}", component_id, error_msg);
+        return Err(RariError::js_execution(format!(
+            "Pending component staging failed for {component_id}: {error_msg}"
+        )));
+    }
+
+    let swap_result = match runtime
+        .execute_script(
+            format!("swap_component_{}.js", component_id.cow_replace('/', "_")),
+            build_atomic_swap_script(component_id),
+        )
+        .await
+    {
+        Ok(json) => json,
+        Err(e) => {
+            let _ = discard_pending_component(runtime, component_id).await;
+            let error_msg = format!("Failed to atomically swap component {component_id}: {e}");
+            tracing::error!("{}", error_msg);
+            return Err(RariError::js_execution(error_msg));
+        }
+    };
+
+    if !swap_result.get("success").and_then(Value::as_bool).unwrap_or(false) {
+        let _ = discard_pending_component(runtime, component_id).await;
+        let error_msg =
+            swap_result.get("error").and_then(|v| v.as_str()).unwrap_or("Unknown error");
+        return Err(RariError::js_execution(format!(
+            "Atomic component swap failed for {component_id}: {error_msg}"
+        )));
+    }
+
+    if let Err(e) = runtime.clear_module_loader_caches(component_id).await {
+        tracing::warn!("Failed to clear module loader caches for {}: {}", component_id, e);
+    }
+    runtime.add_module_to_loader(&live_specifier, component_code.to_string()).await.map_err(
+        |e| {
+            let error_msg =
+                format!("Failed to promote live component module for {component_id}: {e}");
+            tracing::error!("{}", error_msg);
+            RariError::js_execution(error_msg)
+        },
+    )?;
+
+    Ok(())
+}
+
+pub async fn load_component_code(
+    runtime: &dyn JsRuntimeInterface,
+    component_id: &str,
+    component_code: &str,
+) -> Result<(), RariError> {
+    if is_esm_code(component_code) {
+        return load_esm_component_code_atomic(runtime, component_id, component_code).await;
+    }
+
+    let script_name = format!("load_component_{}", component_id.cow_replace('/', "_"));
+    match runtime.execute_script(script_name, component_code.to_string()).await {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            let error_msg = format!("Failed to execute component code for {component_id}: {e}");
+            tracing::error!("{}", error_msg);
+            Err(RariError::js_execution(error_msg))
         }
     }
 }

--- a/crates/rari/src/runtime/factory/mod.rs
+++ b/crates/rari/src/runtime/factory/mod.rs
@@ -1,6 +1,8 @@
+pub(crate) mod component_ops;
 mod create_params;
 mod executor;
 mod interface;
+pub mod pool;
 mod runtime;
 mod runtime_builder;
 pub(crate) mod utils;

--- a/crates/rari/src/runtime/factory/pool/broadcast.rs
+++ b/crates/rari/src/runtime/factory/pool/broadcast.rs
@@ -16,6 +16,18 @@ use super::{
 
 type DynRuntime = Arc<dyn JsRuntimeInterface>;
 
+fn default_slot_error(idx: usize, err: &RariError) -> String {
+    format!("runtime[{idx}]: {err}")
+}
+
+fn default_aggregate_error(label: &str, total: usize, errors: &[String]) -> RariError {
+    RariError::js_runtime(format!(
+        "{label} on {} of {total} runtimes: {}",
+        errors.len(),
+        errors.join("; ")
+    ))
+}
+
 impl JsRuntimePool {
     async fn broadcast_to_healthy<F, Fut, T, FormatError, MakeAggregateError>(
         &self,
@@ -81,13 +93,13 @@ impl JsRuntimePool {
         let script_name = invalidate_script_name(component_id);
         let component_id_msg = component_id.to_string();
         self.broadcast_to_healthy(
-            |idx, err: &RariError| format!("runtime[{idx}]: {err}"),
+            default_slot_error,
             |total, errors: &[String]| {
-                RariError::js_runtime(format!(
-                    "Failed to invalidate component {component_id_msg} on {} of {total} runtimes: {}",
-                    errors.len(),
-                    errors.join("; ")
-                ))
+                default_aggregate_error(
+                    &format!("Failed to invalidate component {component_id_msg}"),
+                    total,
+                    errors,
+                )
             },
             |_idx, runtime: DynRuntime| {
                 let script_name_local = script_name.clone();
@@ -107,13 +119,13 @@ impl JsRuntimePool {
         let component_id_op = component_id.to_string();
         let code = code.to_string();
         self.broadcast_to_healthy(
-            |idx, err: &RariError| format!("runtime[{idx}]: {err}"),
+            default_slot_error,
             |total, errors: &[String]| {
-                RariError::js_runtime(format!(
-                    "Failed to load component code for {component_id_msg} on {} of {total} runtimes: {}",
-                    errors.len(),
-                    errors.join("; ")
-                ))
+                default_aggregate_error(
+                    &format!("Failed to load component code for {component_id_msg}"),
+                    total,
+                    errors,
+                )
             },
             |_idx, runtime: DynRuntime| {
                 let component_id_local = component_id_op.clone();
@@ -135,13 +147,13 @@ impl JsRuntimePool {
         let script_name_op = script_name.to_string();
         let script_code = script_code.to_string();
         self.broadcast_to_healthy(
-            |idx, err: &RariError| format!("runtime[{idx}]: {err}"),
+            default_slot_error,
             |total, errors: &[String]| {
-                RariError::js_runtime(format!(
-                    "Failed to broadcast script {script_name_msg} on {} of {total} runtimes: {}",
-                    errors.len(),
-                    errors.join("; ")
-                ))
+                default_aggregate_error(
+                    &format!("Failed to broadcast script {script_name_msg}"),
+                    total,
+                    errors,
+                )
             },
             |_idx, runtime: DynRuntime| {
                 let name_local = script_name_op.clone();
@@ -160,13 +172,9 @@ impl JsRuntimePool {
         let specifier = specifier.to_string();
         let code = code.to_string();
         self.broadcast_to_healthy(
-            |idx, err: &RariError| format!("runtime[{idx}]: {err}"),
+            default_slot_error,
             |total, errors: &[String]| {
-                RariError::js_runtime(format!(
-                    "Failed to broadcast add_module_to_loader on {} of {total} runtimes: {}",
-                    errors.len(),
-                    errors.join("; ")
-                ))
+                default_aggregate_error("Failed to broadcast add_module_to_loader", total, errors)
             },
             |_idx, runtime: DynRuntime| {
                 let specifier_local = specifier.clone();
@@ -213,13 +221,15 @@ impl JsRuntimePool {
         let component_id_msg = component_id.to_string();
         let component_id_op = component_id.to_string();
         self.broadcast_to_healthy(
-            |idx, err: &RariError| format!("runtime[{idx}]: {err}"),
+            default_slot_error,
             |total, errors: &[String]| {
-                RariError::js_runtime(format!(
-                    "Failed to broadcast clear_module_loader_caches for {component_id_msg} on {} of {total} runtimes: {}",
-                    errors.len(),
-                    errors.join("; ")
-                ))
+                default_aggregate_error(
+                    &format!(
+                        "Failed to broadcast clear_module_loader_caches for {component_id_msg}"
+                    ),
+                    total,
+                    errors,
+                )
             },
             |_idx, runtime: DynRuntime| {
                 let component_id_local = component_id_op.clone();

--- a/crates/rari/src/runtime/factory/pool/broadcast.rs
+++ b/crates/rari/src/runtime/factory/pool/broadcast.rs
@@ -55,8 +55,13 @@ impl JsRuntimePool {
             let Some(runtime) = self.runtime_at(idx) else {
                 continue;
             };
-            let fut = op(idx, runtime);
+            let pool = self;
+            let fut = op(idx, Arc::clone(&runtime));
             slot_futs.push(async move {
+                let _lease = match pool.acquire_slot_lease(idx).await {
+                    Ok(guard) => guard,
+                    Err(e) => return Err((idx, e)),
+                };
                 match time::timeout(Duration::from_millis(timeout_ms), fut).await {
                     Ok(Ok(_)) => Ok(()),
                     Ok(Err(e)) => Err((idx, e)),

--- a/crates/rari/src/runtime/factory/pool/broadcast.rs
+++ b/crates/rari/src/runtime/factory/pool/broadcast.rs
@@ -65,7 +65,10 @@ impl JsRuntimePool {
                 };
                 match time::timeout(Duration::from_millis(timeout_ms), fut).await {
                     Ok(Ok(_)) => Ok(()),
-                    Ok(Err(e)) => Err((idx, e)),
+                    Ok(Err(e)) => {
+                        pool.mark_unhealthy_if_runtime_matches(idx, &expected);
+                        Err((idx, e))
+                    }
                     Err(_) => {
                         pool.mark_unhealthy_if_runtime_matches(idx, &expected);
                         Err((idx, RariError::timeout(format!("timed out after {timeout_ms} ms"))))
@@ -85,13 +88,7 @@ impl JsRuntimePool {
         for result in join_all(slot_futs).await {
             match result {
                 Ok(()) => {}
-                Err((idx, e)) => {
-                    let msg = e.to_string();
-                    if !msg.contains("no longer admissible") && !msg.contains("timed out") {
-                        self.mark_unhealthy(idx);
-                    }
-                    errors.push(format_error(idx, &e));
-                }
+                Err((idx, e)) => errors.push(format_error(idx, &e)),
             }
         }
 

--- a/crates/rari/src/runtime/factory/pool/broadcast.rs
+++ b/crates/rari/src/runtime/factory/pool/broadcast.rs
@@ -1,10 +1,13 @@
 use std::{
     future::Future,
     sync::{Arc, atomic::Ordering},
+    time::Duration,
 };
 
 use component_ops::{build_invalidate_script, invalidate_script_name, load_component_code};
+use futures::future::join_all;
 use rari_error::RariError;
+use tokio::time;
 
 use super::{
     super::{component_ops, interface::JsRuntimeInterface},
@@ -16,46 +19,61 @@ type DynRuntime = Arc<dyn JsRuntimeInterface>;
 impl JsRuntimePool {
     async fn broadcast_to_healthy<F, Fut, T, FormatError, MakeAggregateError>(
         &self,
-        label: &str,
-        mut format_error: FormatError,
+        format_error: FormatError,
         make_aggregate_error: MakeAggregateError,
-        mut op: F,
+        op: F,
     ) -> Result<(), RariError>
     where
-        F: FnMut(usize, DynRuntime) -> Fut,
+        F: Fn(usize, DynRuntime) -> Fut,
         Fut: Future<Output = Result<T, RariError>>,
-        FormatError: FnMut(usize, &RariError) -> String,
+        FormatError: Fn(usize, &RariError) -> String,
         MakeAggregateError: FnOnce(usize, &[String]) -> RariError,
     {
-        self.run_with_timeout(label, async {
-            self.heal_expired();
+        self.probe_and_heal().await;
 
-            let healthy_snapshot: Vec<bool> =
-                self.healthy.iter().map(|h| h.load(Ordering::Acquire)).collect();
-            let mut errors: Vec<String> = Vec::new();
-            let mut executed: usize = 0;
-            for (idx, runtime) in self.runtimes.iter().cloned().enumerate() {
-                if !healthy_snapshot[idx] {
-                    continue;
-                }
-                executed += 1;
-                match op(idx, runtime).await {
-                    Ok(_) => {}
-                    Err(e) => {
-                        self.mark_unhealthy(idx);
-                        errors.push(format_error(idx, &e));
+        let healthy_snapshot: Vec<bool> =
+            self.healthy.iter().map(|h| h.load(Ordering::Acquire)).collect();
+        let timeout_ms = self.timeout_ms;
+
+        let mut slot_futs = Vec::new();
+        for (idx, healthy) in healthy_snapshot.iter().enumerate() {
+            if !healthy {
+                continue;
+            }
+            let Some(runtime) = self.runtime_at(idx) else {
+                continue;
+            };
+            let fut = op(idx, runtime);
+            slot_futs.push(async move {
+                match time::timeout(Duration::from_millis(timeout_ms), fut).await {
+                    Ok(Ok(_)) => Ok(()),
+                    Ok(Err(e)) => Err((idx, e)),
+                    Err(_) => {
+                        Err((idx, RariError::timeout(format!("timed out after {timeout_ms} ms"))))
                     }
                 }
+            });
+        }
+
+        let executed = slot_futs.len();
+        if executed == 0 {
+            return Err(RariError::js_runtime(
+                "No healthy JS runtime available in pool".to_string(),
+            ));
+        }
+
+        let mut errors: Vec<String> = Vec::new();
+        for result in join_all(slot_futs).await {
+            match result {
+                Ok(()) => {}
+                Err((idx, e)) => {
+                    self.mark_unhealthy(idx);
+                    errors.push(format_error(idx, &e));
+                }
             }
-            if executed == 0 {
-                Err(RariError::js_runtime("No healthy JS runtime available in pool".to_string()))
-            } else if errors.is_empty() {
-                Ok(())
-            } else {
-                Err(make_aggregate_error(executed, &errors))
-            }
-        })
-        .await
+        }
+
+        if errors.is_empty() { Ok(()) } else { Err(make_aggregate_error(executed, &errors)) }
     }
 
     pub async fn invalidate_component_all(&self, component_id: &str) -> Result<(), RariError> {
@@ -63,7 +81,6 @@ impl JsRuntimePool {
         let script_name = invalidate_script_name(component_id);
         let component_id_msg = component_id.to_string();
         self.broadcast_to_healthy(
-            "invalidate_component_all",
             |idx, err: &RariError| format!("runtime[{idx}]: {err}"),
             |total, errors: &[String]| {
                 RariError::js_runtime(format!(
@@ -90,7 +107,6 @@ impl JsRuntimePool {
         let component_id_op = component_id.to_string();
         let code = code.to_string();
         self.broadcast_to_healthy(
-            "load_component_code_all",
             |idx, err: &RariError| format!("runtime[{idx}]: {err}"),
             |total, errors: &[String]| {
                 RariError::js_runtime(format!(
@@ -119,7 +135,6 @@ impl JsRuntimePool {
         let script_name_op = script_name.to_string();
         let script_code = script_code.to_string();
         self.broadcast_to_healthy(
-            "broadcast_script",
             |idx, err: &RariError| format!("runtime[{idx}]: {err}"),
             |total, errors: &[String]| {
                 RariError::js_runtime(format!(
@@ -145,7 +160,6 @@ impl JsRuntimePool {
         let specifier = specifier.to_string();
         let code = code.to_string();
         self.broadcast_to_healthy(
-            "broadcast_add_module_to_loader",
             |idx, err: &RariError| format!("runtime[{idx}]: {err}"),
             |total, errors: &[String]| {
                 RariError::js_runtime(format!(
@@ -169,7 +183,6 @@ impl JsRuntimePool {
     ) -> Result<(), RariError> {
         let specifier = specifier.to_string();
         self.broadcast_to_healthy(
-            "broadcast_load_and_evaluate_module",
             |_idx, err: &RariError| err.to_string(),
             |total, errors: &[String]| {
                 RariError::js_runtime(format!(
@@ -200,7 +213,6 @@ impl JsRuntimePool {
         let component_id_msg = component_id.to_string();
         let component_id_op = component_id.to_string();
         self.broadcast_to_healthy(
-            "broadcast_clear_module_loader_caches",
             |idx, err: &RariError| format!("runtime[{idx}]: {err}"),
             |total, errors: &[String]| {
                 RariError::js_runtime(format!(

--- a/crates/rari/src/runtime/factory/pool/broadcast.rs
+++ b/crates/rari/src/runtime/factory/pool/broadcast.rs
@@ -1,0 +1,219 @@
+use std::{
+    future::Future,
+    sync::{Arc, atomic::Ordering},
+};
+
+use component_ops::{build_invalidate_script, invalidate_script_name, load_component_code};
+use rari_error::RariError;
+
+use super::{
+    super::{component_ops, interface::JsRuntimeInterface},
+    JsRuntimePool,
+};
+
+type DynRuntime = Arc<dyn JsRuntimeInterface>;
+
+impl JsRuntimePool {
+    async fn broadcast_to_healthy<F, Fut, T, FormatError, MakeAggregateError>(
+        &self,
+        label: &str,
+        mut format_error: FormatError,
+        make_aggregate_error: MakeAggregateError,
+        mut op: F,
+    ) -> Result<(), RariError>
+    where
+        F: FnMut(usize, DynRuntime) -> Fut,
+        Fut: Future<Output = Result<T, RariError>>,
+        FormatError: FnMut(usize, &RariError) -> String,
+        MakeAggregateError: FnOnce(usize, &[String]) -> RariError,
+    {
+        self.run_with_timeout(label, async {
+            self.heal_expired();
+
+            let healthy_snapshot: Vec<bool> =
+                self.healthy.iter().map(|h| h.load(Ordering::Acquire)).collect();
+            let mut errors: Vec<String> = Vec::new();
+            let mut executed: usize = 0;
+            for (idx, runtime) in self.runtimes.iter().cloned().enumerate() {
+                if !healthy_snapshot[idx] {
+                    continue;
+                }
+                executed += 1;
+                match op(idx, runtime).await {
+                    Ok(_) => {}
+                    Err(e) => {
+                        self.mark_unhealthy(idx);
+                        errors.push(format_error(idx, &e));
+                    }
+                }
+            }
+            if executed == 0 {
+                Err(RariError::js_runtime("No healthy JS runtime available in pool".to_string()))
+            } else if errors.is_empty() {
+                Ok(())
+            } else {
+                Err(make_aggregate_error(executed, &errors))
+            }
+        })
+        .await
+    }
+
+    pub async fn invalidate_component_all(&self, component_id: &str) -> Result<(), RariError> {
+        let script = build_invalidate_script(component_id);
+        let script_name = invalidate_script_name(component_id);
+        let component_id_msg = component_id.to_string();
+        self.broadcast_to_healthy(
+            "invalidate_component_all",
+            |idx, err: &RariError| format!("runtime[{idx}]: {err}"),
+            |total, errors: &[String]| {
+                RariError::js_runtime(format!(
+                    "Failed to invalidate component {component_id_msg} on {} of {total} runtimes: {}",
+                    errors.len(),
+                    errors.join("; ")
+                ))
+            },
+            |_idx, runtime: DynRuntime| {
+                let script_name_local = script_name.clone();
+                let script_local = script.clone();
+                async move { runtime.execute_script(script_name_local, script_local).await }
+            },
+        )
+        .await
+    }
+
+    pub async fn load_component_code_all(
+        &self,
+        component_id: &str,
+        code: &str,
+    ) -> Result<(), RariError> {
+        let component_id_msg = component_id.to_string();
+        let component_id_op = component_id.to_string();
+        let code = code.to_string();
+        self.broadcast_to_healthy(
+            "load_component_code_all",
+            |idx, err: &RariError| format!("runtime[{idx}]: {err}"),
+            |total, errors: &[String]| {
+                RariError::js_runtime(format!(
+                    "Failed to load component code for {component_id_msg} on {} of {total} runtimes: {}",
+                    errors.len(),
+                    errors.join("; ")
+                ))
+            },
+            |_idx, runtime: DynRuntime| {
+                let component_id_local = component_id_op.clone();
+                let code_local = code.clone();
+                async move {
+                    load_component_code(runtime.as_ref(), &component_id_local, &code_local).await
+                }
+            },
+        )
+        .await
+    }
+
+    pub async fn broadcast_script(
+        &self,
+        script_name: &str,
+        script_code: &str,
+    ) -> Result<(), RariError> {
+        let script_name_msg = script_name.to_string();
+        let script_name_op = script_name.to_string();
+        let script_code = script_code.to_string();
+        self.broadcast_to_healthy(
+            "broadcast_script",
+            |idx, err: &RariError| format!("runtime[{idx}]: {err}"),
+            |total, errors: &[String]| {
+                RariError::js_runtime(format!(
+                    "Failed to broadcast script {script_name_msg} on {} of {total} runtimes: {}",
+                    errors.len(),
+                    errors.join("; ")
+                ))
+            },
+            |_idx, runtime: DynRuntime| {
+                let name_local = script_name_op.clone();
+                let code_local = script_code.clone();
+                async move { runtime.execute_script(name_local, code_local).await }
+            },
+        )
+        .await
+    }
+
+    pub async fn broadcast_add_module_to_loader(
+        &self,
+        specifier: &str,
+        code: &str,
+    ) -> Result<(), RariError> {
+        let specifier = specifier.to_string();
+        let code = code.to_string();
+        self.broadcast_to_healthy(
+            "broadcast_add_module_to_loader",
+            |idx, err: &RariError| format!("runtime[{idx}]: {err}"),
+            |total, errors: &[String]| {
+                RariError::js_runtime(format!(
+                    "Failed to broadcast add_module_to_loader on {} of {total} runtimes: {}",
+                    errors.len(),
+                    errors.join("; ")
+                ))
+            },
+            |_idx, runtime: DynRuntime| {
+                let specifier_local = specifier.clone();
+                let code_local = code.clone();
+                async move { runtime.add_module_to_loader(&specifier_local, code_local).await }
+            },
+        )
+        .await
+    }
+
+    pub async fn broadcast_load_and_evaluate_module(
+        &self,
+        specifier: &str,
+    ) -> Result<(), RariError> {
+        let specifier = specifier.to_string();
+        self.broadcast_to_healthy(
+            "broadcast_load_and_evaluate_module",
+            |_idx, err: &RariError| err.to_string(),
+            |total, errors: &[String]| {
+                RariError::js_runtime(format!(
+                    "Failed to broadcast load+evaluate module {specifier} on {} of {total} runtimes: {}",
+                    errors.len(),
+                    errors.join("; ")
+                ))
+            },
+            |idx, runtime: DynRuntime| {
+                let specifier_local = specifier.clone();
+                async move {
+                    let module_id = runtime.load_es_module(&specifier_local).await.map_err(|e| {
+                        RariError::js_execution(format!("runtime[{idx}].load_es_module: {e}"))
+                    })?;
+                    runtime.evaluate_module(module_id).await.map_err(|e| {
+                        RariError::js_execution(format!("runtime[{idx}].evaluate_module: {e}"))
+                    })
+                }
+            },
+        )
+        .await
+    }
+
+    pub async fn broadcast_clear_module_loader_caches(
+        &self,
+        component_id: &str,
+    ) -> Result<(), RariError> {
+        let component_id_msg = component_id.to_string();
+        let component_id_op = component_id.to_string();
+        self.broadcast_to_healthy(
+            "broadcast_clear_module_loader_caches",
+            |idx, err: &RariError| format!("runtime[{idx}]: {err}"),
+            |total, errors: &[String]| {
+                RariError::js_runtime(format!(
+                    "Failed to broadcast clear_module_loader_caches for {component_id_msg} on {} of {total} runtimes: {}",
+                    errors.len(),
+                    errors.join("; ")
+                ))
+            },
+            |_idx, runtime: DynRuntime| {
+                let component_id_local = component_id_op.clone();
+                async move { runtime.clear_module_loader_caches(&component_id_local).await }
+            },
+        )
+        .await
+    }
+}

--- a/crates/rari/src/runtime/factory/pool/broadcast.rs
+++ b/crates/rari/src/runtime/factory/pool/broadcast.rs
@@ -56,9 +56,10 @@ impl JsRuntimePool {
                 continue;
             };
             let pool = self;
-            let fut = op(idx, Arc::clone(&runtime));
+            let expected = Arc::clone(&runtime);
+            let fut = op(idx, runtime);
             slot_futs.push(async move {
-                let _lease = match pool.acquire_slot_lease(idx).await {
+                let _lease = match pool.acquire_slot_lease_for_execute(idx, &expected).await {
                     Ok(guard) => guard,
                     Err(e) => return Err((idx, e)),
                 };
@@ -66,6 +67,7 @@ impl JsRuntimePool {
                     Ok(Ok(_)) => Ok(()),
                     Ok(Err(e)) => Err((idx, e)),
                     Err(_) => {
+                        pool.mark_unhealthy_if_runtime_matches(idx, &expected);
                         Err((idx, RariError::timeout(format!("timed out after {timeout_ms} ms"))))
                     }
                 }
@@ -84,7 +86,10 @@ impl JsRuntimePool {
             match result {
                 Ok(()) => {}
                 Err((idx, e)) => {
-                    self.mark_unhealthy(idx);
+                    let msg = e.to_string();
+                    if !msg.contains("no longer admissible") && !msg.contains("timed out") {
+                        self.mark_unhealthy(idx);
+                    }
                     errors.push(format_error(idx, &e));
                 }
             }

--- a/crates/rari/src/runtime/factory/pool/handle.rs
+++ b/crates/rari/src/runtime/factory/pool/handle.rs
@@ -1,0 +1,85 @@
+use std::{sync::Arc, time::Duration};
+
+use deno_core::ModuleId;
+use rari_error::RariError;
+use serde_json::Value;
+use tokio::{sync::mpsc::Sender, time};
+
+use super::super::interface::{AsyncBatchResult, JsRuntimeInterface};
+use crate::server::middleware::request_context::RequestContext;
+
+macro_rules! forward_async_to_runtime_with_timeout {
+    ($(
+        pub async fn $name:ident(&self $(, $($arg:ident: $arg_ty:ty),*)?) -> Result<$ok:ty, RariError>;
+    )*) => {
+        $(
+            pub async fn $name(&self $(, $($arg: $arg_ty),*)?) -> Result<$ok, RariError> {
+                match time::timeout(
+                    Duration::from_millis(self.timeout_ms),
+                    self.runtime.$name($($($arg),*)?),
+                )
+                .await
+                {
+                    Ok(result) => result,
+                    Err(_) => Err(RariError::timeout(format!(
+                        concat!(stringify!($name), " timed out after {} ms"),
+                        self.timeout_ms
+                    ))),
+                }
+            }
+        )*
+    };
+}
+
+pub struct PooledRuntime {
+    idx: usize,
+    runtime: Arc<dyn JsRuntimeInterface>,
+    timeout_ms: u64,
+}
+
+impl PooledRuntime {
+    pub(super) fn new(idx: usize, runtime: Arc<dyn JsRuntimeInterface>, timeout_ms: u64) -> Self {
+        Self { idx, runtime, timeout_ms }
+    }
+
+    pub fn idx(&self) -> usize {
+        self.idx
+    }
+
+    pub fn runtime(&self) -> &Arc<dyn JsRuntimeInterface> {
+        &self.runtime
+    }
+
+    pub fn timeout_ms(&self) -> u64 {
+        self.timeout_ms
+    }
+
+    pub fn execute_script_batch(&self, scripts: Vec<(String, String)>) -> AsyncBatchResult {
+        self.runtime.execute_script_batch(scripts)
+    }
+
+    /// Streaming holds the isolate for the response lifetime; no overall timeout
+    /// (matches [`crate::runtime::JsExecutionRuntime::execute_script_for_streaming`]).
+    pub async fn execute_script_for_streaming(
+        &self,
+        script_name: String,
+        script_code: String,
+        chunk_sender: Sender<Result<Vec<u8>, RariError>>,
+    ) -> Result<(), RariError> {
+        self.runtime.execute_script_for_streaming(script_name, script_code, chunk_sender).await
+    }
+
+    forward_async_to_runtime_with_timeout! {
+        pub async fn execute_script(&self, script_name: String, script_code: String) -> Result<Value, RariError>;
+        pub async fn execute_function(&self, function_name: &str, args: Vec<Value>) -> Result<Value, RariError>;
+        pub async fn add_module_to_loader(&self, specifier: &str, code: String) -> Result<(), RariError>;
+        pub async fn clear_module_loader_caches(&self, component_id: &str) -> Result<(), RariError>;
+        pub async fn load_es_module(&self, specifier: &str) -> Result<ModuleId, RariError>;
+        pub async fn evaluate_module(&self, module_id: ModuleId) -> Result<Value, RariError>;
+        pub async fn get_module_namespace(&self, module_id: ModuleId) -> Result<Value, RariError>;
+        pub async fn set_request_context(&self, request_context: Arc<RequestContext>) -> Result<(), RariError>;
+        pub async fn clear_request_context(&self) -> Result<(), RariError>;
+        pub async fn clear_request_context_if_matches(&self, expected_context: Arc<RequestContext>) -> Result<(), RariError>;
+        pub async fn execute_script_with_request_context(&self, request_context: Arc<RequestContext>, script_name: String, script_code: String) -> Result<Value, RariError>;
+    }
+}

--- a/crates/rari/src/runtime/factory/pool/interface.rs
+++ b/crates/rari/src/runtime/factory/pool/interface.rs
@@ -1,4 +1,7 @@
-use std::{sync::atomic::Ordering, time::Duration};
+use std::{
+    sync::{Arc, atomic::Ordering},
+    time::Duration,
+};
 
 use futures::future::join_all;
 use rari_error::RariError;
@@ -92,7 +95,7 @@ impl JsRuntimePool {
     }
 
     pub async fn execute_script_batch(
-        &self,
+        self: &Arc<Self>,
         scripts: Vec<(String, String)>,
     ) -> UnboundedReceiver<(usize, Result<Value, RariError>)> {
         self.probe_and_heal().await;
@@ -106,6 +109,7 @@ impl JsRuntimePool {
         let mut candidates: Vec<usize> = self.all_healthy_indices();
         candidates.retain(|&i| i != first);
         candidates.insert(0, first);
+        let timeout_ms = self.timeout_ms;
         for idx in candidates {
             let Some(runtime) = self.runtime_at(idx) else {
                 continue;
@@ -114,13 +118,19 @@ impl JsRuntimePool {
                 continue;
             };
             let tx = tx.clone();
+            let pool = Arc::clone(self);
             tokio::spawn(async move {
                 let _lease = lease;
                 let mut inner_rx = runtime.execute_script_batch(scripts).await;
-                while let Some(item) = inner_rx.recv().await {
-                    if tx.send(item).is_err() {
-                        break;
+                let forward = async {
+                    while let Some(item) = inner_rx.recv().await {
+                        if tx.send(item).is_err() {
+                            break;
+                        }
                     }
+                };
+                if time::timeout(Duration::from_millis(timeout_ms), forward).await.is_err() {
+                    pool.mark_unhealthy_if_runtime_matches(idx, &runtime);
                 }
             });
             return rx;

--- a/crates/rari/src/runtime/factory/pool/interface.rs
+++ b/crates/rari/src/runtime/factory/pool/interface.rs
@@ -121,8 +121,8 @@ impl JsRuntimePool {
             let pool = Arc::clone(self);
             tokio::spawn(async move {
                 let _lease = lease;
-                let mut inner_rx = runtime.execute_script_batch(scripts).await;
                 let forward = async {
+                    let mut inner_rx = runtime.execute_script_batch(scripts).await;
                     while let Some(item) = inner_rx.recv().await {
                         if tx.send(item).is_err() {
                             break;

--- a/crates/rari/src/runtime/factory/pool/interface.rs
+++ b/crates/rari/src/runtime/factory/pool/interface.rs
@@ -1,25 +1,17 @@
-use std::{
-    future::Future,
-    pin::Pin,
-    sync::{Arc, atomic::Ordering},
-    time::Duration,
-};
+use std::{sync::atomic::Ordering, time::Duration};
 
+use futures::future::join_all;
 use rari_error::RariError;
 use serde_json::Value;
-use tokio::{sync::mpsc::unbounded_channel, time};
+use tokio::{
+    sync::mpsc::{UnboundedReceiver, unbounded_channel},
+    time,
+};
 
-use super::{super::interface::AsyncBatchResult, JsRuntimePool};
+use super::JsRuntimePool;
 
 fn pool_unavailable_error() -> RariError {
     RariError::js_runtime("No healthy JS runtime available in pool".to_string())
-}
-
-fn unavailable_future<T>() -> Pin<Box<dyn Future<Output = Result<T, RariError>> + Send>>
-where
-    T: Send + 'static,
-{
-    Box::pin(async move { Err(pool_unavailable_error()) })
 }
 
 fn timeout_error(label: &str, timeout_ms: u64) -> RariError {
@@ -30,112 +22,128 @@ impl JsRuntimePool {
     /// Execute a script on one healthy runtime, or on every healthy runtime when
     /// `setup_mode` is enabled. Setup broadcast keeps the first successful value and
     /// does not mark failed slots unhealthy (bootstrap should stay retryable).
-    pub fn execute_script(
+    pub async fn execute_script(
         &self,
         script_name: String,
         script_code: String,
-    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send>> {
+    ) -> Result<Value, RariError> {
+        self.probe_and_heal().await;
         let timeout_ms = self.timeout_ms;
         if self.setup_mode.load(Ordering::Acquire) {
-            let runtimes = self.runtimes.clone();
             let healthy_snapshot: Vec<bool> =
                 self.healthy.iter().map(|h| h.load(Ordering::Acquire)).collect();
-            Box::pin(async move {
-                match time::timeout(Duration::from_millis(timeout_ms), async {
-                    let mut errors: Vec<String> = Vec::new();
-                    let mut first_value: Option<Value> = None;
-                    let mut executed: usize = 0;
-                    for (idx, runtime) in runtimes.iter().enumerate() {
-                        if !healthy_snapshot[idx] {
-                            continue;
-                        }
-                        executed += 1;
-                        match runtime.execute_script(script_name.clone(), script_code.clone()).await
-                        {
-                            Ok(v) => {
-                                if first_value.is_none() {
-                                    first_value = Some(v);
-                                }
-                            }
-                            Err(e) => {
-                                errors.push(format!("runtime[{idx}]: {e}"));
-                            }
-                        }
-                    }
 
-                    if executed == 0 {
-                        Err(pool_unavailable_error())
-                    } else if errors.is_empty() {
-                        Ok(first_value.unwrap_or(Value::Null))
-                    } else {
-                        Err(RariError::js_runtime(format!(
-                            "Failed to broadcast execute_script {script_name} on {} of {} runtimes: {}",
-                            errors.len(),
-                            executed,
-                            errors.join("; ")
-                        )))
+            let mut slot_futs = Vec::new();
+            for (idx, healthy) in healthy_snapshot.iter().enumerate() {
+                if !healthy {
+                    continue;
+                }
+                let Some(runtime) = self.runtime_at(idx) else {
+                    continue;
+                };
+                let script_name = script_name.clone();
+                let script_code = script_code.clone();
+                slot_futs.push(async move {
+                    match time::timeout(
+                        Duration::from_millis(timeout_ms),
+                        runtime.execute_script(script_name, script_code),
+                    )
+                    .await
+                    {
+                        Ok(Ok(v)) => Ok((idx, v)),
+                        Ok(Err(e)) => Err(format!("runtime[{idx}]: {e}")),
+                        Err(_) => Err(format!("runtime[{idx}]: timed out after {timeout_ms} ms")),
                     }
-                })
-                .await
-                {
-                    Ok(result) => result,
-                    Err(_) => Err(timeout_error("execute_script", timeout_ms)),
-                }
-            })
-        } else {
-            let runtime = match self.pick() {
-                Some(idx) => Arc::clone(&self.runtimes[idx]),
-                None => return unavailable_future(),
-            };
-            Box::pin(async move {
-                match time::timeout(
-                    Duration::from_millis(timeout_ms),
-                    runtime.execute_script(script_name, script_code),
-                )
-                .await
-                {
-                    Ok(result) => result,
-                    Err(_) => Err(timeout_error("execute_script", timeout_ms)),
-                }
-            })
-        }
-    }
-
-    pub fn execute_script_batch(&self, scripts: Vec<(String, String)>) -> AsyncBatchResult {
-        let runtime = match self.pick() {
-            Some(idx) => Arc::clone(&self.runtimes[idx]),
-            None => {
-                let (tx, rx) = unbounded_channel();
-                for (idx, _) in scripts.iter().enumerate() {
-                    let _ = tx.send((idx, Err(pool_unavailable_error())));
-                }
-                return Box::pin(async move { rx });
+                });
             }
-        };
-        Box::pin(async move { runtime.execute_script_batch(scripts).await })
-    }
 
-    pub fn execute_function(
-        &self,
-        function_name: &str,
-        args: Vec<Value>,
-    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send + 'static>> {
-        let timeout_ms = self.timeout_ms;
-        let runtime = match self.pick() {
-            Some(idx) => Arc::clone(&self.runtimes[idx]),
-            None => return unavailable_future(),
-        };
-        let function_name = function_name.to_string();
-        Box::pin(async move {
+            let executed = slot_futs.len();
+            if executed == 0 {
+                return Err(pool_unavailable_error());
+            }
+
+            let mut errors: Vec<String> = Vec::new();
+            let mut successes: Vec<(usize, Value)> = Vec::new();
+            for result in join_all(slot_futs).await {
+                match result {
+                    Ok((idx, v)) => successes.push((idx, v)),
+                    Err(msg) => errors.push(msg),
+                }
+            }
+            successes.sort_by_key(|(idx, _)| *idx);
+            let first_value = successes.into_iter().next().map(|(_, v)| v);
+
+            if errors.is_empty() {
+                Ok(first_value.unwrap_or(Value::Null))
+            } else {
+                Err(RariError::js_runtime(format!(
+                    "Failed to broadcast execute_script {script_name} on {} of {executed} runtimes: {}",
+                    errors.len(),
+                    errors.join("; ")
+                )))
+            }
+        } else {
+            let Some(idx) = self.pick() else {
+                return Err(pool_unavailable_error());
+            };
+            let Some(runtime) = self.runtime_at(idx) else {
+                return Err(pool_unavailable_error());
+            };
             match time::timeout(
                 Duration::from_millis(timeout_ms),
-                runtime.execute_function(&function_name, args),
+                runtime.execute_script(script_name, script_code),
             )
             .await
             {
                 Ok(result) => result,
-                Err(_) => Err(timeout_error("execute_function", timeout_ms)),
+                Err(_) => {
+                    self.mark_unhealthy(idx);
+                    Err(timeout_error("execute_script", timeout_ms))
+                }
             }
-        })
+        }
+    }
+
+    pub async fn execute_script_batch(
+        &self,
+        scripts: Vec<(String, String)>,
+    ) -> UnboundedReceiver<(usize, Result<Value, RariError>)> {
+        self.probe_and_heal().await;
+        let Some(runtime) = self.pick().and_then(|idx| self.runtime_at(idx)) else {
+            let (tx, rx) = unbounded_channel();
+            for (idx, _) in scripts.iter().enumerate() {
+                let _ = tx.send((idx, Err(pool_unavailable_error())));
+            }
+            return rx;
+        };
+        runtime.execute_script_batch(scripts).await
+    }
+
+    pub async fn execute_function(
+        &self,
+        function_name: &str,
+        args: Vec<Value>,
+    ) -> Result<Value, RariError> {
+        self.probe_and_heal().await;
+        let timeout_ms = self.timeout_ms;
+        let Some(idx) = self.pick() else {
+            return Err(pool_unavailable_error());
+        };
+        let Some(runtime) = self.runtime_at(idx) else {
+            return Err(pool_unavailable_error());
+        };
+        let function_name = function_name.to_string();
+        match time::timeout(
+            Duration::from_millis(timeout_ms),
+            runtime.execute_function(&function_name, args),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => {
+                self.mark_unhealthy(idx);
+                Err(timeout_error("execute_function", timeout_ms))
+            }
+        }
     }
 }

--- a/crates/rari/src/runtime/factory/pool/interface.rs
+++ b/crates/rari/src/runtime/factory/pool/interface.rs
@@ -43,7 +43,12 @@ impl JsRuntimePool {
                 };
                 let script_name = script_name.clone();
                 let script_code = script_code.clone();
+                let pool = self;
                 slot_futs.push(async move {
+                    let _lease = match pool.acquire_slot_lease(idx).await {
+                        Ok(guard) => guard,
+                        Err(e) => return Err(format!("runtime[{idx}]: {e}")),
+                    };
                     match time::timeout(
                         Duration::from_millis(timeout_ms),
                         runtime.execute_script(script_name, script_code),
@@ -89,6 +94,7 @@ impl JsRuntimePool {
             let Some(runtime) = self.runtime_at(idx) else {
                 return Err(pool_unavailable_error());
             };
+            let _lease = self.acquire_slot_lease(idx).await?;
             match time::timeout(
                 Duration::from_millis(timeout_ms),
                 runtime.execute_script(script_name, script_code),
@@ -132,6 +138,7 @@ impl JsRuntimePool {
         let Some(runtime) = self.runtime_at(idx) else {
             return Err(pool_unavailable_error());
         };
+        let _lease = self.acquire_slot_lease(idx).await?;
         let function_name = function_name.to_string();
         match time::timeout(
             Duration::from_millis(timeout_ms),

--- a/crates/rari/src/runtime/factory/pool/interface.rs
+++ b/crates/rari/src/runtime/factory/pool/interface.rs
@@ -14,10 +14,6 @@ fn pool_unavailable_error() -> RariError {
     RariError::js_runtime("No healthy JS runtime available in pool".to_string())
 }
 
-fn timeout_error(label: &str, timeout_ms: u64) -> RariError {
-    RariError::timeout(format!("{label} timed out after {timeout_ms} ms"))
-}
-
 impl JsRuntimePool {
     /// Execute a script on one healthy runtime, or on every healthy runtime when
     /// `setup_mode` is enabled. Setup broadcast keeps the first successful value and
@@ -88,33 +84,10 @@ impl JsRuntimePool {
                 )))
             }
         } else {
-            for attempt in 0..2 {
-                let Some(idx) = self.pick() else {
-                    return Err(pool_unavailable_error());
-                };
-                let Some(runtime) = self.runtime_at(idx) else {
-                    return Err(pool_unavailable_error());
-                };
-                let lease_result = self.acquire_slot_lease_for_execute(idx, &runtime).await;
-                match lease_result {
-                    Ok(_lease) => {}
-                    Err(_e) if attempt == 0 => continue,
-                    Err(e) => return Err(e),
-                }
-                match time::timeout(
-                    Duration::from_millis(timeout_ms),
-                    runtime.execute_script(script_name, script_code),
-                )
-                .await
-                {
-                    Ok(result) => return result,
-                    Err(_) => {
-                        self.mark_unhealthy_if_runtime_matches(idx, &runtime);
-                        return Err(timeout_error("execute_script", timeout_ms));
-                    }
-                }
-            }
-            Err(pool_unavailable_error())
+            self.execute_on_admitted_healthy_slot("execute_script", |runtime| {
+                runtime.execute_script(script_name.clone(), script_code.clone())
+            })
+            .await
         }
     }
 
@@ -123,14 +96,39 @@ impl JsRuntimePool {
         scripts: Vec<(String, String)>,
     ) -> UnboundedReceiver<(usize, Result<Value, RariError>)> {
         self.probe_and_heal().await;
-        let Some(runtime) = self.pick().and_then(|idx| self.runtime_at(idx)) else {
-            let (tx, rx) = unbounded_channel();
-            for (idx, _) in scripts.iter().enumerate() {
-                let _ = tx.send((idx, Err(pool_unavailable_error())));
+        let (tx, rx) = unbounded_channel();
+        let Some(first) = self.pick() else {
+            for (script_idx, _) in scripts.iter().enumerate() {
+                let _ = tx.send((script_idx, Err(pool_unavailable_error())));
             }
             return rx;
         };
-        runtime.execute_script_batch(scripts).await
+        let mut candidates: Vec<usize> = self.all_healthy_indices();
+        candidates.retain(|&i| i != first);
+        candidates.insert(0, first);
+        for idx in candidates {
+            let Some(runtime) = self.runtime_at(idx) else {
+                continue;
+            };
+            let Ok(lease) = self.acquire_owned_slot_lease_for_execute(idx, &runtime).await else {
+                continue;
+            };
+            let tx = tx.clone();
+            tokio::spawn(async move {
+                let _lease = lease;
+                let mut inner_rx = runtime.execute_script_batch(scripts).await;
+                while let Some(item) = inner_rx.recv().await {
+                    if tx.send(item).is_err() {
+                        break;
+                    }
+                }
+            });
+            return rx;
+        }
+        for (script_idx, _) in scripts.iter().enumerate() {
+            let _ = tx.send((script_idx, Err(pool_unavailable_error())));
+        }
+        rx
     }
 
     pub async fn execute_function(
@@ -139,34 +137,10 @@ impl JsRuntimePool {
         args: Vec<Value>,
     ) -> Result<Value, RariError> {
         self.probe_and_heal().await;
-        let timeout_ms = self.timeout_ms;
-        for attempt in 0..2 {
-            let Some(idx) = self.pick() else {
-                return Err(pool_unavailable_error());
-            };
-            let Some(runtime) = self.runtime_at(idx) else {
-                return Err(pool_unavailable_error());
-            };
-            let lease_result = self.acquire_slot_lease_for_execute(idx, &runtime).await;
-            match lease_result {
-                Ok(_lease) => {}
-                Err(_e) if attempt == 0 => continue,
-                Err(e) => return Err(e),
-            }
-            let function_name = function_name.to_string();
-            match time::timeout(
-                Duration::from_millis(timeout_ms),
-                runtime.execute_function(&function_name, args),
-            )
-            .await
-            {
-                Ok(result) => return result,
-                Err(_) => {
-                    self.mark_unhealthy_if_runtime_matches(idx, &runtime);
-                    return Err(timeout_error("execute_function", timeout_ms));
-                }
-            }
-        }
-        Err(pool_unavailable_error())
+        let function_name = function_name.to_string();
+        self.execute_on_admitted_healthy_slot("execute_function", move |runtime| {
+            runtime.execute_function(&function_name, args.clone())
+        })
+        .await
     }
 }

--- a/crates/rari/src/runtime/factory/pool/interface.rs
+++ b/crates/rari/src/runtime/factory/pool/interface.rs
@@ -1,0 +1,141 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, atomic::Ordering},
+    time::Duration,
+};
+
+use rari_error::RariError;
+use serde_json::Value;
+use tokio::{sync::mpsc::unbounded_channel, time};
+
+use super::{super::interface::AsyncBatchResult, JsRuntimePool};
+
+fn pool_unavailable_error() -> RariError {
+    RariError::js_runtime("No healthy JS runtime available in pool".to_string())
+}
+
+fn unavailable_future<T>() -> Pin<Box<dyn Future<Output = Result<T, RariError>> + Send>>
+where
+    T: Send + 'static,
+{
+    Box::pin(async move { Err(pool_unavailable_error()) })
+}
+
+fn timeout_error(label: &str, timeout_ms: u64) -> RariError {
+    RariError::timeout(format!("{label} timed out after {timeout_ms} ms"))
+}
+
+impl JsRuntimePool {
+    /// Execute a script on one healthy runtime, or on every healthy runtime when
+    /// `setup_mode` is enabled. Setup broadcast keeps the first successful value and
+    /// does not mark failed slots unhealthy (bootstrap should stay retryable).
+    pub fn execute_script(
+        &self,
+        script_name: String,
+        script_code: String,
+    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send>> {
+        let timeout_ms = self.timeout_ms;
+        if self.setup_mode.load(Ordering::Acquire) {
+            let runtimes = self.runtimes.clone();
+            let healthy_snapshot: Vec<bool> =
+                self.healthy.iter().map(|h| h.load(Ordering::Acquire)).collect();
+            Box::pin(async move {
+                match time::timeout(Duration::from_millis(timeout_ms), async {
+                    let mut errors: Vec<String> = Vec::new();
+                    let mut first_value: Option<Value> = None;
+                    let mut executed: usize = 0;
+                    for (idx, runtime) in runtimes.iter().enumerate() {
+                        if !healthy_snapshot[idx] {
+                            continue;
+                        }
+                        executed += 1;
+                        match runtime.execute_script(script_name.clone(), script_code.clone()).await
+                        {
+                            Ok(v) => {
+                                if first_value.is_none() {
+                                    first_value = Some(v);
+                                }
+                            }
+                            Err(e) => {
+                                errors.push(format!("runtime[{idx}]: {e}"));
+                            }
+                        }
+                    }
+
+                    if executed == 0 {
+                        Err(pool_unavailable_error())
+                    } else if errors.is_empty() {
+                        Ok(first_value.unwrap_or(Value::Null))
+                    } else {
+                        Err(RariError::js_runtime(format!(
+                            "Failed to broadcast execute_script {script_name} on {} of {} runtimes: {}",
+                            errors.len(),
+                            executed,
+                            errors.join("; ")
+                        )))
+                    }
+                })
+                .await
+                {
+                    Ok(result) => result,
+                    Err(_) => Err(timeout_error("execute_script", timeout_ms)),
+                }
+            })
+        } else {
+            let runtime = match self.pick() {
+                Some(idx) => Arc::clone(&self.runtimes[idx]),
+                None => return unavailable_future(),
+            };
+            Box::pin(async move {
+                match time::timeout(
+                    Duration::from_millis(timeout_ms),
+                    runtime.execute_script(script_name, script_code),
+                )
+                .await
+                {
+                    Ok(result) => result,
+                    Err(_) => Err(timeout_error("execute_script", timeout_ms)),
+                }
+            })
+        }
+    }
+
+    pub fn execute_script_batch(&self, scripts: Vec<(String, String)>) -> AsyncBatchResult {
+        let runtime = match self.pick() {
+            Some(idx) => Arc::clone(&self.runtimes[idx]),
+            None => {
+                let (tx, rx) = unbounded_channel();
+                for (idx, _) in scripts.iter().enumerate() {
+                    let _ = tx.send((idx, Err(pool_unavailable_error())));
+                }
+                return Box::pin(async move { rx });
+            }
+        };
+        Box::pin(async move { runtime.execute_script_batch(scripts).await })
+    }
+
+    pub fn execute_function(
+        &self,
+        function_name: &str,
+        args: Vec<Value>,
+    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send + 'static>> {
+        let timeout_ms = self.timeout_ms;
+        let runtime = match self.pick() {
+            Some(idx) => Arc::clone(&self.runtimes[idx]),
+            None => return unavailable_future(),
+        };
+        let function_name = function_name.to_string();
+        Box::pin(async move {
+            match time::timeout(
+                Duration::from_millis(timeout_ms),
+                runtime.execute_function(&function_name, args),
+            )
+            .await
+            {
+                Ok(result) => result,
+                Err(_) => Err(timeout_error("execute_function", timeout_ms)),
+            }
+        })
+    }
+}

--- a/crates/rari/src/runtime/factory/pool/interface.rs
+++ b/crates/rari/src/runtime/factory/pool/interface.rs
@@ -45,7 +45,7 @@ impl JsRuntimePool {
                 let script_code = script_code.clone();
                 let pool = self;
                 slot_futs.push(async move {
-                    let _lease = match pool.acquire_slot_lease(idx).await {
+                    let _lease = match pool.acquire_slot_lease_for_execute(idx, &runtime).await {
                         Ok(guard) => guard,
                         Err(e) => return Err(format!("runtime[{idx}]: {e}")),
                     };
@@ -88,25 +88,33 @@ impl JsRuntimePool {
                 )))
             }
         } else {
-            let Some(idx) = self.pick() else {
-                return Err(pool_unavailable_error());
-            };
-            let Some(runtime) = self.runtime_at(idx) else {
-                return Err(pool_unavailable_error());
-            };
-            let _lease = self.acquire_slot_lease(idx).await?;
-            match time::timeout(
-                Duration::from_millis(timeout_ms),
-                runtime.execute_script(script_name, script_code),
-            )
-            .await
-            {
-                Ok(result) => result,
-                Err(_) => {
-                    self.mark_unhealthy(idx);
-                    Err(timeout_error("execute_script", timeout_ms))
+            for attempt in 0..2 {
+                let Some(idx) = self.pick() else {
+                    return Err(pool_unavailable_error());
+                };
+                let Some(runtime) = self.runtime_at(idx) else {
+                    return Err(pool_unavailable_error());
+                };
+                let lease_result = self.acquire_slot_lease_for_execute(idx, &runtime).await;
+                match lease_result {
+                    Ok(_lease) => {}
+                    Err(_e) if attempt == 0 => continue,
+                    Err(e) => return Err(e),
+                }
+                match time::timeout(
+                    Duration::from_millis(timeout_ms),
+                    runtime.execute_script(script_name, script_code),
+                )
+                .await
+                {
+                    Ok(result) => return result,
+                    Err(_) => {
+                        self.mark_unhealthy_if_runtime_matches(idx, &runtime);
+                        return Err(timeout_error("execute_script", timeout_ms));
+                    }
                 }
             }
+            Err(pool_unavailable_error())
         }
     }
 
@@ -132,25 +140,33 @@ impl JsRuntimePool {
     ) -> Result<Value, RariError> {
         self.probe_and_heal().await;
         let timeout_ms = self.timeout_ms;
-        let Some(idx) = self.pick() else {
-            return Err(pool_unavailable_error());
-        };
-        let Some(runtime) = self.runtime_at(idx) else {
-            return Err(pool_unavailable_error());
-        };
-        let _lease = self.acquire_slot_lease(idx).await?;
-        let function_name = function_name.to_string();
-        match time::timeout(
-            Duration::from_millis(timeout_ms),
-            runtime.execute_function(&function_name, args),
-        )
-        .await
-        {
-            Ok(result) => result,
-            Err(_) => {
-                self.mark_unhealthy(idx);
-                Err(timeout_error("execute_function", timeout_ms))
+        for attempt in 0..2 {
+            let Some(idx) = self.pick() else {
+                return Err(pool_unavailable_error());
+            };
+            let Some(runtime) = self.runtime_at(idx) else {
+                return Err(pool_unavailable_error());
+            };
+            let lease_result = self.acquire_slot_lease_for_execute(idx, &runtime).await;
+            match lease_result {
+                Ok(_lease) => {}
+                Err(_e) if attempt == 0 => continue,
+                Err(e) => return Err(e),
+            }
+            let function_name = function_name.to_string();
+            match time::timeout(
+                Duration::from_millis(timeout_ms),
+                runtime.execute_function(&function_name, args),
+            )
+            .await
+            {
+                Ok(result) => return result,
+                Err(_) => {
+                    self.mark_unhealthy_if_runtime_matches(idx, &runtime);
+                    return Err(timeout_error("execute_function", timeout_ms));
+                }
             }
         }
+        Err(pool_unavailable_error())
     }
 }

--- a/crates/rari/src/runtime/factory/pool/mod.rs
+++ b/crates/rari/src/runtime/factory/pool/mod.rs
@@ -1,0 +1,321 @@
+#![expect(clippy::missing_errors_doc)]
+
+use std::{
+    fmt::{self, Formatter, Result as FmtResult},
+    future::Future,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use deno_core::ModuleId;
+use rari_error::RariError;
+use rustc_hash::FxHashMap;
+use serde_json::Value;
+use tokio::time;
+
+use super::runtime::RariRuntime;
+
+mod broadcast;
+mod handle;
+mod interface;
+mod strategy;
+#[cfg(test)]
+mod tests;
+
+pub use handle::PooledRuntime;
+pub use strategy::{PickStrategy, RoundRobinStrategy};
+
+use super::interface::JsRuntimeInterface;
+use crate::server::middleware::request_context::RequestContext;
+
+/// Matches [`crate::runtime::JsExecutionRuntime`] default script timeout.
+pub const DEFAULT_TIMEOUT_MS: u64 = 30_000;
+
+/// After this many ms, `pick` may re-admit slots marked unhealthy.
+pub const DEFAULT_HEAL_AFTER_MS: u64 = 30_000;
+
+/// Disable automatic healing (tests / explicit recovery only).
+pub const HEAL_DISABLED: u64 = u64::MAX;
+
+pub struct JsRuntimePool {
+    runtimes: Vec<Arc<dyn JsRuntimeInterface>>,
+    pick_strategy: Arc<dyn PickStrategy>,
+    next_index: AtomicUsize,
+    healthy: Vec<AtomicBool>,
+    /// Unix millis when the slot was marked unhealthy; `0` if healthy / unknown.
+    unhealthy_since_ms: Vec<AtomicU64>,
+    setup_mode: AtomicBool,
+    timeout_ms: u64,
+    heal_after_ms: u64,
+}
+
+#[expect(
+    clippy::missing_fields_in_debug,
+    reason = "Debug impl intentionally omits non-trivial fields"
+)]
+impl fmt::Debug for JsRuntimePool {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.debug_struct("JsRuntimePool")
+            .field("size", &self.runtimes.len())
+            .field(
+                "healthy_count",
+                &self.healthy.iter().filter(|h| h.load(Ordering::Acquire)).count(),
+            )
+            .field("timeout_ms", &self.timeout_ms)
+            .field("heal_after_ms", &self.heal_after_ms)
+            .finish()
+    }
+}
+
+fn unix_now_ms() -> u64 {
+    u64::try_from(SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis())
+        .unwrap_or(u64::MAX)
+}
+
+impl JsRuntimePool {
+    pub fn new(
+        pool_size: usize,
+        env_vars: Option<FxHashMap<String, String>>,
+    ) -> Result<Arc<Self>, RariError> {
+        Self::with_strategy(pool_size, env_vars, Arc::new(RoundRobinStrategy))
+    }
+
+    pub fn with_strategy(
+        pool_size: usize,
+        env_vars: Option<FxHashMap<String, String>>,
+        strategy: Arc<dyn PickStrategy>,
+    ) -> Result<Arc<Self>, RariError> {
+        Self::with_strategy_and_limits(
+            pool_size,
+            env_vars,
+            strategy,
+            DEFAULT_TIMEOUT_MS,
+            DEFAULT_HEAL_AFTER_MS,
+        )
+    }
+
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "Each isolate needs an owned env map clone matching RariRuntime::new"
+    )]
+    pub fn with_strategy_and_limits(
+        pool_size: usize,
+        env_vars: Option<FxHashMap<String, String>>,
+        strategy: Arc<dyn PickStrategy>,
+        timeout_ms: u64,
+        heal_after_ms: u64,
+    ) -> Result<Arc<Self>, RariError> {
+        if pool_size == 0 {
+            return Err(RariError::configuration(
+                "JS runtime pool size must be at least 1".to_string(),
+            ));
+        }
+        if timeout_ms == 0 {
+            return Err(RariError::configuration(
+                "JS runtime pool timeout_ms must be at least 1".to_string(),
+            ));
+        }
+
+        let runtimes: Vec<Arc<dyn JsRuntimeInterface>> = (0..pool_size)
+            .map(|_| Arc::new(RariRuntime::new(env_vars.clone())) as Arc<dyn JsRuntimeInterface>)
+            .collect();
+
+        let healthy = runtimes.iter().map(|_| AtomicBool::new(true)).collect();
+        let unhealthy_since_ms = runtimes.iter().map(|_| AtomicU64::new(0)).collect();
+
+        Ok(Arc::new(Self {
+            runtimes,
+            pick_strategy: strategy,
+            next_index: AtomicUsize::new(0),
+            healthy,
+            unhealthy_since_ms,
+            setup_mode: AtomicBool::new(false),
+            timeout_ms,
+            heal_after_ms,
+        }))
+    }
+
+    pub fn size(&self) -> usize {
+        self.runtimes.len()
+    }
+
+    pub fn timeout_ms(&self) -> u64 {
+        self.timeout_ms
+    }
+
+    pub fn heal_after_ms(&self) -> u64 {
+        self.heal_after_ms
+    }
+
+    pub fn runtime_at(&self, idx: usize) -> Option<Arc<dyn JsRuntimeInterface>> {
+        self.runtimes.get(idx).map(Arc::clone)
+    }
+
+    pub fn pick(&self) -> Option<usize> {
+        self.heal_expired();
+
+        let healthy_indices: Vec<usize> = self
+            .healthy
+            .iter()
+            .enumerate()
+            .filter_map(|(i, h)| if h.load(Ordering::Acquire) { Some(i) } else { None })
+            .collect();
+
+        let idx = self.pick_strategy.pick(&healthy_indices, &self.next_index)?;
+        if idx >= self.runtimes.len() {
+            tracing::error!(
+                idx,
+                pool_size = self.runtimes.len(),
+                "PickStrategy returned out-of-range index"
+            );
+            return None;
+        }
+        Some(idx)
+    }
+
+    pub fn mark_unhealthy(&self, idx: usize) {
+        if let Some(h) = self.healthy.get(idx) {
+            h.store(false, Ordering::Release);
+            if let Some(since) = self.unhealthy_since_ms.get(idx) {
+                since.store(unix_now_ms(), Ordering::Release);
+            }
+            tracing::warn!("Marked JS runtime pool slot {} as unhealthy", idx);
+        }
+    }
+
+    pub fn mark_healthy(&self, idx: usize) {
+        if let Some(h) = self.healthy.get(idx) {
+            h.store(true, Ordering::Release);
+            if let Some(since) = self.unhealthy_since_ms.get(idx) {
+                since.store(0, Ordering::Release);
+            }
+            tracing::info!("Marked JS runtime pool slot {} as healthy", idx);
+        }
+    }
+
+    /// Re-admit slots that have been unhealthy for at least `heal_after_ms`.
+    /// No-op when healing is disabled (`HEAL_DISABLED`).
+    fn heal_expired(&self) {
+        if self.heal_after_ms == HEAL_DISABLED {
+            return;
+        }
+        let now = unix_now_ms();
+        for (idx, flag) in self.healthy.iter().enumerate() {
+            if flag.load(Ordering::Acquire) {
+                continue;
+            }
+            let since =
+                self.unhealthy_since_ms.get(idx).map(|s| s.load(Ordering::Acquire)).unwrap_or(0);
+            if since == 0 {
+                continue;
+            }
+            if now.saturating_sub(since) >= self.heal_after_ms {
+                self.mark_healthy(idx);
+            }
+        }
+    }
+
+    pub fn is_healthy(&self, idx: usize) -> bool {
+        self.healthy.get(idx).map(|h| h.load(Ordering::Acquire)).unwrap_or(false)
+    }
+
+    pub fn healthy_count(&self) -> usize {
+        self.healthy.iter().filter(|h| h.load(Ordering::Acquire)).count()
+    }
+
+    pub fn all_healthy_indices(&self) -> Vec<usize> {
+        self.healthy
+            .iter()
+            .enumerate()
+            .filter_map(|(i, h)| if h.load(Ordering::Acquire) { Some(i) } else { None })
+            .collect()
+    }
+
+    pub fn set_setup_mode(&self, on: bool) {
+        self.setup_mode.store(on, Ordering::Release);
+        tracing::info!("JS runtime pool setup_mode = {}", on);
+    }
+
+    pub fn pick_runtime(&self) -> Result<PooledRuntime, RariError> {
+        let idx = self.pick().ok_or_else(|| {
+            RariError::js_runtime("No healthy JS runtime available in pool".to_string())
+        })?;
+        let runtime = Arc::clone(&self.runtimes[idx]);
+        Ok(PooledRuntime::new(idx, runtime, self.timeout_ms))
+    }
+
+    /// Load+evaluate on a single picked isolate.
+    ///
+    /// `ModuleId` values are isolate-local. For bootstrap / HMR that must reach every
+    /// slot, use [`Self::broadcast_load_and_evaluate_module`] instead.
+    pub async fn load_and_evaluate_on_picked(
+        &self,
+        specifier: &str,
+    ) -> Result<(ModuleId, Value), RariError> {
+        let handle = self.pick_runtime()?;
+        let runtime = Arc::clone(handle.runtime());
+        let specifier = specifier.to_string();
+        self.run_with_timeout("load_and_evaluate_on_picked", async move {
+            let module_id = runtime.load_es_module(&specifier).await?;
+            let value = runtime.evaluate_module(module_id).await?;
+            Ok((module_id, value))
+        })
+        .await
+    }
+
+    pub async fn with_request_context<F, Fut, T>(
+        &self,
+        ctx: Arc<RequestContext>,
+        op: F,
+    ) -> Result<T, RariError>
+    where
+        F: FnOnce(Arc<dyn JsRuntimeInterface>) -> Fut,
+        Fut: Future<Output = Result<T, RariError>>,
+    {
+        let handle = self.pick_runtime()?;
+        let runtime = Arc::clone(handle.runtime());
+        self.run_with_timeout("with_request_context", async {
+            runtime.set_request_context(Arc::clone(&ctx)).await?;
+            let result = op(Arc::clone(&runtime)).await;
+            let cleanup = runtime.clear_request_context_if_matches(ctx).await;
+            match (result, cleanup) {
+                (Ok(value), Ok(())) => Ok(value),
+                (Ok(value), Err(cleanup_err)) => {
+                    tracing::error!(
+                        "Failed to clear request context after successful operation: {}",
+                        cleanup_err
+                    );
+                    Ok(value)
+                }
+                (Err(op_err), Ok(())) => Err(op_err),
+                (Err(op_err), Err(cleanup_err)) => {
+                    tracing::error!(
+                        "Failed to clear request context after operation error: {}",
+                        cleanup_err
+                    );
+                    Err(op_err)
+                }
+            }
+        })
+        .await
+    }
+
+    pub(super) async fn run_with_timeout<T, Fut>(
+        &self,
+        label: &str,
+        fut: Fut,
+    ) -> Result<T, RariError>
+    where
+        Fut: Future<Output = Result<T, RariError>>,
+    {
+        match time::timeout(Duration::from_millis(self.timeout_ms), fut).await {
+            Ok(result) => result,
+            Err(_) => {
+                Err(RariError::timeout(format!("{label} timed out after {} ms", self.timeout_ms)))
+            }
+        }
+    }
+}

--- a/crates/rari/src/runtime/factory/pool/mod.rs
+++ b/crates/rari/src/runtime/factory/pool/mod.rs
@@ -11,11 +11,12 @@ use std::{
 };
 
 use deno_core::ModuleId;
+use futures::future::join_all;
 use parking_lot::RwLock;
 use rari_error::RariError;
 use rustc_hash::FxHashMap;
 use serde_json::Value;
-use tokio::time;
+use tokio::{sync::Mutex as AsyncMutex, time};
 
 use super::runtime::RariRuntime;
 
@@ -52,6 +53,8 @@ pub struct JsRuntimePool {
     healthy: Vec<AtomicBool>,
     /// Unix millis when the slot was marked unhealthy; `0` if healthy / unknown.
     unhealthy_since_ms: Vec<AtomicU64>,
+    /// Per-slot lease so `with_request_context` cannot interleave on one runtime.
+    slot_leases: Vec<Arc<AsyncMutex<()>>>,
     setup_mode: AtomicBool,
     timeout_ms: u64,
     heal_after_ms: u64,
@@ -129,6 +132,7 @@ impl JsRuntimePool {
 
         let healthy = runtimes.iter().map(|_| AtomicBool::new(true)).collect();
         let unhealthy_since_ms = runtimes.iter().map(|_| AtomicU64::new(0)).collect();
+        let slot_leases = (0..pool_size).map(|_| Arc::new(AsyncMutex::new(()))).collect();
 
         Ok(Arc::new(Self {
             runtimes,
@@ -137,6 +141,7 @@ impl JsRuntimePool {
             next_index: AtomicUsize::new(0),
             healthy,
             unhealthy_since_ms,
+            slot_leases,
             setup_mode: AtomicBool::new(false),
             timeout_ms,
             heal_after_ms,
@@ -268,22 +273,36 @@ impl JsRuntimePool {
     /// Probe expired-unhealthy slots with a lightweight script before re-admission.
     /// Successful probes call [`Self::mark_healthy`]. Failures rebuild the isolate and
     /// probe again; if that also fails the quarantine timestamp is refreshed.
+    ///
+    /// Expired slots are probed concurrently so one hung isolate cannot delay the rest.
     pub async fn probe_and_heal(&self) {
         let indices = self.expired_unhealthy_indices();
         if indices.is_empty() {
             return;
         }
         let probe_timeout_ms = self.timeout_ms.clamp(1, 1_000);
-        for idx in indices {
-            if self.probe_slot(idx, probe_timeout_ms).await {
+
+        let probe_futs = indices.iter().map(|&idx| {
+            let probe = self.probe_slot(idx, probe_timeout_ms);
+            async move { (idx, probe.await) }
+        });
+        let probe_results = join_all(probe_futs).await;
+
+        let mut rebuild_indices = Vec::new();
+        for (idx, ok) in probe_results {
+            if ok {
                 self.mark_healthy(idx);
-                continue;
+            } else {
+                rebuild_indices.push(idx);
             }
+        }
+
+        let rebuild_futs = rebuild_indices.into_iter().map(|idx| async move {
             tracing::warn!(idx, "Heal probe failed; rebuilding JS runtime pool slot");
             if let Err(e) = self.rebuild_slot(idx) {
                 tracing::error!(idx, error = %e, "Failed to rebuild JS runtime pool slot");
                 self.refresh_unhealthy_timestamp(idx);
-                continue;
+                return;
             }
             if self.probe_slot(idx, probe_timeout_ms).await {
                 self.mark_healthy(idx);
@@ -294,7 +313,8 @@ impl JsRuntimePool {
                 );
                 self.refresh_unhealthy_timestamp(idx);
             }
-        }
+        });
+        join_all(rebuild_futs).await;
     }
 
     async fn probe_slot(&self, idx: usize, probe_timeout_ms: u64) -> bool {
@@ -372,55 +392,71 @@ impl JsRuntimePool {
     }
 
     pub async fn with_request_context<F, Fut, T>(
-        &self,
+        self: &Arc<Self>,
         ctx: Arc<RequestContext>,
         op: F,
     ) -> Result<T, RariError>
     where
-        F: FnOnce(Arc<dyn JsRuntimeInterface>) -> Fut,
-        Fut: Future<Output = Result<T, RariError>>,
+        T: Send + 'static,
+        F: FnOnce(Arc<dyn JsRuntimeInterface>) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<T, RariError>> + Send + 'static,
     {
         let handle = self.pick_runtime().await?;
         let idx = handle.idx();
         let runtime = Arc::clone(handle.runtime());
-
-        runtime.set_request_context(Arc::clone(&ctx)).await?;
-
-        let Ok(op_result) =
-            time::timeout(Duration::from_millis(self.timeout_ms), op(Arc::clone(&runtime))).await
-        else {
-            let cleanup = runtime.clear_request_context_if_matches(Arc::clone(&ctx)).await;
-            self.mark_unhealthy(idx);
-            if let Err(cleanup_err) = cleanup {
-                tracing::error!("Failed to clear request context after timeout: {}", cleanup_err);
-            }
-            return Err(RariError::timeout(format!(
-                "with_request_context timed out after {} ms",
-                self.timeout_ms
+        let Some(lease) = self.slot_leases.get(idx).cloned() else {
+            return Err(RariError::js_runtime(format!(
+                "No lease available for JS runtime pool slot {idx}"
             )));
         };
+        let pool = Arc::clone(self);
+        let timeout_ms = self.timeout_ms;
 
-        let cleanup = runtime.clear_request_context_if_matches(ctx).await;
-        match (op_result, cleanup) {
-            (Ok(value), Ok(())) => Ok(value),
-            (Ok(_value), Err(cleanup_err)) => {
-                self.mark_unhealthy(idx);
-                tracing::error!(
-                    "Failed to clear request context after successful operation: {}",
-                    cleanup_err
-                );
-                Err(cleanup_err)
+        tokio::spawn(async move {
+            let _lease_guard = lease.lock_owned().await;
+
+            runtime.set_request_context(Arc::clone(&ctx)).await?;
+
+            let Ok(op_result) =
+                time::timeout(Duration::from_millis(timeout_ms), op(Arc::clone(&runtime))).await
+            else {
+                let cleanup = runtime.clear_request_context_if_matches(Arc::clone(&ctx)).await;
+                pool.mark_unhealthy(idx);
+                if let Err(cleanup_err) = cleanup {
+                    tracing::error!(
+                        "Failed to clear request context after timeout: {}",
+                        cleanup_err
+                    );
+                }
+                return Err(RariError::timeout(format!(
+                    "with_request_context timed out after {timeout_ms} ms"
+                )));
+            };
+
+            let cleanup = runtime.clear_request_context_if_matches(ctx).await;
+            match (op_result, cleanup) {
+                (Ok(value), Ok(())) => Ok(value),
+                (Ok(_value), Err(cleanup_err)) => {
+                    pool.mark_unhealthy(idx);
+                    tracing::error!(
+                        "Failed to clear request context after successful operation: {}",
+                        cleanup_err
+                    );
+                    Err(cleanup_err)
+                }
+                (Err(op_err), Ok(())) => Err(op_err),
+                (Err(op_err), Err(cleanup_err)) => {
+                    pool.mark_unhealthy(idx);
+                    tracing::error!(
+                        "Failed to clear request context after operation error: {}",
+                        cleanup_err
+                    );
+                    Err(op_err)
+                }
             }
-            (Err(op_err), Ok(())) => Err(op_err),
-            (Err(op_err), Err(cleanup_err)) => {
-                self.mark_unhealthy(idx);
-                tracing::error!(
-                    "Failed to clear request context after operation error: {}",
-                    cleanup_err
-                );
-                Err(op_err)
-            }
-        }
+        })
+        .await
+        .map_err(|e| RariError::js_runtime(format!("with_request_context task join failed: {e}")))?
     }
 
     pub(super) async fn run_with_timeout_on_slot<T, Fut>(

--- a/crates/rari/src/runtime/factory/pool/mod.rs
+++ b/crates/rari/src/runtime/factory/pool/mod.rs
@@ -16,7 +16,10 @@ use parking_lot::RwLock;
 use rari_error::RariError;
 use rustc_hash::FxHashMap;
 use serde_json::Value;
-use tokio::{sync::Mutex as AsyncMutex, time};
+use tokio::{
+    sync::{Mutex as AsyncMutex, MutexGuard as AsyncMutexGuard},
+    time,
+};
 
 use super::runtime::RariRuntime;
 
@@ -55,6 +58,8 @@ pub struct JsRuntimePool {
     unhealthy_since_ms: Vec<AtomicU64>,
     /// Per-slot lease so `with_request_context` cannot interleave on one runtime.
     slot_leases: Vec<Arc<AsyncMutex<()>>>,
+    /// Set when request-context cleanup fails or times out; blocks probe-only heal.
+    needs_rebuild: Vec<AtomicBool>,
     setup_mode: AtomicBool,
     timeout_ms: u64,
     heal_after_ms: u64,
@@ -133,6 +138,7 @@ impl JsRuntimePool {
         let healthy = runtimes.iter().map(|_| AtomicBool::new(true)).collect();
         let unhealthy_since_ms = runtimes.iter().map(|_| AtomicU64::new(0)).collect();
         let slot_leases = (0..pool_size).map(|_| Arc::new(AsyncMutex::new(()))).collect();
+        let needs_rebuild = (0..pool_size).map(|_| AtomicBool::new(false)).collect();
 
         Ok(Arc::new(Self {
             runtimes,
@@ -142,6 +148,7 @@ impl JsRuntimePool {
             healthy,
             unhealthy_since_ms,
             slot_leases,
+            needs_rebuild,
             setup_mode: AtomicBool::new(false),
             timeout_ms,
             heal_after_ms,
@@ -178,23 +185,56 @@ impl JsRuntimePool {
         }
     }
 
+    fn mark_needs_rebuild(&self, idx: usize) {
+        if let Some(flag) = self.needs_rebuild.get(idx) {
+            flag.store(true, Ordering::Release);
+        }
+    }
+
+    fn clear_needs_rebuild(&self, idx: usize) {
+        if let Some(flag) = self.needs_rebuild.get(idx) {
+            flag.store(false, Ordering::Release);
+        }
+    }
+
+    fn needs_rebuild(&self, idx: usize) -> bool {
+        self.needs_rebuild.get(idx).is_some_and(|f| f.load(Ordering::Acquire))
+    }
+
+    fn runtime_still_installed(&self, idx: usize, expected: &Arc<dyn JsRuntimeInterface>) -> bool {
+        self.runtime_at(idx).is_some_and(|current| Arc::ptr_eq(&current, expected))
+    }
+
+    pub(super) async fn acquire_slot_lease(
+        &self,
+        idx: usize,
+    ) -> Result<AsyncMutexGuard<'_, ()>, RariError> {
+        let Some(lease) = self.slot_leases.get(idx) else {
+            return Err(RariError::js_runtime(format!(
+                "No lease available for JS runtime pool slot {idx}"
+            )));
+        };
+        Ok(lease.lock().await)
+    }
+
     /// Replace the isolate in `idx` with a freshly constructed runtime.
     ///
     /// In-flight sticky handles keep the old `Arc` until dropped; new picks see the replacement.
-    pub fn rebuild_slot(&self, idx: usize) -> Result<(), RariError> {
+    pub fn rebuild_slot(&self, idx: usize) -> Result<Arc<dyn JsRuntimeInterface>, RariError> {
         if idx >= self.runtimes.len() {
             return Err(RariError::js_runtime(format!(
                 "Cannot rebuild JS runtime pool slot {idx}: out of range"
             )));
         }
         let replacement = (self.runtime_factory)();
+        let installed = Arc::clone(&replacement);
         if !self.replace_runtime_at(idx, replacement) {
             return Err(RariError::js_runtime(format!(
                 "Cannot rebuild JS runtime pool slot {idx}: slot missing"
             )));
         }
         tracing::info!(idx, "Rebuilt JS runtime pool slot");
-        Ok(())
+        Ok(installed)
     }
 
     pub fn pick(&self) -> Option<usize> {
@@ -274,7 +314,8 @@ impl JsRuntimePool {
     /// Successful probes call [`Self::mark_healthy`]. Failures rebuild the isolate and
     /// probe again; if that also fails the quarantine timestamp is refreshed.
     ///
-    /// Expired slots are probed concurrently so one hung isolate cannot delay the rest.
+    /// Each slot heals under its lease so concurrent callers cannot probe/rebuild the
+    /// same index at once, and request-context work cannot interleave mid-heal.
     pub async fn probe_and_heal(&self) {
         let indices = self.expired_unhealthy_indices();
         if indices.is_empty() {
@@ -282,29 +323,41 @@ impl JsRuntimePool {
         }
         let probe_timeout_ms = self.timeout_ms.clamp(1, 1_000);
 
-        let probe_futs = indices.iter().map(|&idx| {
-            let probe = self.probe_slot(idx, probe_timeout_ms);
-            async move { (idx, probe.await) }
-        });
-        let probe_results = join_all(probe_futs).await;
-
-        let mut rebuild_indices = Vec::new();
-        for (idx, ok) in probe_results {
-            if ok {
-                self.mark_healthy(idx);
-            } else {
-                rebuild_indices.push(idx);
-            }
-        }
-
-        let rebuild_futs = rebuild_indices.into_iter().map(|idx| async move {
-            tracing::warn!(idx, "Heal probe failed; rebuilding JS runtime pool slot");
-            if let Err(e) = self.rebuild_slot(idx) {
-                tracing::error!(idx, error = %e, "Failed to rebuild JS runtime pool slot");
-                self.refresh_unhealthy_timestamp(idx);
+        let heal_futs = indices.into_iter().map(|idx| async move {
+            let Ok(_lease) = self.acquire_slot_lease(idx).await else {
+                return;
+            };
+            if self.is_healthy(idx) {
                 return;
             }
-            if self.probe_slot(idx, probe_timeout_ms).await {
+
+            let force_rebuild = self.needs_rebuild(idx);
+            if !force_rebuild {
+                let Some(runtime) = self.runtime_at(idx) else {
+                    return;
+                };
+                if self.probe_runtime(idx, &runtime, probe_timeout_ms).await
+                    && self.runtime_still_installed(idx, &runtime)
+                    && !self.needs_rebuild(idx)
+                {
+                    self.mark_healthy(idx);
+                    return;
+                }
+            }
+
+            tracing::warn!(idx, "Heal probe failed; rebuilding JS runtime pool slot");
+            let replacement = match self.rebuild_slot(idx) {
+                Ok(runtime) => runtime,
+                Err(e) => {
+                    tracing::error!(idx, error = %e, "Failed to rebuild JS runtime pool slot");
+                    self.refresh_unhealthy_timestamp(idx);
+                    return;
+                }
+            };
+            if self.probe_runtime(idx, &replacement, probe_timeout_ms).await
+                && self.runtime_still_installed(idx, &replacement)
+            {
+                self.clear_needs_rebuild(idx);
                 self.mark_healthy(idx);
             } else {
                 tracing::warn!(
@@ -314,13 +367,15 @@ impl JsRuntimePool {
                 self.refresh_unhealthy_timestamp(idx);
             }
         });
-        join_all(rebuild_futs).await;
+        join_all(heal_futs).await;
     }
 
-    async fn probe_slot(&self, idx: usize, probe_timeout_ms: u64) -> bool {
-        let Some(runtime) = self.runtime_at(idx) else {
-            return false;
-        };
+    async fn probe_runtime(
+        &self,
+        idx: usize,
+        runtime: &Arc<dyn JsRuntimeInterface>,
+        probe_timeout_ms: u64,
+    ) -> bool {
         let probe = time::timeout(
             Duration::from_millis(probe_timeout_ms),
             runtime.execute_script("__pool_heal_probe__".into(), "1".into()),
@@ -383,6 +438,7 @@ impl JsRuntimePool {
         let idx = handle.idx();
         let runtime = Arc::clone(handle.runtime());
         let specifier = specifier.to_string();
+        let _lease = self.acquire_slot_lease(idx).await?;
         self.run_with_timeout_on_slot(idx, "load_and_evaluate_on_picked", async move {
             let module_id = runtime.load_es_module(&specifier).await?;
             let value = runtime.evaluate_module(module_id).await?;
@@ -420,13 +476,27 @@ impl JsRuntimePool {
             let Ok(op_result) =
                 time::timeout(Duration::from_millis(timeout_ms), op(Arc::clone(&runtime))).await
             else {
-                let cleanup = runtime.clear_request_context_if_matches(Arc::clone(&ctx)).await;
+                let cleanup = time::timeout(
+                    Duration::from_millis(timeout_ms),
+                    runtime.clear_request_context_if_matches(Arc::clone(&ctx)),
+                )
+                .await;
                 pool.mark_unhealthy(idx);
-                if let Err(cleanup_err) = cleanup {
-                    tracing::error!(
-                        "Failed to clear request context after timeout: {}",
-                        cleanup_err
-                    );
+                match cleanup {
+                    Ok(Ok(())) => {}
+                    Ok(Err(cleanup_err)) => {
+                        tracing::error!(
+                            "Failed to clear request context after timeout: {}",
+                            cleanup_err
+                        );
+                        pool.mark_needs_rebuild(idx);
+                    }
+                    Err(_) => {
+                        tracing::error!(
+                            "Clearing request context timed out after {timeout_ms} ms; slot needs rebuild"
+                        );
+                        pool.mark_needs_rebuild(idx);
+                    }
                 }
                 return Err(RariError::timeout(format!(
                     "with_request_context timed out after {timeout_ms} ms"
@@ -438,6 +508,7 @@ impl JsRuntimePool {
                 (Ok(value), Ok(())) => Ok(value),
                 (Ok(_value), Err(cleanup_err)) => {
                     pool.mark_unhealthy(idx);
+                    pool.mark_needs_rebuild(idx);
                     tracing::error!(
                         "Failed to clear request context after successful operation: {}",
                         cleanup_err
@@ -447,6 +518,7 @@ impl JsRuntimePool {
                 (Err(op_err), Ok(())) => Err(op_err),
                 (Err(op_err), Err(cleanup_err)) => {
                     pool.mark_unhealthy(idx);
+                    pool.mark_needs_rebuild(idx);
                     tracing::error!(
                         "Failed to clear request context after operation error: {}",
                         cleanup_err

--- a/crates/rari/src/runtime/factory/pool/mod.rs
+++ b/crates/rari/src/runtime/factory/pool/mod.rs
@@ -205,6 +205,32 @@ impl JsRuntimePool {
         self.runtime_at(idx).is_some_and(|current| Arc::ptr_eq(&current, expected))
     }
 
+    fn heal_eligible(&self, idx: usize) -> bool {
+        if self.heal_after_ms == HEAL_DISABLED {
+            return false;
+        }
+        if self.is_healthy(idx) {
+            return false;
+        }
+        let since =
+            self.unhealthy_since_ms.get(idx).map(|s| s.load(Ordering::Acquire)).unwrap_or(0);
+        if since == 0 {
+            return false;
+        }
+        let now = unix_now_ms();
+        now.saturating_sub(since) >= self.heal_after_ms
+    }
+
+    fn slot_admissible_for_execute(
+        &self,
+        idx: usize,
+        expected: &Arc<dyn JsRuntimeInterface>,
+    ) -> bool {
+        self.is_healthy(idx)
+            && !self.needs_rebuild(idx)
+            && self.runtime_still_installed(idx, expected)
+    }
+
     pub(super) async fn acquire_slot_lease(
         &self,
         idx: usize,
@@ -217,10 +243,48 @@ impl JsRuntimePool {
         Ok(lease.lock().await)
     }
 
-    /// Replace the isolate in `idx` with a freshly constructed runtime.
+    /// Acquire a slot lease for heal work. Returns `None` when the slot is no longer
+    /// heal-eligible after waiting (quarantine refreshed or already healed elsewhere).
+    pub(super) async fn acquire_slot_lease_for_heal(
+        &self,
+        idx: usize,
+    ) -> Result<Option<AsyncMutexGuard<'_, ()>>, RariError> {
+        let guard = self.acquire_slot_lease(idx).await?;
+        if !self.heal_eligible(idx) {
+            return Ok(None);
+        }
+        Ok(Some(guard))
+    }
+
+    /// Lock the slot, then verify it is still admissible for the expected runtime.
+    pub(super) async fn acquire_slot_lease_for_execute(
+        &self,
+        idx: usize,
+        expected: &Arc<dyn JsRuntimeInterface>,
+    ) -> Result<AsyncMutexGuard<'_, ()>, RariError> {
+        let guard = self.acquire_slot_lease(idx).await?;
+        if !self.slot_admissible_for_execute(idx, expected) {
+            return Err(RariError::js_runtime(format!(
+                "JS runtime pool slot {idx} is no longer admissible for execution"
+            )));
+        }
+        Ok(guard)
+    }
+
+    pub(super) fn mark_unhealthy_if_runtime_matches(
+        &self,
+        idx: usize,
+        expected: &Arc<dyn JsRuntimeInterface>,
+    ) {
+        if self.runtime_still_installed(idx, expected) {
+            self.mark_unhealthy(idx);
+        }
+    }
+
+    /// Replace the isolate in `idx`. Caller must hold the slot lease.
     ///
     /// In-flight sticky handles keep the old `Arc` until dropped; new picks see the replacement.
-    pub fn rebuild_slot(&self, idx: usize) -> Result<Arc<dyn JsRuntimeInterface>, RariError> {
+    fn rebuild_slot_held(&self, idx: usize) -> Result<Arc<dyn JsRuntimeInterface>, RariError> {
         if idx >= self.runtimes.len() {
             return Err(RariError::js_runtime(format!(
                 "Cannot rebuild JS runtime pool slot {idx}: out of range"
@@ -286,28 +350,7 @@ impl JsRuntimePool {
     }
 
     fn expired_unhealthy_indices(&self) -> Vec<usize> {
-        if self.heal_after_ms == HEAL_DISABLED {
-            return Vec::new();
-        }
-        let now = unix_now_ms();
-        self.healthy
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, flag)| {
-                if flag.load(Ordering::Acquire) {
-                    return None;
-                }
-                let since = self
-                    .unhealthy_since_ms
-                    .get(idx)
-                    .map(|s| s.load(Ordering::Acquire))
-                    .unwrap_or(0);
-                if since == 0 {
-                    return None;
-                }
-                if now.saturating_sub(since) >= self.heal_after_ms { Some(idx) } else { None }
-            })
-            .collect()
+        (0..self.runtimes.len()).filter(|&idx| self.heal_eligible(idx)).collect()
     }
 
     /// Probe expired-unhealthy slots with a lightweight script before re-admission.
@@ -324,7 +367,10 @@ impl JsRuntimePool {
         let probe_timeout_ms = self.timeout_ms.clamp(1, 1_000);
 
         let heal_futs = indices.into_iter().map(|idx| async move {
-            let Ok(_lease) = self.acquire_slot_lease(idx).await else {
+            let Ok(guard) = self.acquire_slot_lease_for_heal(idx).await else {
+                return;
+            };
+            let Some(_lease) = guard else {
                 return;
             };
             if self.is_healthy(idx) {
@@ -346,7 +392,7 @@ impl JsRuntimePool {
             }
 
             tracing::warn!(idx, "Heal probe failed; rebuilding JS runtime pool slot");
-            let replacement = match self.rebuild_slot(idx) {
+            let replacement = match self.rebuild_slot_held(idx) {
                 Ok(runtime) => runtime,
                 Err(e) => {
                     tracing::error!(idx, error = %e, "Failed to rebuild JS runtime pool slot");
@@ -434,17 +480,32 @@ impl JsRuntimePool {
         &self,
         specifier: &str,
     ) -> Result<(ModuleId, Value), RariError> {
-        let handle = self.pick_runtime().await?;
-        let idx = handle.idx();
-        let runtime = Arc::clone(handle.runtime());
-        let specifier = specifier.to_string();
-        let _lease = self.acquire_slot_lease(idx).await?;
-        self.run_with_timeout_on_slot(idx, "load_and_evaluate_on_picked", async move {
-            let module_id = runtime.load_es_module(&specifier).await?;
-            let value = runtime.evaluate_module(module_id).await?;
-            Ok((module_id, value))
-        })
-        .await
+        for attempt in 0..2 {
+            let handle = self.pick_runtime().await?;
+            let idx = handle.idx();
+            let runtime = Arc::clone(handle.runtime());
+            let specifier = specifier.to_string();
+            let lease_result = self.acquire_slot_lease_for_execute(idx, &runtime).await;
+            match lease_result {
+                Ok(_lease) => {}
+                Err(_e) if attempt == 0 => continue,
+                Err(e) => return Err(e),
+            }
+            let runtime_for_op = Arc::clone(&runtime);
+            return self
+                .run_with_timeout_on_slot(
+                    idx,
+                    "load_and_evaluate_on_picked",
+                    &runtime,
+                    async move {
+                        let module_id = runtime_for_op.load_es_module(&specifier).await?;
+                        let value = runtime_for_op.evaluate_module(module_id).await?;
+                        Ok((module_id, value))
+                    },
+                )
+                .await;
+        }
+        Err(RariError::js_runtime("No healthy JS runtime available in pool".to_string()))
     }
 
     pub async fn with_request_context<F, Fut, T>(
@@ -481,7 +542,7 @@ impl JsRuntimePool {
                     runtime.clear_request_context_if_matches(Arc::clone(&ctx)),
                 )
                 .await;
-                pool.mark_unhealthy(idx);
+                pool.mark_unhealthy_if_runtime_matches(idx, &runtime);
                 match cleanup {
                     Ok(Ok(())) => {}
                     Ok(Err(cleanup_err)) => {
@@ -507,7 +568,7 @@ impl JsRuntimePool {
             match (op_result, cleanup) {
                 (Ok(value), Ok(())) => Ok(value),
                 (Ok(_value), Err(cleanup_err)) => {
-                    pool.mark_unhealthy(idx);
+                    pool.mark_unhealthy_if_runtime_matches(idx, &runtime);
                     pool.mark_needs_rebuild(idx);
                     tracing::error!(
                         "Failed to clear request context after successful operation: {}",
@@ -517,7 +578,7 @@ impl JsRuntimePool {
                 }
                 (Err(op_err), Ok(())) => Err(op_err),
                 (Err(op_err), Err(cleanup_err)) => {
-                    pool.mark_unhealthy(idx);
+                    pool.mark_unhealthy_if_runtime_matches(idx, &runtime);
                     pool.mark_needs_rebuild(idx);
                     tracing::error!(
                         "Failed to clear request context after operation error: {}",
@@ -535,6 +596,7 @@ impl JsRuntimePool {
         &self,
         idx: usize,
         label: &str,
+        expected: &Arc<dyn JsRuntimeInterface>,
         fut: Fut,
     ) -> Result<T, RariError>
     where
@@ -543,7 +605,7 @@ impl JsRuntimePool {
         match time::timeout(Duration::from_millis(self.timeout_ms), fut).await {
             Ok(result) => result,
             Err(_) => {
-                self.mark_unhealthy(idx);
+                self.mark_unhealthy_if_runtime_matches(idx, expected);
                 Err(RariError::timeout(format!("{label} timed out after {} ms", self.timeout_ms)))
             }
         }

--- a/crates/rari/src/runtime/factory/pool/mod.rs
+++ b/crates/rari/src/runtime/factory/pool/mod.rs
@@ -543,36 +543,15 @@ impl JsRuntimePool {
     ) -> Result<(ModuleId, Value), RariError> {
         self.probe_and_heal().await;
         let specifier = specifier.to_string();
-        let first = self.pick().ok_or_else(|| {
-            RariError::js_runtime("No healthy JS runtime available in pool".to_string())
-        })?;
-        let mut candidates: Vec<usize> = self.all_healthy_indices();
-        candidates.retain(|&i| i != first);
-        candidates.insert(0, first);
-
-        for idx in candidates {
-            let Some(runtime) = self.runtime_at(idx) else {
-                continue;
-            };
-            let Ok(_lease) = self.acquire_slot_lease_for_execute(idx, &runtime).await else {
-                continue;
-            };
-            let runtime_for_op = Arc::clone(&runtime);
+        self.execute_on_admitted_healthy_slot("load_and_evaluate_on_picked", move |runtime| {
             let specifier = specifier.clone();
-            return self
-                .run_with_timeout_on_slot(
-                    idx,
-                    "load_and_evaluate_on_picked",
-                    &runtime,
-                    async move {
-                        let module_id = runtime_for_op.load_es_module(&specifier).await?;
-                        let value = runtime_for_op.evaluate_module(module_id).await?;
-                        Ok((module_id, value))
-                    },
-                )
-                .await;
-        }
-        Err(RariError::js_runtime("No healthy JS runtime available in pool".to_string()))
+            async move {
+                let module_id = runtime.load_es_module(&specifier).await?;
+                let value = runtime.evaluate_module(module_id).await?;
+                Ok((module_id, value))
+            }
+        })
+        .await
     }
 
     pub async fn with_request_context<F, Fut, T>(
@@ -686,24 +665,5 @@ impl JsRuntimePool {
         })
         .await
         .map_err(|e| RariError::js_runtime(format!("with_request_context task join failed: {e}")))?
-    }
-
-    pub(super) async fn run_with_timeout_on_slot<T, Fut>(
-        &self,
-        idx: usize,
-        label: &str,
-        expected: &Arc<dyn JsRuntimeInterface>,
-        fut: Fut,
-    ) -> Result<T, RariError>
-    where
-        Fut: Future<Output = Result<T, RariError>>,
-    {
-        match time::timeout(Duration::from_millis(self.timeout_ms), fut).await {
-            Ok(result) => result,
-            Err(_) => {
-                self.mark_unhealthy_if_runtime_matches(idx, expected);
-                Err(RariError::timeout(format!("{label} timed out after {} ms", self.timeout_ms)))
-            }
-        }
     }
 }

--- a/crates/rari/src/runtime/factory/pool/mod.rs
+++ b/crates/rari/src/runtime/factory/pool/mod.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use deno_core::ModuleId;
+use parking_lot::RwLock;
 use rari_error::RariError;
 use rustc_hash::FxHashMap;
 use serde_json::Value;
@@ -40,8 +41,12 @@ pub const DEFAULT_HEAL_AFTER_MS: u64 = 30_000;
 /// Disable automatic healing (tests / explicit recovery only).
 pub const HEAL_DISABLED: u64 = u64::MAX;
 
+/// Creates a fresh isolate when heal rebuilds a quarantined slot.
+pub type RuntimeFactory = Arc<dyn Fn() -> Arc<dyn JsRuntimeInterface> + Send + Sync>;
+
 pub struct JsRuntimePool {
-    runtimes: Vec<Arc<dyn JsRuntimeInterface>>,
+    runtimes: Vec<RwLock<Arc<dyn JsRuntimeInterface>>>,
+    runtime_factory: RuntimeFactory,
     pick_strategy: Arc<dyn PickStrategy>,
     next_index: AtomicUsize,
     healthy: Vec<AtomicBool>,
@@ -97,10 +102,6 @@ impl JsRuntimePool {
         )
     }
 
-    #[expect(
-        clippy::needless_pass_by_value,
-        reason = "Each isolate needs an owned env map clone matching RariRuntime::new"
-    )]
     pub fn with_strategy_and_limits(
         pool_size: usize,
         env_vars: Option<FxHashMap<String, String>>,
@@ -119,15 +120,19 @@ impl JsRuntimePool {
             ));
         }
 
-        let runtimes: Vec<Arc<dyn JsRuntimeInterface>> = (0..pool_size)
-            .map(|_| Arc::new(RariRuntime::new(env_vars.clone())) as Arc<dyn JsRuntimeInterface>)
-            .collect();
+        let runtime_factory: RuntimeFactory = Arc::new(move || {
+            Arc::new(RariRuntime::new(env_vars.clone())) as Arc<dyn JsRuntimeInterface>
+        });
+
+        let runtimes: Vec<RwLock<Arc<dyn JsRuntimeInterface>>> =
+            (0..pool_size).map(|_| RwLock::new(runtime_factory())).collect();
 
         let healthy = runtimes.iter().map(|_| AtomicBool::new(true)).collect();
         let unhealthy_since_ms = runtimes.iter().map(|_| AtomicU64::new(0)).collect();
 
         Ok(Arc::new(Self {
             runtimes,
+            runtime_factory,
             pick_strategy: strategy,
             next_index: AtomicUsize::new(0),
             healthy,
@@ -151,12 +156,43 @@ impl JsRuntimePool {
     }
 
     pub fn runtime_at(&self, idx: usize) -> Option<Arc<dyn JsRuntimeInterface>> {
-        self.runtimes.get(idx).map(Arc::clone)
+        self.runtimes.get(idx).map(|slot| Arc::clone(&slot.read()))
+    }
+
+    fn replace_runtime_at(&self, idx: usize, runtime: Arc<dyn JsRuntimeInterface>) -> bool {
+        let Some(slot) = self.runtimes.get(idx) else {
+            return false;
+        };
+        *slot.write() = runtime;
+        true
+    }
+
+    fn refresh_unhealthy_timestamp(&self, idx: usize) {
+        if let Some(since) = self.unhealthy_since_ms.get(idx) {
+            since.store(unix_now_ms(), Ordering::Release);
+        }
+    }
+
+    /// Replace the isolate in `idx` with a freshly constructed runtime.
+    ///
+    /// In-flight sticky handles keep the old `Arc` until dropped; new picks see the replacement.
+    pub fn rebuild_slot(&self, idx: usize) -> Result<(), RariError> {
+        if idx >= self.runtimes.len() {
+            return Err(RariError::js_runtime(format!(
+                "Cannot rebuild JS runtime pool slot {idx}: out of range"
+            )));
+        }
+        let replacement = (self.runtime_factory)();
+        if !self.replace_runtime_at(idx, replacement) {
+            return Err(RariError::js_runtime(format!(
+                "Cannot rebuild JS runtime pool slot {idx}: slot missing"
+            )));
+        }
+        tracing::info!(idx, "Rebuilt JS runtime pool slot");
+        Ok(())
     }
 
     pub fn pick(&self) -> Option<usize> {
-        self.heal_expired();
-
         let healthy_indices: Vec<usize> = self
             .healthy
             .iter()
@@ -170,6 +206,14 @@ impl JsRuntimePool {
                 idx,
                 pool_size = self.runtimes.len(),
                 "PickStrategy returned out-of-range index"
+            );
+            return None;
+        }
+        if !healthy_indices.contains(&idx) {
+            tracing::error!(
+                idx,
+                ?healthy_indices,
+                "PickStrategy returned index not in healthy snapshot"
             );
             return None;
         }
@@ -196,24 +240,81 @@ impl JsRuntimePool {
         }
     }
 
-    /// Re-admit slots that have been unhealthy for at least `heal_after_ms`.
-    /// No-op when healing is disabled (`HEAL_DISABLED`).
-    fn heal_expired(&self) {
+    fn expired_unhealthy_indices(&self) -> Vec<usize> {
         if self.heal_after_ms == HEAL_DISABLED {
-            return;
+            return Vec::new();
         }
         let now = unix_now_ms();
-        for (idx, flag) in self.healthy.iter().enumerate() {
-            if flag.load(Ordering::Acquire) {
-                continue;
-            }
-            let since =
-                self.unhealthy_since_ms.get(idx).map(|s| s.load(Ordering::Acquire)).unwrap_or(0);
-            if since == 0 {
-                continue;
-            }
-            if now.saturating_sub(since) >= self.heal_after_ms {
+        self.healthy
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, flag)| {
+                if flag.load(Ordering::Acquire) {
+                    return None;
+                }
+                let since = self
+                    .unhealthy_since_ms
+                    .get(idx)
+                    .map(|s| s.load(Ordering::Acquire))
+                    .unwrap_or(0);
+                if since == 0 {
+                    return None;
+                }
+                if now.saturating_sub(since) >= self.heal_after_ms { Some(idx) } else { None }
+            })
+            .collect()
+    }
+
+    /// Probe expired-unhealthy slots with a lightweight script before re-admission.
+    /// Successful probes call [`Self::mark_healthy`]. Failures rebuild the isolate and
+    /// probe again; if that also fails the quarantine timestamp is refreshed.
+    pub async fn probe_and_heal(&self) {
+        let indices = self.expired_unhealthy_indices();
+        if indices.is_empty() {
+            return;
+        }
+        let probe_timeout_ms = self.timeout_ms.clamp(1, 1_000);
+        for idx in indices {
+            if self.probe_slot(idx, probe_timeout_ms).await {
                 self.mark_healthy(idx);
+                continue;
+            }
+            tracing::warn!(idx, "Heal probe failed; rebuilding JS runtime pool slot");
+            if let Err(e) = self.rebuild_slot(idx) {
+                tracing::error!(idx, error = %e, "Failed to rebuild JS runtime pool slot");
+                self.refresh_unhealthy_timestamp(idx);
+                continue;
+            }
+            if self.probe_slot(idx, probe_timeout_ms).await {
+                self.mark_healthy(idx);
+            } else {
+                tracing::warn!(
+                    idx,
+                    "Heal probe still failing after rebuild; keeping slot unhealthy"
+                );
+                self.refresh_unhealthy_timestamp(idx);
+            }
+        }
+    }
+
+    async fn probe_slot(&self, idx: usize, probe_timeout_ms: u64) -> bool {
+        let Some(runtime) = self.runtime_at(idx) else {
+            return false;
+        };
+        let probe = time::timeout(
+            Duration::from_millis(probe_timeout_ms),
+            runtime.execute_script("__pool_heal_probe__".into(), "1".into()),
+        )
+        .await;
+        match probe {
+            Ok(Ok(_)) => true,
+            Ok(Err(e)) => {
+                tracing::warn!(idx, error = %e, "Heal probe script failed");
+                false
+            }
+            Err(_) => {
+                tracing::warn!(idx, "Heal probe timed out");
+                false
             }
         }
     }
@@ -239,11 +340,14 @@ impl JsRuntimePool {
         tracing::info!("JS runtime pool setup_mode = {}", on);
     }
 
-    pub fn pick_runtime(&self) -> Result<PooledRuntime, RariError> {
+    pub async fn pick_runtime(&self) -> Result<PooledRuntime, RariError> {
+        self.probe_and_heal().await;
         let idx = self.pick().ok_or_else(|| {
             RariError::js_runtime("No healthy JS runtime available in pool".to_string())
         })?;
-        let runtime = Arc::clone(&self.runtimes[idx]);
+        let runtime = self.runtime_at(idx).ok_or_else(|| {
+            RariError::js_runtime("No healthy JS runtime available in pool".to_string())
+        })?;
         Ok(PooledRuntime::new(idx, runtime, self.timeout_ms))
     }
 
@@ -255,10 +359,11 @@ impl JsRuntimePool {
         &self,
         specifier: &str,
     ) -> Result<(ModuleId, Value), RariError> {
-        let handle = self.pick_runtime()?;
+        let handle = self.pick_runtime().await?;
+        let idx = handle.idx();
         let runtime = Arc::clone(handle.runtime());
         let specifier = specifier.to_string();
-        self.run_with_timeout("load_and_evaluate_on_picked", async move {
+        self.run_with_timeout_on_slot(idx, "load_and_evaluate_on_picked", async move {
             let module_id = runtime.load_es_module(&specifier).await?;
             let value = runtime.evaluate_module(module_id).await?;
             Ok((module_id, value))
@@ -275,36 +380,52 @@ impl JsRuntimePool {
         F: FnOnce(Arc<dyn JsRuntimeInterface>) -> Fut,
         Fut: Future<Output = Result<T, RariError>>,
     {
-        let handle = self.pick_runtime()?;
+        let handle = self.pick_runtime().await?;
+        let idx = handle.idx();
         let runtime = Arc::clone(handle.runtime());
-        self.run_with_timeout("with_request_context", async {
-            runtime.set_request_context(Arc::clone(&ctx)).await?;
-            let result = op(Arc::clone(&runtime)).await;
-            let cleanup = runtime.clear_request_context_if_matches(ctx).await;
-            match (result, cleanup) {
-                (Ok(value), Ok(())) => Ok(value),
-                (Ok(value), Err(cleanup_err)) => {
-                    tracing::error!(
-                        "Failed to clear request context after successful operation: {}",
-                        cleanup_err
-                    );
-                    Ok(value)
-                }
-                (Err(op_err), Ok(())) => Err(op_err),
-                (Err(op_err), Err(cleanup_err)) => {
-                    tracing::error!(
-                        "Failed to clear request context after operation error: {}",
-                        cleanup_err
-                    );
-                    Err(op_err)
-                }
+
+        runtime.set_request_context(Arc::clone(&ctx)).await?;
+
+        let Ok(op_result) =
+            time::timeout(Duration::from_millis(self.timeout_ms), op(Arc::clone(&runtime))).await
+        else {
+            let cleanup = runtime.clear_request_context_if_matches(Arc::clone(&ctx)).await;
+            self.mark_unhealthy(idx);
+            if let Err(cleanup_err) = cleanup {
+                tracing::error!("Failed to clear request context after timeout: {}", cleanup_err);
             }
-        })
-        .await
+            return Err(RariError::timeout(format!(
+                "with_request_context timed out after {} ms",
+                self.timeout_ms
+            )));
+        };
+
+        let cleanup = runtime.clear_request_context_if_matches(ctx).await;
+        match (op_result, cleanup) {
+            (Ok(value), Ok(())) => Ok(value),
+            (Ok(_value), Err(cleanup_err)) => {
+                self.mark_unhealthy(idx);
+                tracing::error!(
+                    "Failed to clear request context after successful operation: {}",
+                    cleanup_err
+                );
+                Err(cleanup_err)
+            }
+            (Err(op_err), Ok(())) => Err(op_err),
+            (Err(op_err), Err(cleanup_err)) => {
+                self.mark_unhealthy(idx);
+                tracing::error!(
+                    "Failed to clear request context after operation error: {}",
+                    cleanup_err
+                );
+                Err(op_err)
+            }
+        }
     }
 
-    pub(super) async fn run_with_timeout<T, Fut>(
+    pub(super) async fn run_with_timeout_on_slot<T, Fut>(
         &self,
+        idx: usize,
         label: &str,
         fut: Fut,
     ) -> Result<T, RariError>
@@ -314,6 +435,7 @@ impl JsRuntimePool {
         match time::timeout(Duration::from_millis(self.timeout_ms), fut).await {
             Ok(result) => result,
             Err(_) => {
+                self.mark_unhealthy(idx);
                 Err(RariError::timeout(format!("{label} timed out after {} ms", self.timeout_ms)))
             }
         }

--- a/crates/rari/src/runtime/factory/pool/mod.rs
+++ b/crates/rari/src/runtime/factory/pool/mod.rs
@@ -17,7 +17,7 @@ use rari_error::RariError;
 use rustc_hash::FxHashMap;
 use serde_json::Value;
 use tokio::{
-    sync::{Mutex as AsyncMutex, MutexGuard as AsyncMutexGuard},
+    sync::{Mutex as AsyncMutex, MutexGuard as AsyncMutexGuard, OwnedMutexGuard},
     time,
 };
 
@@ -271,6 +271,26 @@ impl JsRuntimePool {
         Ok(guard)
     }
 
+    /// Owned lease for work that must outlive `&self` (e.g. spawned batch forwarding).
+    pub(super) async fn acquire_owned_slot_lease_for_execute(
+        &self,
+        idx: usize,
+        expected: &Arc<dyn JsRuntimeInterface>,
+    ) -> Result<OwnedMutexGuard<()>, RariError> {
+        let Some(lease) = self.slot_leases.get(idx).cloned() else {
+            return Err(RariError::js_runtime(format!(
+                "No lease available for JS runtime pool slot {idx}"
+            )));
+        };
+        let guard = lease.lock_owned().await;
+        if !self.slot_admissible_for_execute(idx, expected) {
+            return Err(RariError::js_runtime(format!(
+                "JS runtime pool slot {idx} is no longer admissible for execution"
+            )));
+        }
+        Ok(guard)
+    }
+
     pub(super) fn mark_unhealthy_if_runtime_matches(
         &self,
         idx: usize,
@@ -279,6 +299,47 @@ impl JsRuntimePool {
         if self.runtime_still_installed(idx, expected) {
             self.mark_unhealthy(idx);
         }
+    }
+
+    /// Try each healthy slot until one admits the lease, then run `op` under timeout.
+    /// Propagates execution errors immediately; returns pool-unavailable only when every
+    /// candidate is missing or fails admission.
+    pub(super) async fn execute_on_admitted_healthy_slot<T, F, Fut>(
+        &self,
+        op_label: &str,
+        mut op: F,
+    ) -> Result<T, RariError>
+    where
+        T: Send,
+        F: FnMut(Arc<dyn JsRuntimeInterface>) -> Fut,
+        Fut: Future<Output = Result<T, RariError>> + Send,
+    {
+        let first = self.pick().ok_or_else(|| {
+            RariError::js_runtime("No healthy JS runtime available in pool".to_string())
+        })?;
+        let mut candidates: Vec<usize> = self.all_healthy_indices();
+        candidates.retain(|&i| i != first);
+        candidates.insert(0, first);
+
+        let timeout_ms = self.timeout_ms;
+        for idx in candidates {
+            let Some(runtime) = self.runtime_at(idx) else {
+                continue;
+            };
+            let Ok(_lease) = self.acquire_slot_lease_for_execute(idx, &runtime).await else {
+                continue;
+            };
+            match time::timeout(Duration::from_millis(timeout_ms), op(Arc::clone(&runtime))).await {
+                Ok(result) => return result,
+                Err(_) => {
+                    self.mark_unhealthy_if_runtime_matches(idx, &runtime);
+                    return Err(RariError::timeout(format!(
+                        "{op_label} timed out after {timeout_ms} ms"
+                    )));
+                }
+            }
+        }
+        Err(RariError::js_runtime("No healthy JS runtime available in pool".to_string()))
     }
 
     /// Replace the isolate in `idx`. Caller must hold the slot lease.
@@ -480,18 +541,24 @@ impl JsRuntimePool {
         &self,
         specifier: &str,
     ) -> Result<(ModuleId, Value), RariError> {
-        for attempt in 0..2 {
-            let handle = self.pick_runtime().await?;
-            let idx = handle.idx();
-            let runtime = Arc::clone(handle.runtime());
-            let specifier = specifier.to_string();
-            let lease_result = self.acquire_slot_lease_for_execute(idx, &runtime).await;
-            match lease_result {
-                Ok(_lease) => {}
-                Err(_e) if attempt == 0 => continue,
-                Err(e) => return Err(e),
-            }
+        self.probe_and_heal().await;
+        let specifier = specifier.to_string();
+        let first = self.pick().ok_or_else(|| {
+            RariError::js_runtime("No healthy JS runtime available in pool".to_string())
+        })?;
+        let mut candidates: Vec<usize> = self.all_healthy_indices();
+        candidates.retain(|&i| i != first);
+        candidates.insert(0, first);
+
+        for idx in candidates {
+            let Some(runtime) = self.runtime_at(idx) else {
+                continue;
+            };
+            let Ok(_lease) = self.acquire_slot_lease_for_execute(idx, &runtime).await else {
+                continue;
+            };
             let runtime_for_op = Arc::clone(&runtime);
+            let specifier = specifier.clone();
             return self
                 .run_with_timeout_on_slot(
                     idx,
@@ -521,18 +588,28 @@ impl JsRuntimePool {
         let handle = self.pick_runtime().await?;
         let idx = handle.idx();
         let runtime = Arc::clone(handle.runtime());
-        let Some(lease) = self.slot_leases.get(idx).cloned() else {
-            return Err(RariError::js_runtime(format!(
-                "No lease available for JS runtime pool slot {idx}"
-            )));
-        };
         let pool = Arc::clone(self);
         let timeout_ms = self.timeout_ms;
 
         tokio::spawn(async move {
-            let _lease_guard = lease.lock_owned().await;
+            let _lease_guard = pool.acquire_slot_lease_for_execute(idx, &runtime).await?;
 
-            runtime.set_request_context(Arc::clone(&ctx)).await?;
+            match time::timeout(
+                Duration::from_millis(timeout_ms),
+                runtime.set_request_context(Arc::clone(&ctx)),
+            )
+            .await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => return Err(e),
+                Err(_) => {
+                    pool.mark_unhealthy_if_runtime_matches(idx, &runtime);
+                    pool.mark_needs_rebuild(idx);
+                    return Err(RariError::timeout(format!(
+                        "set_request_context timed out after {timeout_ms} ms"
+                    )));
+                }
+            }
 
             let Ok(op_result) =
                 time::timeout(Duration::from_millis(timeout_ms), op(Arc::clone(&runtime))).await
@@ -564,10 +641,14 @@ impl JsRuntimePool {
                 )));
             };
 
-            let cleanup = runtime.clear_request_context_if_matches(ctx).await;
+            let cleanup = time::timeout(
+                Duration::from_millis(timeout_ms),
+                runtime.clear_request_context_if_matches(ctx),
+            )
+            .await;
             match (op_result, cleanup) {
-                (Ok(value), Ok(())) => Ok(value),
-                (Ok(_value), Err(cleanup_err)) => {
+                (Ok(value), Ok(Ok(()))) => Ok(value),
+                (Ok(_value), Ok(Err(cleanup_err))) => {
                     pool.mark_unhealthy_if_runtime_matches(idx, &runtime);
                     pool.mark_needs_rebuild(idx);
                     tracing::error!(
@@ -576,13 +657,28 @@ impl JsRuntimePool {
                     );
                     Err(cleanup_err)
                 }
-                (Err(op_err), Ok(())) => Err(op_err),
-                (Err(op_err), Err(cleanup_err)) => {
+                (Ok(_value), Err(_)) => {
+                    pool.mark_unhealthy_if_runtime_matches(idx, &runtime);
+                    pool.mark_needs_rebuild(idx);
+                    Err(RariError::timeout(format!(
+                        "clear_request_context timed out after {timeout_ms} ms"
+                    )))
+                }
+                (Err(op_err), Ok(Ok(()))) => Err(op_err),
+                (Err(op_err), Ok(Err(cleanup_err))) => {
                     pool.mark_unhealthy_if_runtime_matches(idx, &runtime);
                     pool.mark_needs_rebuild(idx);
                     tracing::error!(
                         "Failed to clear request context after operation error: {}",
                         cleanup_err
+                    );
+                    Err(op_err)
+                }
+                (Err(op_err), Err(_)) => {
+                    pool.mark_unhealthy_if_runtime_matches(idx, &runtime);
+                    pool.mark_needs_rebuild(idx);
+                    tracing::error!(
+                        "Clearing request context timed out after {timeout_ms} ms"
                     );
                     Err(op_err)
                 }

--- a/crates/rari/src/runtime/factory/pool/strategy.rs
+++ b/crates/rari/src/runtime/factory/pool/strategy.rs
@@ -1,0 +1,19 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+pub trait PickStrategy: Send + Sync {
+    fn pick(&self, healthy_indices: &[usize], next: &AtomicUsize) -> Option<usize>;
+}
+
+#[non_exhaustive]
+pub struct RoundRobinStrategy;
+
+impl PickStrategy for RoundRobinStrategy {
+    fn pick(&self, healthy_indices: &[usize], next: &AtomicUsize) -> Option<usize> {
+        if healthy_indices.is_empty() {
+            None
+        } else {
+            let pos = next.fetch_add(1, Ordering::Relaxed) % healthy_indices.len();
+            Some(healthy_indices[pos])
+        }
+    }
+}

--- a/crates/rari/src/runtime/factory/pool/tests.rs
+++ b/crates/rari/src/runtime/factory/pool/tests.rs
@@ -1,0 +1,1017 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use rari_error::RariError;
+use serde_json::{Value, json};
+use tokio::{sync::mpsc, time::sleep};
+
+use super::*;
+use crate::server::middleware::request_context::RequestContext;
+
+struct CountingRuntime {
+    calls: Arc<AtomicUsize>,
+    hang_script: Arc<AtomicBool>,
+}
+
+impl CountingRuntime {
+    fn new(calls: Arc<AtomicUsize>) -> Self {
+        Self { calls, hang_script: Arc::new(AtomicBool::new(false)) }
+    }
+}
+
+impl JsRuntimeInterface for CountingRuntime {
+    fn execute_script(
+        &self,
+        _script_name: String,
+        _script_code: String,
+    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send>> {
+        let calls = Arc::clone(&self.calls);
+        let hang = self.hang_script.load(Ordering::SeqCst);
+        Box::pin(async move {
+            if hang {
+                sleep(Duration::from_secs(60)).await;
+            }
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(json!({"ok": true}))
+        })
+    }
+
+    fn execute_script_batch(
+        &self,
+        _scripts: Vec<(String, String)>,
+    ) -> Pin<
+        Box<dyn Future<Output = mpsc::UnboundedReceiver<(usize, Result<Value, RariError>)>> + Send>,
+    > {
+        let (_tx, rx) = mpsc::unbounded_channel();
+        Box::pin(async move { rx })
+    }
+
+    fn execute_function(
+        &self,
+        _function_name: &str,
+        _args: Vec<Value>,
+    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send + 'static>> {
+        Box::pin(async move { Ok(json!(null)) })
+    }
+
+    fn add_module_to_loader(
+        &self,
+        _specifier: &str,
+        _code: String,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn load_es_module(
+        &self,
+        _specifier: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<deno_core::ModuleId, RariError>> + Send>> {
+        Box::pin(async move { Ok(0) })
+    }
+
+    fn evaluate_module(
+        &self,
+        _module_id: deno_core::ModuleId,
+    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send>> {
+        Box::pin(async move { Ok(json!(null)) })
+    }
+
+    fn get_module_namespace(
+        &self,
+        _module_id: deno_core::ModuleId,
+    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send>> {
+        Box::pin(async move { Ok(json!(null)) })
+    }
+
+    fn clear_module_loader_caches(
+        &self,
+        _component_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn set_request_context(
+        &self,
+        _request_context: Arc<RequestContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn clear_request_context(&self) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn clear_request_context_if_matches(
+        &self,
+        _expected_context: Arc<RequestContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn execute_script_with_request_context(
+        &self,
+        _request_context: Arc<RequestContext>,
+        script_name: String,
+        script_code: String,
+    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send>> {
+        self.execute_script(script_name, script_code)
+    }
+
+    fn execute_script_for_streaming(
+        &self,
+        _script_name: String,
+        _script_code: String,
+        _chunk_sender: mpsc::Sender<Result<Vec<u8>, RariError>>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+}
+
+fn build_pool_with_counters(size: usize) -> (Arc<JsRuntimePool>, Vec<Arc<AtomicUsize>>) {
+    let mut runtimes: Vec<Arc<dyn JsRuntimeInterface>> = Vec::with_capacity(size);
+    let mut counters: Vec<Arc<AtomicUsize>> = Vec::with_capacity(size);
+
+    for _ in 0..size {
+        let counter = Arc::new(AtomicUsize::new(0));
+        counters.push(Arc::clone(&counter));
+        let runtime = CountingRuntime::new(Arc::clone(&counter));
+        runtimes.push(Arc::new(runtime));
+    }
+
+    let healthy = (0..size).map(|_| AtomicBool::new(true)).collect();
+    let unhealthy_since_ms = (0..size).map(|_| AtomicU64::new(0)).collect();
+
+    let pool = Arc::new(JsRuntimePool {
+        runtimes,
+        pick_strategy: Arc::new(RoundRobinStrategy),
+        next_index: AtomicUsize::new(0),
+        healthy,
+        unhealthy_since_ms,
+        setup_mode: AtomicBool::new(false),
+        timeout_ms: DEFAULT_TIMEOUT_MS,
+        heal_after_ms: HEAL_DISABLED,
+    });
+
+    (pool, counters)
+}
+
+#[tokio::test]
+async fn round_robin_distributes_across_runtimes() -> Result<(), RariError> {
+    let (pool, counters) = build_pool_with_counters(3);
+
+    for _ in 0..9 {
+        pool.execute_script("test".into(), "1+1".into()).await?;
+    }
+
+    assert_eq!(counters[0].load(Ordering::SeqCst), 3);
+    assert_eq!(counters[1].load(Ordering::SeqCst), 3);
+    assert_eq!(counters[2].load(Ordering::SeqCst), 3);
+    Ok(())
+}
+
+#[tokio::test]
+async fn pool_size_zero_is_rejected() {
+    let result = JsRuntimePool::new(0, None);
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn pool_size_one_picks_always_index_zero() -> Result<(), RariError> {
+    let (pool, counters) = build_pool_with_counters(1);
+
+    for _ in 0..5 {
+        pool.execute_script("test".into(), "1+1".into()).await?;
+    }
+
+    assert_eq!(counters[0].load(Ordering::SeqCst), 5);
+    Ok(())
+}
+
+#[tokio::test]
+async fn mark_unhealthy_changes_round_robin_distribution() -> Result<(), RariError> {
+    let (pool, counters) = build_pool_with_counters(3);
+
+    pool.mark_unhealthy(0);
+    pool.mark_unhealthy(2);
+
+    for _ in 0..6 {
+        pool.execute_script("test".into(), "1+1".into()).await?;
+    }
+
+    assert_eq!(counters[0].load(Ordering::SeqCst), 0);
+    assert_eq!(counters[2].load(Ordering::SeqCst), 0);
+    assert!(counters[1].load(Ordering::SeqCst) >= 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn mark_healthy_restores_round_robin() -> Result<(), RariError> {
+    let (pool, counters) = build_pool_with_counters(3);
+
+    pool.mark_unhealthy(1);
+
+    for _ in 0..3 {
+        pool.execute_script("test".into(), "1+1".into()).await?;
+    }
+    let before = counters[1].load(Ordering::SeqCst);
+    assert_eq!(before, 0);
+
+    pool.mark_healthy(1);
+
+    for _ in 0..3 {
+        pool.execute_script("test".into(), "1+1".into()).await?;
+    }
+
+    assert!(counters[1].load(Ordering::SeqCst) > before);
+    Ok(())
+}
+
+#[tokio::test]
+async fn heal_expired_re_admits_unhealthy_slots() -> Result<(), RariError> {
+    let (_unused, counters) = build_pool_with_counters(2);
+    let runtimes = (0..2)
+        .map(|i| {
+            Arc::new(CountingRuntime::new(Arc::clone(&counters[i]))) as Arc<dyn JsRuntimeInterface>
+        })
+        .collect::<Vec<_>>();
+    let pool = Arc::new(JsRuntimePool {
+        runtimes,
+        pick_strategy: Arc::new(RoundRobinStrategy),
+        next_index: AtomicUsize::new(0),
+        healthy: (0..2).map(|_| AtomicBool::new(true)).collect(),
+        unhealthy_since_ms: (0..2).map(|_| AtomicU64::new(0)).collect(),
+        setup_mode: AtomicBool::new(false),
+        timeout_ms: DEFAULT_TIMEOUT_MS,
+        heal_after_ms: 1,
+    });
+
+    pool.mark_unhealthy(0);
+    assert!(!pool.is_healthy(0));
+
+    sleep(Duration::from_millis(5)).await;
+    let _ = pool.pick();
+    assert!(pool.is_healthy(0), "expired unhealthy slot should be healed on pick");
+    Ok(())
+}
+
+#[tokio::test]
+async fn execute_script_times_out_when_runtime_hangs() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let runtime = CountingRuntime::new(Arc::clone(&calls));
+    runtime.hang_script.store(true, Ordering::SeqCst);
+
+    let pool = Arc::new(JsRuntimePool {
+        runtimes: vec![Arc::new(runtime)],
+        pick_strategy: Arc::new(RoundRobinStrategy),
+        next_index: AtomicUsize::new(0),
+        healthy: vec![AtomicBool::new(true)],
+        unhealthy_since_ms: vec![AtomicU64::new(0)],
+        setup_mode: AtomicBool::new(false),
+        timeout_ms: 20,
+        heal_after_ms: HEAL_DISABLED,
+    });
+
+    let result = pool.execute_script("hang.js".into(), "1".into()).await;
+    assert!(result.is_err(), "expected timeout error");
+    let msg = match result {
+        Ok(_) => String::new(),
+        Err(e) => e.to_string(),
+    };
+    assert!(msg.contains("timed out"), "got: {msg}");
+}
+
+#[test]
+fn healthy_count_tracks_marks() {
+    let (pool, _) = build_pool_with_counters(4);
+    assert_eq!(pool.healthy_count(), 4);
+
+    pool.mark_unhealthy(1);
+    pool.mark_unhealthy(3);
+    assert_eq!(pool.healthy_count(), 2);
+
+    pool.mark_healthy(1);
+    assert_eq!(pool.healthy_count(), 3);
+
+    assert_eq!(pool.all_healthy_indices(), vec![0, 1, 2]);
+}
+
+struct BroadcastingRuntime {
+    fail_next: Arc<AtomicBool>,
+}
+
+impl JsRuntimeInterface for BroadcastingRuntime {
+    fn execute_script(
+        &self,
+        _script_name: String,
+        _script_code: String,
+    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send>> {
+        let fail = Arc::clone(&self.fail_next);
+        Box::pin(async move {
+            if fail.load(Ordering::SeqCst) {
+                Err(RariError::js_runtime("simulated failure".to_string()))
+            } else {
+                Ok(json!({"ok": true}))
+            }
+        })
+    }
+
+    fn execute_script_batch(
+        &self,
+        _scripts: Vec<(String, String)>,
+    ) -> Pin<
+        Box<dyn Future<Output = mpsc::UnboundedReceiver<(usize, Result<Value, RariError>)>> + Send>,
+    > {
+        let (_tx, rx) = mpsc::unbounded_channel();
+        Box::pin(async move { rx })
+    }
+
+    fn execute_function(
+        &self,
+        _function_name: &str,
+        _args: Vec<Value>,
+    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send + 'static>> {
+        Box::pin(async move { Ok(json!(null)) })
+    }
+
+    fn add_module_to_loader(
+        &self,
+        _specifier: &str,
+        _code: String,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        let fail = Arc::clone(&self.fail_next);
+        Box::pin(async move {
+            if fail.load(Ordering::SeqCst) {
+                Err(RariError::js_runtime("simulated load failure".to_string()))
+            } else {
+                Ok(())
+            }
+        })
+    }
+
+    fn load_es_module(
+        &self,
+        _specifier: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<deno_core::ModuleId, RariError>> + Send>> {
+        Box::pin(async move { Ok(0) })
+    }
+
+    fn evaluate_module(
+        &self,
+        _module_id: deno_core::ModuleId,
+    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send>> {
+        let fail = Arc::clone(&self.fail_next);
+        Box::pin(async move {
+            if fail.load(Ordering::SeqCst) {
+                Err(RariError::js_runtime("simulated evaluate failure".to_string()))
+            } else {
+                Ok(json!(null))
+            }
+        })
+    }
+
+    fn get_module_namespace(
+        &self,
+        _module_id: deno_core::ModuleId,
+    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send>> {
+        Box::pin(async move { Ok(json!(null)) })
+    }
+
+    fn clear_module_loader_caches(
+        &self,
+        _component_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn set_request_context(
+        &self,
+        _request_context: Arc<RequestContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn clear_request_context(&self) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn clear_request_context_if_matches(
+        &self,
+        _expected_context: Arc<RequestContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn execute_script_with_request_context(
+        &self,
+        _request_context: Arc<RequestContext>,
+        script_name: String,
+        script_code: String,
+    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send>> {
+        self.execute_script(script_name, script_code)
+    }
+
+    fn execute_script_for_streaming(
+        &self,
+        _script_name: String,
+        _script_code: String,
+        _chunk_sender: mpsc::Sender<Result<Vec<u8>, RariError>>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+}
+
+fn build_pool_with_fail_flags(size: usize) -> (Arc<JsRuntimePool>, Vec<Arc<AtomicBool>>) {
+    let mut runtimes: Vec<Arc<dyn JsRuntimeInterface>> = Vec::with_capacity(size);
+    let mut flags: Vec<Arc<AtomicBool>> = Vec::with_capacity(size);
+
+    for _ in 0..size {
+        let flag = Arc::new(AtomicBool::new(false));
+        flags.push(Arc::clone(&flag));
+        runtimes.push(Arc::new(BroadcastingRuntime { fail_next: Arc::clone(&flag) }));
+    }
+
+    let healthy = (0..size).map(|_| AtomicBool::new(true)).collect();
+    let unhealthy_since_ms = (0..size).map(|_| AtomicU64::new(0)).collect();
+
+    let pool = Arc::new(JsRuntimePool {
+        runtimes,
+        pick_strategy: Arc::new(RoundRobinStrategy),
+        next_index: AtomicUsize::new(0),
+        healthy,
+        unhealthy_since_ms,
+        setup_mode: AtomicBool::new(false),
+        timeout_ms: DEFAULT_TIMEOUT_MS,
+        heal_after_ms: HEAL_DISABLED,
+    });
+
+    (pool, flags)
+}
+
+#[tokio::test]
+async fn setup_mode_broadcasts_to_all_runtimes() -> Result<(), RariError> {
+    let (pool, counters) = build_pool_with_counters(3);
+
+    pool.set_setup_mode(true);
+    pool.execute_script("setup.js".into(), "init".into()).await?;
+
+    assert_eq!(counters[0].load(Ordering::SeqCst), 1);
+    assert_eq!(counters[1].load(Ordering::SeqCst), 1);
+    assert_eq!(counters[2].load(Ordering::SeqCst), 1);
+
+    pool.set_setup_mode(false);
+    for _ in 0..6 {
+        pool.execute_script("req.js".into(), "go".into()).await?;
+    }
+
+    assert_eq!(counters[0].load(Ordering::SeqCst), 3);
+    assert_eq!(counters[1].load(Ordering::SeqCst), 3);
+    assert_eq!(counters[2].load(Ordering::SeqCst), 3);
+    Ok(())
+}
+
+#[tokio::test]
+async fn setup_mode_aggregates_errors() {
+    let (pool, flags) = build_pool_with_fail_flags(3);
+
+    pool.set_setup_mode(true);
+    flags[1].store(true, Ordering::SeqCst);
+
+    let result = pool.execute_script("setup.js".into(), "init".into()).await;
+    assert!(result.is_err());
+    let err_msg = match result {
+        Ok(_) => String::new(),
+        Err(e) => e.to_string(),
+    };
+    assert!(err_msg.contains("1 of 3 runtimes"), "got: {err_msg}");
+}
+
+#[tokio::test]
+async fn setup_mode_returns_pool_unavailable_when_all_unhealthy() {
+    let (pool, _counters) = build_pool_with_counters(2);
+    pool.mark_unhealthy(0);
+    pool.mark_unhealthy(1);
+    pool.set_setup_mode(true);
+
+    let result = pool.execute_script("setup.js".into(), "init".into()).await;
+    assert!(result.is_err(), "setup-mode broadcast with zero healthy runtimes must not return Ok");
+    let err_msg = match result {
+        Ok(_) => String::new(),
+        Err(e) => e.to_string(),
+    };
+    assert!(err_msg.contains("No healthy JS runtime available in pool"), "got: {err_msg}");
+}
+
+#[tokio::test]
+async fn invalidate_component_all_returns_error_when_some_runtime_fails() {
+    let (pool, flags) = build_pool_with_fail_flags(2);
+
+    flags[1].store(true, Ordering::SeqCst);
+
+    let result = pool.invalidate_component_all("MyComponent").await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn invalidate_component_all_succeeds_when_all_runtimes_ok() {
+    let (pool, _flags) = build_pool_with_fail_flags(2);
+
+    let result = pool.invalidate_component_all("MyComponent").await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn broadcast_load_and_evaluate_module_reports_evaluate_failures() {
+    let (pool, flags) = build_pool_with_fail_flags(2);
+    flags[1].store(true, Ordering::SeqCst);
+
+    let result = pool.broadcast_load_and_evaluate_module("MyComponent").await;
+    assert!(result.is_err());
+    let msg = match result {
+        Ok(()) => String::new(),
+        Err(e) => e.to_string(),
+    };
+
+    assert!(msg.contains("runtime[1].evaluate_module"), "got: {msg}");
+    assert!(!msg.contains("runtime[1].load_es_module"), "got: {msg}");
+}
+
+#[tokio::test]
+async fn pool_size_one_behaves_like_single_runtime() -> Result<(), RariError> {
+    let (pool, counters) = build_pool_with_counters(1);
+
+    for _ in 0..5 {
+        pool.execute_script("test".into(), "1+1".into()).await?;
+    }
+
+    assert_eq!(counters[0].load(Ordering::SeqCst), 5);
+    Ok(())
+}
+
+#[test]
+fn pick_returns_none_when_all_unhealthy() {
+    let (pool, _) = build_pool_with_counters(2);
+    pool.mark_unhealthy(0);
+    pool.mark_unhealthy(1);
+    assert!(pool.pick().is_none());
+}
+
+#[tokio::test]
+async fn execute_script_returns_pool_unavailable_when_all_unhealthy() {
+    let (pool, counters) = build_pool_with_counters(2);
+    pool.mark_unhealthy(0);
+    pool.mark_unhealthy(1);
+
+    let result = pool.execute_script("x.js".into(), "1".into()).await;
+    assert!(result.is_err());
+    let msg = match result {
+        Ok(_) => String::new(),
+        Err(e) => e.to_string(),
+    };
+    assert!(msg.contains("No healthy JS runtime available in pool"), "got: {msg}");
+
+    assert_eq!(counters[0].load(Ordering::SeqCst), 0);
+    assert_eq!(counters[1].load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn execute_script_batch_emits_pool_unavailable_for_each_script_when_all_unhealthy()
+-> Result<(), RariError> {
+    let (pool, _counters) = build_pool_with_counters(2);
+    pool.mark_unhealthy(0);
+    pool.mark_unhealthy(1);
+
+    let scripts = vec![
+        ("a".to_string(), "1".to_string()),
+        ("b".to_string(), "2".to_string()),
+        ("c".to_string(), "3".to_string()),
+    ];
+    let expected_len = scripts.len();
+    let mut rx = pool.execute_script_batch(scripts).await;
+
+    let mut errors: Vec<(usize, String)> = Vec::new();
+    for _ in 0..expected_len {
+        match rx.recv().await {
+            Some((idx, Err(e))) => errors.push((idx, e.to_string())),
+            Some((idx, Ok(_))) => {
+                return Err(RariError::js_runtime(format!("expected error at idx {idx}, got Ok")));
+            }
+            None => {
+                return Err(RariError::js_runtime(format!(
+                    "channel closed before receiving all {expected_len} errors"
+                )));
+            }
+        }
+    }
+    assert_eq!(rx.recv().await, None, "receiver should be closed after N errors");
+
+    assert_eq!(errors.len(), expected_len);
+    let mut indices: Vec<usize> = errors.iter().map(|(i, _)| *i).collect();
+    indices.sort_unstable();
+    assert_eq!(indices, vec![0, 1, 2]);
+    for (_, msg) in &errors {
+        assert!(msg.contains("No healthy JS runtime available in pool"), "got: {msg}");
+    }
+    Ok(())
+}
+
+#[test]
+fn pick_runtime_returns_error_when_all_unhealthy() {
+    let (pool, _) = build_pool_with_counters(2);
+    pool.mark_unhealthy(0);
+    pool.mark_unhealthy(1);
+    assert!(pool.pick_runtime().is_err());
+}
+
+#[tokio::test]
+async fn pooled_runtime_is_sticky_across_calls() -> Result<(), RariError> {
+    let (pool, _counters) = build_pool_with_counters(3);
+    let handle = pool.pick_runtime()?;
+    let expected_idx = handle.idx();
+    let expected_runtime = Arc::clone(handle.runtime());
+
+    for i in 0..3 {
+        if i != expected_idx {
+            pool.mark_unhealthy(i);
+        }
+    }
+
+    assert!(Arc::ptr_eq(handle.runtime(), &expected_runtime));
+    assert_eq!(handle.idx(), expected_idx);
+
+    pool.mark_unhealthy(expected_idx);
+
+    assert!(Arc::ptr_eq(handle.runtime(), &expected_runtime));
+    assert_eq!(handle.idx(), expected_idx);
+    Ok(())
+}
+
+#[tokio::test]
+async fn pooled_runtime_routes_through_self_runtime_after_pool_changes() -> Result<(), RariError> {
+    let (pool, counters) = build_pool_with_counters(3);
+    let handle = pool.pick_runtime()?;
+    let picked_idx = handle.idx();
+
+    pool.mark_unhealthy(0);
+    pool.mark_unhealthy(2);
+
+    handle.execute_script("s.js".into(), "x".into()).await?;
+    handle.execute_script("s.js".into(), "y".into()).await?;
+
+    assert_eq!(counters[picked_idx].load(Ordering::SeqCst), 2);
+    assert_eq!(counters[(picked_idx + 1) % 3].load(Ordering::SeqCst), 0);
+    Ok(())
+}
+
+struct RequestContextRuntime {
+    last_seen: Arc<Mutex<Option<Arc<RequestContext>>>>,
+    fail_cleanup: Arc<AtomicBool>,
+}
+
+impl JsRuntimeInterface for RequestContextRuntime {
+    fn execute_script(
+        &self,
+        _script_name: String,
+        _script_code: String,
+    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send>> {
+        Box::pin(async move { Ok(json!({"ok": true})) })
+    }
+
+    fn execute_script_batch(
+        &self,
+        _scripts: Vec<(String, String)>,
+    ) -> Pin<
+        Box<dyn Future<Output = mpsc::UnboundedReceiver<(usize, Result<Value, RariError>)>> + Send>,
+    > {
+        let (_tx, rx) = mpsc::unbounded_channel();
+        Box::pin(async move { rx })
+    }
+
+    fn execute_function(
+        &self,
+        _function_name: &str,
+        _args: Vec<Value>,
+    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send + 'static>> {
+        Box::pin(async move { Ok(json!(null)) })
+    }
+
+    fn add_module_to_loader(
+        &self,
+        _specifier: &str,
+        _code: String,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn load_es_module(
+        &self,
+        _specifier: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<deno_core::ModuleId, RariError>> + Send>> {
+        Box::pin(async move { Ok(0) })
+    }
+
+    fn evaluate_module(
+        &self,
+        _module_id: deno_core::ModuleId,
+    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send>> {
+        Box::pin(async move { Ok(json!(null)) })
+    }
+
+    fn get_module_namespace(
+        &self,
+        _module_id: deno_core::ModuleId,
+    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send>> {
+        Box::pin(async move { Ok(json!(null)) })
+    }
+
+    fn clear_module_loader_caches(
+        &self,
+        _component_id: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn set_request_context(
+        &self,
+        request_context: Arc<RequestContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        let last_seen = Arc::clone(&self.last_seen);
+        Box::pin(async move {
+            let mut guard = last_seen
+                .lock()
+                .map_err(|_| RariError::js_runtime("request context mutex poisoned".to_string()))?;
+            *guard = Some(Arc::clone(&request_context));
+            Ok(())
+        })
+    }
+
+    fn clear_request_context(&self) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn clear_request_context_if_matches(
+        &self,
+        expected_context: Arc<RequestContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        let last_seen = Arc::clone(&self.last_seen);
+        let fail_cleanup = Arc::clone(&self.fail_cleanup);
+        Box::pin(async move {
+            if fail_cleanup.load(Ordering::Acquire) {
+                return Err(RariError::js_runtime("forced cleanup failure".to_string()));
+            }
+            let mut guard = last_seen
+                .lock()
+                .map_err(|_| RariError::js_runtime("request context mutex poisoned".to_string()))?;
+            if let Some(current) = guard.as_ref() {
+                if Arc::ptr_eq(current, &expected_context) {
+                    *guard = None;
+                    return Ok(());
+                }
+                return Err(RariError::js_runtime("request context mismatch on clear".to_string()));
+            }
+            Err(RariError::js_runtime("no request context to clear".to_string()))
+        })
+    }
+
+    fn execute_script_with_request_context(
+        &self,
+        _request_context: Arc<RequestContext>,
+        script_name: String,
+        script_code: String,
+    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send>> {
+        self.execute_script(script_name, script_code)
+    }
+
+    fn execute_script_for_streaming(
+        &self,
+        _script_name: String,
+        _script_code: String,
+        _chunk_sender: mpsc::Sender<Result<Vec<u8>, RariError>>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+}
+
+type LastSeenSlot = Arc<Mutex<Option<Arc<RequestContext>>>>;
+
+fn build_pool_with_distinct_request_context_runtimes(
+    size: usize,
+) -> (Arc<JsRuntimePool>, Vec<LastSeenSlot>) {
+    let last_seens: Vec<LastSeenSlot> = (0..size).map(|_| Arc::new(Mutex::new(None))).collect();
+    let runtimes: Vec<Arc<dyn JsRuntimeInterface>> = last_seens
+        .iter()
+        .map(|ls| {
+            Arc::new(RequestContextRuntime {
+                last_seen: Arc::clone(ls),
+                fail_cleanup: Arc::new(AtomicBool::new(false)),
+            }) as Arc<dyn JsRuntimeInterface>
+        })
+        .collect();
+    let healthy = runtimes.iter().map(|_| AtomicBool::new(true)).collect();
+    let unhealthy_since_ms = runtimes.iter().map(|_| AtomicU64::new(0)).collect();
+    let pool = Arc::new(JsRuntimePool {
+        runtimes,
+        pick_strategy: Arc::new(RoundRobinStrategy),
+        next_index: AtomicUsize::new(0),
+        healthy,
+        unhealthy_since_ms,
+        setup_mode: AtomicBool::new(false),
+        timeout_ms: DEFAULT_TIMEOUT_MS,
+        heal_after_ms: HEAL_DISABLED,
+    });
+    (pool, last_seens)
+}
+
+#[tokio::test]
+async fn pooled_runtime_set_and_clear_request_context_round_trip() -> Result<(), RariError> {
+    let (pool, last_seens) = build_pool_with_distinct_request_context_runtimes(2);
+
+    let handle = pool.pick_runtime()?;
+    let picked_idx = handle.idx();
+    let ctx = Arc::new(RequestContext::new("/test".to_string()));
+
+    handle.set_request_context(Arc::clone(&ctx)).await?;
+    assert!(
+        last_seens[picked_idx].lock().map(|guard| guard.is_some()).unwrap_or(false),
+        "set_request_context must touch the picked runtime, not another slot"
+    );
+    for (i, ls) in last_seens.iter().enumerate() {
+        if i != picked_idx {
+            assert!(
+                ls.lock().map(|guard| guard.is_none()).unwrap_or(true),
+                "non-picked runtime {i} must not be touched"
+            );
+        }
+    }
+
+    handle.clear_request_context_if_matches(Arc::clone(&ctx)).await?;
+    assert!(
+        last_seens[picked_idx].lock().map(|guard| guard.is_none()).unwrap_or(false),
+        "clear must touch the same runtime that was set"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn load_and_evaluate_on_picked_returns_ok_on_healthy_pool() -> Result<(), RariError> {
+    let (pool, _counters) = build_pool_with_counters(2);
+    let result = pool.load_and_evaluate_on_picked("m.js").await;
+    assert!(result.is_ok(), "load_and_evaluate_on_picked should succeed on healthy pool");
+    let (module_id, _) = result?;
+    assert_eq!(module_id, 0, "fake CountingRuntime returns Ok(0) for load_es_module");
+    Ok(())
+}
+
+#[tokio::test]
+async fn load_and_evaluate_on_picked_returns_pool_unavailable_when_all_unhealthy() {
+    let (pool, _counters) = build_pool_with_counters(2);
+    pool.mark_unhealthy(0);
+    pool.mark_unhealthy(1);
+
+    let result = pool.load_and_evaluate_on_picked("m.js").await;
+    assert!(result.is_err());
+    let msg = match result {
+        Ok(_) => String::new(),
+        Err(e) => e.to_string(),
+    };
+    assert!(msg.contains("No healthy JS runtime available in pool"), "got: {msg}");
+}
+
+#[tokio::test]
+async fn with_request_context_runs_op_and_cleans_up() {
+    let (pool, last_seens) = build_pool_with_distinct_request_context_runtimes(2);
+
+    let ctx = Arc::new(RequestContext::new("/with_req_ctx".to_string()));
+    let ctx_for_op = Arc::clone(&ctx);
+
+    let observed_during_op = Arc::new(Mutex::new(false));
+
+    let observed_inside = Arc::clone(&observed_during_op);
+    let result = pool
+        .with_request_context(Arc::clone(&ctx), move |runtime| {
+            let observed = observed_inside;
+            let ctx_for_op = ctx_for_op;
+            async move {
+                let _ = runtime.execute_script("noop".into(), "1".into()).await?;
+                let mut observed = observed
+                    .lock()
+                    .map_err(|_| RariError::js_runtime("observed mutex poisoned".to_string()))?;
+                *observed = true;
+                drop(observed);
+                let _ = ctx_for_op;
+                Ok::<_, RariError>(())
+            }
+        })
+        .await;
+
+    assert!(result.is_ok());
+    assert!(
+        observed_during_op.lock().map(|guard| *guard).unwrap_or(false),
+        "op must have executed on a runtime"
+    );
+    let touched: Vec<usize> = last_seens
+        .iter()
+        .enumerate()
+        .filter_map(|(i, ls)| {
+            if ls.lock().map(|guard| guard.is_some()).unwrap_or(false) { Some(i) } else { None }
+        })
+        .collect();
+    assert_eq!(
+        touched.len(),
+        0,
+        "no runtime should retain ctx after with_request_context returns; touched: {touched:?}"
+    );
+}
+
+#[tokio::test]
+async fn with_request_context_cleans_up_even_when_op_errors() {
+    let (pool, last_seens) = build_pool_with_distinct_request_context_runtimes(1);
+
+    let ctx = Arc::new(RequestContext::new("/error_path".to_string()));
+
+    let result = pool
+        .with_request_context(Arc::clone(&ctx), |_runtime| async {
+            Err::<(), _>(RariError::js_runtime("op failed".to_string()))
+        })
+        .await;
+
+    assert!(result.is_err());
+    assert!(
+        last_seens[0].lock().map(|guard| guard.is_none()).unwrap_or(false),
+        "ctx must be cleared even when op returns Err"
+    );
+}
+
+#[tokio::test]
+async fn with_request_context_returns_op_value_when_cleanup_fails() -> Result<(), RariError> {
+    let fail_flag = Arc::new(AtomicBool::new(true));
+    let last_seen = Arc::new(Mutex::new(None));
+    let runtime: Arc<dyn JsRuntimeInterface> = Arc::new(RequestContextRuntime {
+        last_seen: Arc::clone(&last_seen),
+        fail_cleanup: Arc::clone(&fail_flag),
+    });
+    let runtimes: Vec<Arc<dyn JsRuntimeInterface>> = vec![Arc::clone(&runtime)];
+    let healthy = runtimes.iter().map(|_| AtomicBool::new(true)).collect();
+    let unhealthy_since_ms = runtimes.iter().map(|_| AtomicU64::new(0)).collect();
+    let pool = Arc::new(JsRuntimePool {
+        runtimes,
+        pick_strategy: Arc::new(RoundRobinStrategy),
+        next_index: AtomicUsize::new(0),
+        healthy,
+        unhealthy_since_ms,
+        setup_mode: AtomicBool::new(false),
+        timeout_ms: DEFAULT_TIMEOUT_MS,
+        heal_after_ms: HEAL_DISABLED,
+    });
+
+    let ctx = Arc::new(RequestContext::new("/cleanup_fails".to_string()));
+
+    let value =
+        pool.with_request_context(Arc::clone(&ctx), |_runtime| async { Ok(42_i32) }).await?;
+    assert_eq!(value, 42);
+    Ok(())
+}
+
+#[tokio::test]
+async fn setup_mode_error_message_uses_executed_not_total() {
+    let (pool, flags) = build_pool_with_fail_flags(4);
+    pool.mark_unhealthy(1);
+    pool.mark_unhealthy(3);
+    pool.set_setup_mode(true);
+    flags[2].store(true, Ordering::SeqCst);
+
+    let result = pool.execute_script("setup.js".into(), "init".into()).await;
+    let msg = match result {
+        Ok(_) => String::new(),
+        Err(e) => e.to_string(),
+    };
+    assert!(
+        msg.contains("1 of 2 runtimes"),
+        "error must report failed/attempted (1 of 2), got: {msg}"
+    );
+    assert!(!msg.contains("1 of 4 runtimes"), "error must not use total pool size, got: {msg}");
+}
+
+#[tokio::test]
+async fn invalidate_component_all_error_uses_executed_not_total() {
+    let (pool, flags) = build_pool_with_fail_flags(4);
+    pool.mark_unhealthy(0);
+    pool.mark_unhealthy(3);
+    flags[2].store(true, Ordering::SeqCst);
+
+    let result = pool.invalidate_component_all("MyComponent").await;
+    let msg = match result {
+        Ok(()) => String::new(),
+        Err(e) => e.to_string(),
+    };
+    assert!(
+        msg.contains("1 of 2 runtimes"),
+        "error must report failed/attempted (1 of 2), got: {msg}"
+    );
+}

--- a/crates/rari/src/runtime/factory/pool/tests.rs
+++ b/crates/rari/src/runtime/factory/pool/tests.rs
@@ -181,6 +181,7 @@ fn pool_from_runtimes(
         healthy: (0..size).map(|_| AtomicBool::new(true)).collect(),
         unhealthy_since_ms: (0..size).map(|_| AtomicU64::new(0)).collect(),
         slot_leases: (0..size).map(|_| Arc::new(AsyncMutex::new(()))).collect(),
+        needs_rebuild: (0..size).map(|_| AtomicBool::new(false)).collect(),
         setup_mode: AtomicBool::new(false),
         timeout_ms,
         heal_after_ms,
@@ -317,6 +318,7 @@ async fn probe_and_heal_rebuilds_and_re_admits_when_probe_fails() -> Result<(), 
         healthy: vec![AtomicBool::new(true)],
         unhealthy_since_ms: vec![AtomicU64::new(0)],
         slot_leases: vec![Arc::new(AsyncMutex::new(()))],
+        needs_rebuild: vec![AtomicBool::new(false)],
         setup_mode: AtomicBool::new(false),
         timeout_ms: DEFAULT_TIMEOUT_MS,
         heal_after_ms: 1,
@@ -351,6 +353,7 @@ async fn probe_and_heal_keeps_unhealthy_when_rebuild_still_fails() -> Result<(),
         healthy: vec![AtomicBool::new(true)],
         unhealthy_since_ms: vec![AtomicU64::new(0)],
         slot_leases: vec![Arc::new(AsyncMutex::new(()))],
+        needs_rebuild: vec![AtomicBool::new(false)],
         setup_mode: AtomicBool::new(false),
         timeout_ms: DEFAULT_TIMEOUT_MS,
         heal_after_ms: 1,
@@ -1142,14 +1145,39 @@ async fn with_request_context_returns_cleanup_error_and_quarantines() {
         last_seen: Arc::clone(&last_seen),
         fail_cleanup: Arc::clone(&fail_flag),
     });
-    let runtimes: Vec<Arc<dyn JsRuntimeInterface>> = vec![Arc::clone(&runtime)];
-    let pool = pool_from_runtimes(runtimes, DEFAULT_TIMEOUT_MS, HEAL_DISABLED);
+    let rebuilds = Arc::new(AtomicUsize::new(0));
+    let rebuilds_for_factory = Arc::clone(&rebuilds);
+    let pool = Arc::new(JsRuntimePool {
+        runtimes: wrap_runtimes(vec![runtime]),
+        runtime_factory: Arc::new(move || {
+            rebuilds_for_factory.fetch_add(1, Ordering::SeqCst);
+            Arc::new(CountingRuntime::new(Arc::new(AtomicUsize::new(0))))
+                as Arc<dyn JsRuntimeInterface>
+        }),
+        pick_strategy: Arc::new(RoundRobinStrategy),
+        next_index: AtomicUsize::new(0),
+        healthy: vec![AtomicBool::new(true)],
+        unhealthy_since_ms: vec![AtomicU64::new(0)],
+        slot_leases: vec![Arc::new(AsyncMutex::new(()))],
+        needs_rebuild: vec![AtomicBool::new(false)],
+        setup_mode: AtomicBool::new(false),
+        timeout_ms: DEFAULT_TIMEOUT_MS,
+        heal_after_ms: 1,
+    });
 
     let ctx = Arc::new(RequestContext::new("/cleanup_fails".to_string()));
-
     let result = pool.with_request_context(Arc::clone(&ctx), |_runtime| async { Ok(42_i32) }).await;
     assert!(result.is_err(), "cleanup failure must be returned");
     assert!(!pool.is_healthy(0), "cleanup failure must quarantine the slot");
+
+    sleep(Duration::from_millis(5)).await;
+    pool.probe_and_heal().await;
+    assert_eq!(
+        rebuilds.load(Ordering::SeqCst),
+        1,
+        "cleanup failure must force rebuild on heal, not probe-only re-admit"
+    );
+    assert!(pool.is_healthy(0), "successful rebuild probe should re-admit");
 }
 
 #[tokio::test]

--- a/crates/rari/src/runtime/factory/pool/tests.rs
+++ b/crates/rari/src/runtime/factory/pool/tests.rs
@@ -1181,6 +1181,51 @@ async fn with_request_context_returns_cleanup_error_and_quarantines() {
 }
 
 #[tokio::test]
+#[expect(clippy::unwrap_used, reason = "test task joins are hard failures")]
+async fn queued_waiter_rejects_contaminated_slot_before_rebuild() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let runtime: Arc<dyn JsRuntimeInterface> = Arc::new(CountingRuntime::new(Arc::clone(&calls)));
+    let pool = pool_from_runtimes(vec![Arc::clone(&runtime)], DEFAULT_TIMEOUT_MS, HEAL_DISABLED);
+
+    let pool_hold = Arc::clone(&pool);
+    let blocker = tokio::spawn(async move {
+        pool_hold
+            .with_request_context(
+                Arc::new(RequestContext::new("/block".to_string())),
+                |_rt| async {
+                    sleep(Duration::from_millis(200)).await;
+                    Ok(())
+                },
+            )
+            .await
+    });
+
+    sleep(Duration::from_millis(10)).await;
+    pool.mark_needs_rebuild(0);
+
+    let pool_exec = Arc::clone(&pool);
+    let exec = tokio::spawn(async move { pool_exec.execute_script("x".into(), "1".into()).await });
+
+    sleep(Duration::from_millis(50)).await;
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "waiter must not execute while slot is contaminated"
+    );
+
+    let blocker_result = blocker.await.unwrap();
+    assert!(blocker_result.is_ok(), "blocker should complete cleanly");
+
+    let result = exec.await.unwrap();
+    assert!(result.is_err(), "must reject contaminated slot after acquiring lease");
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "waiter must not execute on contaminated runtime before rebuild"
+    );
+}
+
+#[tokio::test]
 async fn setup_mode_error_message_uses_executed_not_total() {
     let (pool, flags) = build_pool_with_fail_flags(4);
     pool.mark_unhealthy(1);

--- a/crates/rari/src/runtime/factory/pool/tests.rs
+++ b/crates/rari/src/runtime/factory/pool/tests.rs
@@ -11,7 +11,10 @@ use std::{
 use parking_lot::RwLock;
 use rari_error::RariError;
 use serde_json::{Value, json};
-use tokio::{sync::mpsc, time::sleep};
+use tokio::{
+    sync::{Mutex as AsyncMutex, mpsc},
+    time::sleep,
+};
 
 use super::*;
 use crate::server::middleware::request_context::RequestContext;
@@ -177,6 +180,7 @@ fn pool_from_runtimes(
         next_index: AtomicUsize::new(0),
         healthy: (0..size).map(|_| AtomicBool::new(true)).collect(),
         unhealthy_since_ms: (0..size).map(|_| AtomicU64::new(0)).collect(),
+        slot_leases: (0..size).map(|_| Arc::new(AsyncMutex::new(()))).collect(),
         setup_mode: AtomicBool::new(false),
         timeout_ms,
         heal_after_ms,
@@ -312,6 +316,7 @@ async fn probe_and_heal_rebuilds_and_re_admits_when_probe_fails() -> Result<(), 
         next_index: AtomicUsize::new(0),
         healthy: vec![AtomicBool::new(true)],
         unhealthy_since_ms: vec![AtomicU64::new(0)],
+        slot_leases: vec![Arc::new(AsyncMutex::new(()))],
         setup_mode: AtomicBool::new(false),
         timeout_ms: DEFAULT_TIMEOUT_MS,
         heal_after_ms: 1,
@@ -345,6 +350,7 @@ async fn probe_and_heal_keeps_unhealthy_when_rebuild_still_fails() -> Result<(),
         next_index: AtomicUsize::new(0),
         healthy: vec![AtomicBool::new(true)],
         unhealthy_since_ms: vec![AtomicU64::new(0)],
+        slot_leases: vec![Arc::new(AsyncMutex::new(()))],
         setup_mode: AtomicBool::new(false),
         timeout_ms: DEFAULT_TIMEOUT_MS,
         heal_after_ms: 1,
@@ -1035,6 +1041,77 @@ async fn with_request_context_cleans_up_even_when_op_errors() {
     assert!(
         last_seens[0].lock().map(|guard| guard.is_none()).unwrap_or(false),
         "ctx must be cleared even when op returns Err"
+    );
+}
+
+#[tokio::test]
+async fn with_request_context_serializes_same_slot_so_ops_see_own_context() {
+    let (pool, last_seens) = build_pool_with_distinct_request_context_runtimes(1);
+    let last_seen = Arc::clone(&last_seens[0]);
+
+    let ctx_a = Arc::new(RequestContext::new("/lease_a".to_string()));
+    let ctx_b = Arc::new(RequestContext::new("/lease_b".to_string()));
+
+    let pool_a = Arc::clone(&pool);
+    let last_a = Arc::clone(&last_seen);
+    let ctx_a_op = Arc::clone(&ctx_a);
+    let fut_a = async move {
+        pool_a
+            .with_request_context(Arc::clone(&ctx_a_op), move |_runtime| {
+                let last_a = last_a;
+                let ctx_a_op = ctx_a_op;
+                async move {
+                    sleep(Duration::from_millis(30)).await;
+                    let guard = last_a
+                        .lock()
+                        .map_err(|_| RariError::js_runtime("last_seen poisoned".to_string()))?;
+                    let current = guard.as_ref().ok_or_else(|| {
+                        RariError::js_runtime("expected request context during op A".to_string())
+                    })?;
+                    if !Arc::ptr_eq(current, &ctx_a_op) {
+                        return Err(RariError::js_runtime(
+                            "op A observed a different request context".to_string(),
+                        ));
+                    }
+                    Ok(())
+                }
+            })
+            .await
+    };
+
+    let pool_b = Arc::clone(&pool);
+    let last_b = Arc::clone(&last_seen);
+    let ctx_b_op = Arc::clone(&ctx_b);
+    let fut_b = async move {
+        pool_b
+            .with_request_context(Arc::clone(&ctx_b_op), move |_runtime| {
+                let last_b = last_b;
+                let ctx_b_op = ctx_b_op;
+                async move {
+                    sleep(Duration::from_millis(30)).await;
+                    let guard = last_b
+                        .lock()
+                        .map_err(|_| RariError::js_runtime("last_seen poisoned".to_string()))?;
+                    let current = guard.as_ref().ok_or_else(|| {
+                        RariError::js_runtime("expected request context during op B".to_string())
+                    })?;
+                    if !Arc::ptr_eq(current, &ctx_b_op) {
+                        return Err(RariError::js_runtime(
+                            "op B observed a different request context".to_string(),
+                        ));
+                    }
+                    Ok(())
+                }
+            })
+            .await
+    };
+
+    let (res_a, res_b) = tokio::join!(fut_a, fut_b);
+    assert!(res_a.is_ok(), "op A failed: {res_a:?}");
+    assert!(res_b.is_ok(), "op B failed: {res_b:?}");
+    assert!(
+        last_seen.lock().map(|guard| guard.is_none()).unwrap_or(false),
+        "request context must be cleared after both ops"
     );
 }
 

--- a/crates/rari/src/runtime/factory/pool/tests.rs
+++ b/crates/rari/src/runtime/factory/pool/tests.rs
@@ -12,7 +12,8 @@ use parking_lot::RwLock;
 use rari_error::RariError;
 use serde_json::{Value, json};
 use tokio::{
-    sync::{Mutex as AsyncMutex, mpsc},
+    sync::{Mutex as AsyncMutex, Notify, mpsc},
+    task::yield_now,
     time::sleep,
 };
 
@@ -1187,34 +1188,35 @@ async fn queued_waiter_rejects_contaminated_slot_before_rebuild() {
     let runtime: Arc<dyn JsRuntimeInterface> = Arc::new(CountingRuntime::new(Arc::clone(&calls)));
     let pool = pool_from_runtimes(vec![Arc::clone(&runtime)], DEFAULT_TIMEOUT_MS, HEAL_DISABLED);
 
+    let context_installed = Arc::new(Notify::new());
+    let release_blocker = Arc::new(Notify::new());
+    let context_installed_blocker = Arc::clone(&context_installed);
+    let release_blocker_blocker = Arc::clone(&release_blocker);
+
     let pool_hold = Arc::clone(&pool);
     let blocker = tokio::spawn(async move {
         pool_hold
             .with_request_context(
                 Arc::new(RequestContext::new("/block".to_string())),
-                |_rt| async {
-                    sleep(Duration::from_millis(200)).await;
+                move |_rt| async move {
+                    context_installed_blocker.notify_waiters();
+                    release_blocker_blocker.notified().await;
                     Ok(())
                 },
             )
             .await
     });
 
-    sleep(Duration::from_millis(10)).await;
+    context_installed.notified().await;
     pool.mark_needs_rebuild(0);
 
     let pool_exec = Arc::clone(&pool);
     let exec = tokio::spawn(async move { pool_exec.execute_script("x".into(), "1".into()).await });
 
-    sleep(Duration::from_millis(50)).await;
-    assert_eq!(
-        calls.load(Ordering::SeqCst),
-        0,
-        "waiter must not execute while slot is contaminated"
-    );
-
-    let blocker_result = blocker.await.unwrap();
-    assert!(blocker_result.is_ok(), "blocker should complete cleanly");
+    for _ in 0..100 {
+        yield_now().await;
+    }
+    release_blocker.notify_one();
 
     let result = exec.await.unwrap();
     assert!(result.is_err(), "must reject contaminated slot after acquiring lease");
@@ -1223,6 +1225,9 @@ async fn queued_waiter_rejects_contaminated_slot_before_rebuild() {
         0,
         "waiter must not execute on contaminated runtime before rebuild"
     );
+
+    let blocker_result = blocker.await.unwrap();
+    assert!(blocker_result.is_ok(), "blocker should complete cleanly");
 }
 
 #[tokio::test]

--- a/crates/rari/src/runtime/factory/pool/tests.rs
+++ b/crates/rari/src/runtime/factory/pool/tests.rs
@@ -5,9 +5,10 @@ use std::{
         Arc, Mutex,
         atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 
+use parking_lot::RwLock;
 use rari_error::RariError;
 use serde_json::{Value, json};
 use tokio::{sync::mpsc, time::sleep};
@@ -18,11 +19,18 @@ use crate::server::middleware::request_context::RequestContext;
 struct CountingRuntime {
     calls: Arc<AtomicUsize>,
     hang_script: Arc<AtomicBool>,
+    hang_load: Arc<AtomicBool>,
+    fail_script: Arc<AtomicBool>,
 }
 
 impl CountingRuntime {
     fn new(calls: Arc<AtomicUsize>) -> Self {
-        Self { calls, hang_script: Arc::new(AtomicBool::new(false)) }
+        Self {
+            calls,
+            hang_script: Arc::new(AtomicBool::new(false)),
+            hang_load: Arc::new(AtomicBool::new(false)),
+            fail_script: Arc::new(AtomicBool::new(false)),
+        }
     }
 }
 
@@ -34,11 +42,15 @@ impl JsRuntimeInterface for CountingRuntime {
     ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send>> {
         let calls = Arc::clone(&self.calls);
         let hang = self.hang_script.load(Ordering::SeqCst);
+        let fail = self.fail_script.load(Ordering::SeqCst);
         Box::pin(async move {
             if hang {
                 sleep(Duration::from_secs(60)).await;
             }
             calls.fetch_add(1, Ordering::SeqCst);
+            if fail {
+                return Err(RariError::js_runtime("script failed".to_string()));
+            }
             Ok(json!({"ok": true}))
         })
     }
@@ -73,7 +85,13 @@ impl JsRuntimeInterface for CountingRuntime {
         &self,
         _specifier: &str,
     ) -> Pin<Box<dyn Future<Output = Result<deno_core::ModuleId, RariError>> + Send>> {
-        Box::pin(async move { Ok(0) })
+        let hang = self.hang_load.load(Ordering::SeqCst);
+        Box::pin(async move {
+            if hang {
+                sleep(Duration::from_secs(60)).await;
+            }
+            Ok(0)
+        })
     }
 
     fn evaluate_module(
@@ -134,6 +152,37 @@ impl JsRuntimeInterface for CountingRuntime {
     }
 }
 
+fn wrap_runtimes(
+    runtimes: Vec<Arc<dyn JsRuntimeInterface>>,
+) -> Vec<RwLock<Arc<dyn JsRuntimeInterface>>> {
+    runtimes.into_iter().map(RwLock::new).collect()
+}
+
+fn counting_runtime_factory() -> RuntimeFactory {
+    Arc::new(|| {
+        Arc::new(CountingRuntime::new(Arc::new(AtomicUsize::new(0)))) as Arc<dyn JsRuntimeInterface>
+    })
+}
+
+fn pool_from_runtimes(
+    runtimes: Vec<Arc<dyn JsRuntimeInterface>>,
+    timeout_ms: u64,
+    heal_after_ms: u64,
+) -> Arc<JsRuntimePool> {
+    let size = runtimes.len();
+    Arc::new(JsRuntimePool {
+        runtimes: wrap_runtimes(runtimes),
+        runtime_factory: counting_runtime_factory(),
+        pick_strategy: Arc::new(RoundRobinStrategy),
+        next_index: AtomicUsize::new(0),
+        healthy: (0..size).map(|_| AtomicBool::new(true)).collect(),
+        unhealthy_since_ms: (0..size).map(|_| AtomicU64::new(0)).collect(),
+        setup_mode: AtomicBool::new(false),
+        timeout_ms,
+        heal_after_ms,
+    })
+}
+
 fn build_pool_with_counters(size: usize) -> (Arc<JsRuntimePool>, Vec<Arc<AtomicUsize>>) {
     let mut runtimes: Vec<Arc<dyn JsRuntimeInterface>> = Vec::with_capacity(size);
     let mut counters: Vec<Arc<AtomicUsize>> = Vec::with_capacity(size);
@@ -145,20 +194,7 @@ fn build_pool_with_counters(size: usize) -> (Arc<JsRuntimePool>, Vec<Arc<AtomicU
         runtimes.push(Arc::new(runtime));
     }
 
-    let healthy = (0..size).map(|_| AtomicBool::new(true)).collect();
-    let unhealthy_since_ms = (0..size).map(|_| AtomicU64::new(0)).collect();
-
-    let pool = Arc::new(JsRuntimePool {
-        runtimes,
-        pick_strategy: Arc::new(RoundRobinStrategy),
-        next_index: AtomicUsize::new(0),
-        healthy,
-        unhealthy_since_ms,
-        setup_mode: AtomicBool::new(false),
-        timeout_ms: DEFAULT_TIMEOUT_MS,
-        heal_after_ms: HEAL_DISABLED,
-    });
-
+    let pool = pool_from_runtimes(runtimes, DEFAULT_TIMEOUT_MS, HEAL_DISABLED);
     (pool, counters)
 }
 
@@ -234,30 +270,91 @@ async fn mark_healthy_restores_round_robin() -> Result<(), RariError> {
 }
 
 #[tokio::test]
-async fn heal_expired_re_admits_unhealthy_slots() -> Result<(), RariError> {
+async fn probe_and_heal_re_admits_after_successful_probe() -> Result<(), RariError> {
     let (_unused, counters) = build_pool_with_counters(2);
     let runtimes = (0..2)
         .map(|i| {
             Arc::new(CountingRuntime::new(Arc::clone(&counters[i]))) as Arc<dyn JsRuntimeInterface>
         })
         .collect::<Vec<_>>();
-    let pool = Arc::new(JsRuntimePool {
-        runtimes,
-        pick_strategy: Arc::new(RoundRobinStrategy),
-        next_index: AtomicUsize::new(0),
-        healthy: (0..2).map(|_| AtomicBool::new(true)).collect(),
-        unhealthy_since_ms: (0..2).map(|_| AtomicU64::new(0)).collect(),
-        setup_mode: AtomicBool::new(false),
-        timeout_ms: DEFAULT_TIMEOUT_MS,
-        heal_after_ms: 1,
-    });
+    let pool = pool_from_runtimes(runtimes, DEFAULT_TIMEOUT_MS, 1);
 
     pool.mark_unhealthy(0);
     assert!(!pool.is_healthy(0));
 
     sleep(Duration::from_millis(5)).await;
     let _ = pool.pick();
-    assert!(pool.is_healthy(0), "expired unhealthy slot should be healed on pick");
+    assert!(!pool.is_healthy(0), "sync pick must not re-admit without a probe");
+
+    pool.probe_and_heal().await;
+    assert!(pool.is_healthy(0), "successful heal probe should re-admit the slot");
+    Ok(())
+}
+
+#[tokio::test]
+#[expect(clippy::expect_used)]
+async fn probe_and_heal_rebuilds_and_re_admits_when_probe_fails() -> Result<(), RariError> {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let runtime = CountingRuntime::new(Arc::clone(&calls));
+    runtime.fail_script.store(true, Ordering::SeqCst);
+    let original: Arc<dyn JsRuntimeInterface> = Arc::new(runtime);
+
+    let rebuilds = Arc::new(AtomicUsize::new(0));
+    let rebuilds_for_factory = Arc::clone(&rebuilds);
+    let pool = Arc::new(JsRuntimePool {
+        runtimes: wrap_runtimes(vec![Arc::clone(&original)]),
+        runtime_factory: Arc::new(move || {
+            rebuilds_for_factory.fetch_add(1, Ordering::SeqCst);
+            Arc::new(CountingRuntime::new(Arc::new(AtomicUsize::new(0))))
+                as Arc<dyn JsRuntimeInterface>
+        }),
+        pick_strategy: Arc::new(RoundRobinStrategy),
+        next_index: AtomicUsize::new(0),
+        healthy: vec![AtomicBool::new(true)],
+        unhealthy_since_ms: vec![AtomicU64::new(0)],
+        setup_mode: AtomicBool::new(false),
+        timeout_ms: DEFAULT_TIMEOUT_MS,
+        heal_after_ms: 1,
+    });
+
+    pool.mark_unhealthy(0);
+    sleep(Duration::from_millis(5)).await;
+    pool.probe_and_heal().await;
+
+    assert_eq!(rebuilds.load(Ordering::SeqCst), 1, "failed probe should rebuild once");
+    assert!(pool.is_healthy(0), "successful post-rebuild probe should re-admit");
+    let replacement = pool.runtime_at(0).expect("slot exists");
+    assert!(!Arc::ptr_eq(&original, &replacement), "slot must hold the rebuilt isolate");
+    Ok(())
+}
+
+#[tokio::test]
+async fn probe_and_heal_keeps_unhealthy_when_rebuild_still_fails() -> Result<(), RariError> {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let runtime = CountingRuntime::new(Arc::clone(&calls));
+    runtime.fail_script.store(true, Ordering::SeqCst);
+
+    let pool = Arc::new(JsRuntimePool {
+        runtimes: wrap_runtimes(vec![Arc::new(runtime)]),
+        runtime_factory: Arc::new(|| {
+            let rebuilt = CountingRuntime::new(Arc::new(AtomicUsize::new(0)));
+            rebuilt.fail_script.store(true, Ordering::SeqCst);
+            Arc::new(rebuilt) as Arc<dyn JsRuntimeInterface>
+        }),
+        pick_strategy: Arc::new(RoundRobinStrategy),
+        next_index: AtomicUsize::new(0),
+        healthy: vec![AtomicBool::new(true)],
+        unhealthy_since_ms: vec![AtomicU64::new(0)],
+        setup_mode: AtomicBool::new(false),
+        timeout_ms: DEFAULT_TIMEOUT_MS,
+        heal_after_ms: 1,
+    });
+
+    pool.mark_unhealthy(0);
+    sleep(Duration::from_millis(5)).await;
+    pool.probe_and_heal().await;
+    assert!(!pool.is_healthy(0), "slot must stay unhealthy when rebuild probe also fails");
+    assert!(calls.load(Ordering::SeqCst) >= 1, "original probe should have executed");
     Ok(())
 }
 
@@ -267,16 +364,7 @@ async fn execute_script_times_out_when_runtime_hangs() {
     let runtime = CountingRuntime::new(Arc::clone(&calls));
     runtime.hang_script.store(true, Ordering::SeqCst);
 
-    let pool = Arc::new(JsRuntimePool {
-        runtimes: vec![Arc::new(runtime)],
-        pick_strategy: Arc::new(RoundRobinStrategy),
-        next_index: AtomicUsize::new(0),
-        healthy: vec![AtomicBool::new(true)],
-        unhealthy_since_ms: vec![AtomicU64::new(0)],
-        setup_mode: AtomicBool::new(false),
-        timeout_ms: 20,
-        heal_after_ms: HEAL_DISABLED,
-    });
+    let pool = pool_from_runtimes(vec![Arc::new(runtime)], 20, HEAL_DISABLED);
 
     let result = pool.execute_script("hang.js".into(), "1".into()).await;
     assert!(result.is_err(), "expected timeout error");
@@ -437,19 +525,7 @@ fn build_pool_with_fail_flags(size: usize) -> (Arc<JsRuntimePool>, Vec<Arc<Atomi
         runtimes.push(Arc::new(BroadcastingRuntime { fail_next: Arc::clone(&flag) }));
     }
 
-    let healthy = (0..size).map(|_| AtomicBool::new(true)).collect();
-    let unhealthy_since_ms = (0..size).map(|_| AtomicU64::new(0)).collect();
-
-    let pool = Arc::new(JsRuntimePool {
-        runtimes,
-        pick_strategy: Arc::new(RoundRobinStrategy),
-        next_index: AtomicUsize::new(0),
-        healthy,
-        unhealthy_since_ms,
-        setup_mode: AtomicBool::new(false),
-        timeout_ms: DEFAULT_TIMEOUT_MS,
-        heal_after_ms: HEAL_DISABLED,
-    });
+    let pool = pool_from_runtimes(runtimes, DEFAULT_TIMEOUT_MS, HEAL_DISABLED);
 
     (pool, flags)
 }
@@ -524,6 +600,31 @@ async fn invalidate_component_all_succeeds_when_all_runtimes_ok() {
 
     let result = pool.invalidate_component_all("MyComponent").await;
     assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn broadcast_continues_when_one_runtime_hangs() {
+    let hang_calls = Arc::new(AtomicUsize::new(0));
+    let ok_calls = Arc::new(AtomicUsize::new(0));
+    let hang_runtime = CountingRuntime::new(Arc::clone(&hang_calls));
+    hang_runtime.hang_script.store(true, Ordering::SeqCst);
+    let ok_runtime = CountingRuntime::new(Arc::clone(&ok_calls));
+
+    let pool =
+        pool_from_runtimes(vec![Arc::new(hang_runtime), Arc::new(ok_runtime)], 30, HEAL_DISABLED);
+
+    let started = Instant::now();
+    let result = pool.broadcast_script("s.js", "1").await;
+    let elapsed = started.elapsed();
+
+    assert!(result.is_err(), "hanging slot should make broadcast report aggregate error");
+    assert!(ok_calls.load(Ordering::SeqCst) >= 1, "healthy slot must still run despite peer hang");
+    assert!(!pool.is_healthy(0), "timed-out slot must be marked unhealthy");
+    assert!(pool.is_healthy(1), "successful slot must stay healthy");
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "peer hang must not serialize the full shared budget; elapsed={elapsed:?}"
+    );
 }
 
 #[tokio::test]
@@ -621,18 +722,18 @@ async fn execute_script_batch_emits_pool_unavailable_for_each_script_when_all_un
     Ok(())
 }
 
-#[test]
-fn pick_runtime_returns_error_when_all_unhealthy() {
+#[tokio::test]
+async fn pick_runtime_returns_error_when_all_unhealthy() {
     let (pool, _) = build_pool_with_counters(2);
     pool.mark_unhealthy(0);
     pool.mark_unhealthy(1);
-    assert!(pool.pick_runtime().is_err());
+    assert!(pool.pick_runtime().await.is_err());
 }
 
 #[tokio::test]
 async fn pooled_runtime_is_sticky_across_calls() -> Result<(), RariError> {
     let (pool, _counters) = build_pool_with_counters(3);
-    let handle = pool.pick_runtime()?;
+    let handle = pool.pick_runtime().await?;
     let expected_idx = handle.idx();
     let expected_runtime = Arc::clone(handle.runtime());
 
@@ -655,7 +756,7 @@ async fn pooled_runtime_is_sticky_across_calls() -> Result<(), RariError> {
 #[tokio::test]
 async fn pooled_runtime_routes_through_self_runtime_after_pool_changes() -> Result<(), RariError> {
     let (pool, counters) = build_pool_with_counters(3);
-    let handle = pool.pick_runtime()?;
+    let handle = pool.pick_runtime().await?;
     let picked_idx = handle.idx();
 
     pool.mark_unhealthy(0);
@@ -813,18 +914,7 @@ fn build_pool_with_distinct_request_context_runtimes(
             }) as Arc<dyn JsRuntimeInterface>
         })
         .collect();
-    let healthy = runtimes.iter().map(|_| AtomicBool::new(true)).collect();
-    let unhealthy_since_ms = runtimes.iter().map(|_| AtomicU64::new(0)).collect();
-    let pool = Arc::new(JsRuntimePool {
-        runtimes,
-        pick_strategy: Arc::new(RoundRobinStrategy),
-        next_index: AtomicUsize::new(0),
-        healthy,
-        unhealthy_since_ms,
-        setup_mode: AtomicBool::new(false),
-        timeout_ms: DEFAULT_TIMEOUT_MS,
-        heal_after_ms: HEAL_DISABLED,
-    });
+    let pool = pool_from_runtimes(runtimes, DEFAULT_TIMEOUT_MS, HEAL_DISABLED);
     (pool, last_seens)
 }
 
@@ -832,7 +922,7 @@ fn build_pool_with_distinct_request_context_runtimes(
 async fn pooled_runtime_set_and_clear_request_context_round_trip() -> Result<(), RariError> {
     let (pool, last_seens) = build_pool_with_distinct_request_context_runtimes(2);
 
-    let handle = pool.pick_runtime()?;
+    let handle = pool.pick_runtime().await?;
     let picked_idx = handle.idx();
     let ctx = Arc::new(RequestContext::new("/test".to_string()));
 
@@ -949,7 +1039,26 @@ async fn with_request_context_cleans_up_even_when_op_errors() {
 }
 
 #[tokio::test]
-async fn with_request_context_returns_op_value_when_cleanup_fails() -> Result<(), RariError> {
+async fn load_and_evaluate_on_picked_quarantines_timed_out_slot() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let runtime = CountingRuntime::new(Arc::clone(&calls));
+    runtime.hang_load.store(true, Ordering::SeqCst);
+
+    let pool = pool_from_runtimes(vec![Arc::new(runtime)], 20, HEAL_DISABLED);
+
+    let result = pool.load_and_evaluate_on_picked("m.js").await;
+    assert!(result.is_err(), "expected timeout");
+    let msg = match result {
+        Ok(_) => String::new(),
+        Err(e) => e.to_string(),
+    };
+    assert!(msg.contains("timed out"), "got: {msg}");
+    assert!(!pool.is_healthy(0), "timed-out slot must be quarantined");
+    assert!(pool.pick().is_none(), "quarantined slot must not be selected again");
+}
+
+#[tokio::test]
+async fn with_request_context_returns_cleanup_error_and_quarantines() {
     let fail_flag = Arc::new(AtomicBool::new(true));
     let last_seen = Arc::new(Mutex::new(None));
     let runtime: Arc<dyn JsRuntimeInterface> = Arc::new(RequestContextRuntime {
@@ -957,25 +1066,13 @@ async fn with_request_context_returns_op_value_when_cleanup_fails() -> Result<()
         fail_cleanup: Arc::clone(&fail_flag),
     });
     let runtimes: Vec<Arc<dyn JsRuntimeInterface>> = vec![Arc::clone(&runtime)];
-    let healthy = runtimes.iter().map(|_| AtomicBool::new(true)).collect();
-    let unhealthy_since_ms = runtimes.iter().map(|_| AtomicU64::new(0)).collect();
-    let pool = Arc::new(JsRuntimePool {
-        runtimes,
-        pick_strategy: Arc::new(RoundRobinStrategy),
-        next_index: AtomicUsize::new(0),
-        healthy,
-        unhealthy_since_ms,
-        setup_mode: AtomicBool::new(false),
-        timeout_ms: DEFAULT_TIMEOUT_MS,
-        heal_after_ms: HEAL_DISABLED,
-    });
+    let pool = pool_from_runtimes(runtimes, DEFAULT_TIMEOUT_MS, HEAL_DISABLED);
 
     let ctx = Arc::new(RequestContext::new("/cleanup_fails".to_string()));
 
-    let value =
-        pool.with_request_context(Arc::clone(&ctx), |_runtime| async { Ok(42_i32) }).await?;
-    assert_eq!(value, 42);
-    Ok(())
+    let result = pool.with_request_context(Arc::clone(&ctx), |_runtime| async { Ok(42_i32) }).await;
+    assert!(result.is_err(), "cleanup failure must be returned");
+    assert!(!pool.is_healthy(0), "cleanup failure must quarantine the slot");
 }
 
 #[tokio::test]

--- a/crates/rari/src/runtime/factory/runtime.rs
+++ b/crates/rari/src/runtime/factory/runtime.rs
@@ -22,6 +22,7 @@ use tokio::{
 use crate::{
     runtime::{
         factory::{
+            component_ops::pending_component_id,
             executor::{self, execute_script},
             interface::{AsyncBatchResult, JsRuntimeInterface},
             runtime_builder::build_js_runtime,
@@ -513,7 +514,7 @@ async fn handle_js_request(
             let is_pending_hmr = specifier.contains("/rari_hmr/pending/");
             let is_hmr_specifier = specifier.contains("/rari_hmr/");
             if is_pending_hmr {
-                let pending_id = format!("__rari_hmr_pending__:{component_id}");
+                let pending_id = pending_component_id(&component_id);
                 module_loader.register_component_specifier(&pending_id, &specifier);
             } else {
                 let existing_specifier = module_loader

--- a/crates/rari/src/runtime/factory/runtime.rs
+++ b/crates/rari/src/runtime/factory/runtime.rs
@@ -510,15 +510,23 @@ async fn handle_js_request(
         JsRequest::AddModuleToLoader { specifier, code, result_tx } => {
             module_loader.set_module_code(specifier.clone(), code);
             let component_id = extract_component_id_from_specifier(&specifier);
+            let is_pending_hmr = specifier.contains("/rari_hmr/pending/");
             let is_hmr_specifier = specifier.contains("/rari_hmr/");
-            let existing_specifier =
-                module_loader.component_specifiers.get(&component_id).map(|entry| entry.clone());
-            let has_existing_hmr_mapping = existing_specifier
-                .as_ref()
-                .map(|spec| spec.contains("/rari_hmr/"))
-                .unwrap_or(false);
-            if is_hmr_specifier || !has_existing_hmr_mapping {
-                module_loader.register_component_specifier(&component_id, &specifier);
+            if is_pending_hmr {
+                let pending_id = format!("__rari_hmr_pending__:{component_id}");
+                module_loader.register_component_specifier(&pending_id, &specifier);
+            } else {
+                let existing_specifier = module_loader
+                    .component_specifiers
+                    .get(&component_id)
+                    .map(|entry| entry.clone());
+                let has_existing_hmr_mapping = existing_specifier
+                    .as_ref()
+                    .map(|spec| spec.contains("/rari_hmr/"))
+                    .unwrap_or(false);
+                if is_hmr_specifier || !has_existing_hmr_mapping {
+                    module_loader.register_component_specifier(&component_id, &specifier);
+                }
             }
             let _ = result_tx.send(Ok(()));
         }
@@ -905,8 +913,11 @@ fn extract_component_id_from_specifier(specifier: &str) -> String {
             .unwrap_or(after_component)
             .trim_end_matches(".js")
             .to_string()
+    } else if let Some(hmr_idx) = specifier.rfind("/rari_hmr/pending/") {
+        let after_hmr = &specifier[hmr_idx + "/rari_hmr/pending/".len()..];
+        after_hmr.split('?').next().unwrap_or(after_hmr).trim_end_matches(".js").to_string()
     } else if let Some(hmr_idx) = specifier.rfind("/rari_hmr/server/") {
-        let after_hmr = &specifier[hmr_idx + 17..];
+        let after_hmr = &specifier[hmr_idx + "/rari_hmr/server/".len()..];
         after_hmr.split('?').next().unwrap_or(after_hmr).trim_end_matches(".js").to_string()
     } else {
         specifier

--- a/crates/rari/src/runtime/mod.rs
+++ b/crates/rari/src/runtime/mod.rs
@@ -1,13 +1,7 @@
-use std::{
-    future::Future,
-    sync::{Arc, OnceLock},
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::{future::Future, sync::Arc, time::Duration};
 
-use cow_utils::CowUtils;
 use deno_core::ModuleId;
 use rari_error::RariError;
-use regex::Regex;
 use rustc_hash::FxHashMap;
 use serde_json::Value;
 use tokio::{
@@ -24,7 +18,12 @@ pub mod transpile;
 use factory::JsRuntimeInterface;
 
 use crate::{
-    runtime::factory::RariRuntime,
+    runtime::factory::{
+        RariRuntime,
+        component_ops::{
+            build_invalidate_script, invalidate_script_name, load_component_code as load_component,
+        },
+    },
     server::{
         middleware::request_context::RequestContext, rendering::metadata,
         routing::types::ParamValue,
@@ -40,23 +39,6 @@ impl Default for JsExecutionRuntime {
     fn default() -> Self {
         Self::new(None)
     }
-}
-
-fn escape_js_string(s: &str) -> String {
-    s.cow_replace('\\', "\\\\")
-        .cow_replace('"', r#"\""#)
-        .cow_replace('\n', "\\n")
-        .cow_replace('\r', "\\r")
-        .into_owned()
-}
-
-fn is_esm_code(code: &str) -> bool {
-    static ESM_REGEX: OnceLock<Regex> = OnceLock::new();
-    #[expect(clippy::expect_used, reason = "Infallible operation with valid inputs")]
-    let regex = ESM_REGEX
-        .get_or_init(|| Regex::new(r"(?m)^\s*export[\s{]").expect("Valid ESM detection regex"));
-
-    regex.is_match(code)
 }
 
 fn parse_string_array_value(value: &Value) -> Vec<String> {
@@ -309,90 +291,9 @@ impl JsExecutionRuntime {
     }
 
     pub async fn invalidate_component(&self, component_id: &str) -> Result<(), RariError> {
-        let escaped_component_id = escape_js_string(component_id);
+        let script = build_invalidate_script(component_id);
 
-        let script = format!(
-            r#"
-            (function() {{
-                const componentId = "{escaped_component_id}";
-                let deleted = false;
-
-                if (globalThis[componentId]) {{
-                    delete globalThis[componentId];
-                    deleted = true;
-                }}
-
-                const moduleNamespace = globalThis['~rsc']?.modules?.[componentId];
-                if (moduleNamespace) {{
-                    for (const key in moduleNamespace) {{
-                        if (key !== 'default' && typeof moduleNamespace[key] === 'function' && globalThis[key] === moduleNamespace[key]) {{
-                            delete globalThis[key];
-                            deleted = true;
-                        }}
-                    }}
-                }}
-
-                if (globalThis['~rsc']?.functions?.[componentId]) {{
-                    delete globalThis['~rsc'].functions[componentId];
-                    deleted = true;
-                }}
-
-                if (globalThis['~rari']?.ssrModules) {{
-                    const colonPrefix = componentId + ':';
-                    const hashPrefix = componentId + '#';
-                    for (const key in globalThis['~rari'].ssrModules) {{
-                        if (key === componentId || key.startsWith(colonPrefix) || key.startsWith(hashPrefix)) {{
-                            delete globalThis['~rari'].ssrModules[key];
-                            deleted = true;
-                        }}
-                    }}
-                }}
-
-                if (globalThis['~rari']?.serverManifest) {{
-                    const colonPrefix = componentId + ':';
-                    const hashPrefix = componentId + '#';
-                    for (const key in globalThis['~rari'].serverManifest) {{
-                        if (key === componentId || key.startsWith(colonPrefix) || key.startsWith(hashPrefix)) {{
-                            delete globalThis['~rari'].serverManifest[key];
-                            deleted = true;
-                        }}
-                    }}
-                }}
-
-                if (globalThis['~rari']?.registeredServerFunctions) {{
-                    const colonPrefix = componentId + ':';
-                    const hashPrefix = componentId + '#';
-                    for (const key of globalThis['~rari'].registeredServerFunctions) {{
-                        if (key === componentId || key.startsWith(colonPrefix) || key.startsWith(hashPrefix)) {{
-                            globalThis['~rari'].registeredServerFunctions.delete(key);
-                            deleted = true;
-                        }}
-                    }}
-                }}
-
-                if (globalThis['~rsc']?.modules?.[componentId]) {{
-                    delete globalThis['~rsc'].modules[componentId];
-                    deleted = true;
-                }}
-
-                if (globalThis.RscModuleManager && globalThis.RscModuleManager.unregister) {{
-                    try {{
-                        globalThis.RscModuleManager.unregister(componentId);
-                        deleted = true;
-                    }} catch (e) {{
-                        console.warn('Failed to unregister from RscModuleManager:', e);
-                    }}
-                }}
-
-                return {{ success: true, deleted: deleted }};
-            }})()
-            "#
-        );
-
-        match self
-            .execute_script(format!("invalidate_{}", component_id.cow_replace('/', "_")), script)
-            .await
-        {
+        match self.execute_script(invalidate_script_name(component_id), script).await {
             Ok(_) => Ok(()),
             Err(e) => {
                 tracing::error!("Failed to invalidate component {}: {}", component_id, e);
@@ -403,128 +304,26 @@ impl JsExecutionRuntime {
         }
     }
 
-    #[expect(clippy::too_many_lines)]
     pub async fn load_component_code(
         &self,
         component_id: &str,
         component_code: &str,
     ) -> Result<(), RariError> {
-        let is_esm = is_esm_code(component_code);
+        let runtime = Arc::clone(&self.runtime);
+        let component_id = component_id.to_string();
+        let component_code = component_code.to_string();
 
-        if is_esm {
-            let timestamp =
-                SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis();
-
-            let hmr_specifier = format!("file:///rari_hmr/server/{component_id}.js?v={timestamp}");
-
-            if let Err(e) = self.clear_module_loader_caches(component_id).await {
-                tracing::warn!("Failed to clear module loader caches for {}: {}", component_id, e);
-            }
-
-            self.add_module_to_loader(&hmr_specifier, component_code.to_string()).await.map_err(
-                |e| {
-                    let error_msg =
-                        format!("Failed to add component module to loader for {component_id}: {e}");
-                    tracing::error!("{}", error_msg);
-                    RariError::js_execution(error_msg)
-                },
-            )?;
-
-            let module_id = self.load_es_module(component_id).await.map_err(|e| {
-                let error_msg = format!("Failed to load ES module for {component_id}: {e}");
-                tracing::error!("{}", error_msg);
-                RariError::js_execution(error_msg)
-            })?;
-
-            self.evaluate_module(module_id).await.map_err(|e| {
-                let error_msg = format!("Failed to evaluate ES module for {component_id}: {e}");
-                tracing::error!("{}", error_msg);
-                RariError::js_execution(error_msg)
-            })?;
-
-            let escaped_component_id = escape_js_string(component_id);
-            let escaped_hmr_specifier = escape_js_string(&hmr_specifier);
-
-            let registration_script = format!(
-                r#"(async function() {{
-                    try {{
-                        const moduleNamespace = await import("{escaped_hmr_specifier}");
-                        const componentId = "{escaped_component_id}";
-
-                        if (!globalThis['~rsc']) globalThis['~rsc'] = {{}};
-                        if (!globalThis['~rsc'].modules) globalThis['~rsc'].modules = {{}};
-                        if (!globalThis['~rsc'].functions) globalThis['~rsc'].functions = {{}};
-
-                        globalThis['~rsc'].modules[componentId] = moduleNamespace;
-
-                        if (moduleNamespace.default) {{
-                            globalThis[componentId] = moduleNamespace.default;
-                        }} else {{
-                            const exports = Object.values(moduleNamespace).filter(v => typeof v === 'function');
-                            if (exports.length > 0) {{
-                                globalThis[componentId] = exports[0];
-                            }}
-                        }}
-
-                        const namedExports = {{}};
-                        for (const [key, value] of Object.entries(moduleNamespace)) {{
-                            if (key !== 'default' && typeof value === 'function') {{
-                                namedExports[key] = value;
-                            }}
-                        }}
-
-                        if (Object.keys(namedExports).length > 0) {{
-                            globalThis['~rsc'].functions[componentId] = namedExports;
-                        }}
-
-                        return {{ success: true }};
-                    }} catch (error) {{
-                        console.error('[rari] Failed to register component {escaped_component_id}:', error);
-                        return {{ success: false, error: error.message }};
-                    }}
-                }})()"#
-            );
-
-            let result = self
-                .execute_script(
-                    format!("register_component_{}.js", component_id.cow_replace('/', "_")),
-                    registration_script,
-                )
-                .await
-                .map_err(|e| {
-                    let error_msg =
-                        format!("Failed to register component {component_id} to globalThis: {e}");
-                    tracing::error!("{}", error_msg);
-                    RariError::js_execution(error_msg)
-                })?;
-
-            let success = result.get("success").and_then(Value::as_bool).unwrap_or(false);
-
-            if !success {
-                let error_msg =
-                    result.get("error").and_then(|v| v.as_str()).unwrap_or("Unknown error");
-                tracing::error!(
-                    "Component registration failed for {}: {}",
-                    component_id,
-                    error_msg
-                );
-                return Err(RariError::js_execution(format!(
-                    "Component registration failed for {component_id}: {error_msg}"
-                )));
-            }
-
-            Ok(())
-        } else {
-            let script_name = format!("load_component_{}", component_id.cow_replace('/', "_"));
-            match self.execute_script(script_name, component_code.to_string()).await {
-                Ok(_) => Ok(()),
-                Err(e) => {
-                    let error_msg =
-                        format!("Failed to execute component code for {component_id}: {e}");
-                    tracing::error!("{}", error_msg);
-                    Err(RariError::js_execution(error_msg))
-                }
-            }
+        match time::timeout(
+            Duration::from_millis(self.timeout_ms),
+            load_component(runtime.as_ref(), &component_id, &component_code),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(RariError::timeout(format!(
+                "Loading component {component_id} timed out after {} ms",
+                self.timeout_ms
+            ))),
         }
     }
 

--- a/crates/rari/src/server/vite/hmr.rs
+++ b/crates/rari/src/server/vite/hmr.rs
@@ -533,10 +533,6 @@ async fn handle_reload_component(
         let renderer = Arc::clone(&state.renderer);
         let component_id = component_id.clone();
         run_with_renderer_result(renderer, move |renderer| async move {
-            if let Err(e) = renderer.runtime.invalidate_component(&component_id).await {
-                tracing::error!("Failed to invalidate component {}: {}", component_id, e);
-            }
-
             renderer.runtime.load_component_code(&component_id, &bundle_code).await?;
 
             let mut registry = renderer.component_registry.lock();

--- a/crates/rari/src/server/vite/rsc.rs
+++ b/crates/rari/src/server/vite/rsc.rs
@@ -1,10 +1,6 @@
 #![expect(clippy::missing_errors_doc, clippy::too_many_lines)]
 
-use std::{
-    path::Path,
-    sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::{path::Path, sync::Arc};
 
 use axum::{extract::State, http::StatusCode, response::Json};
 use cow_utils::CowUtils;
@@ -15,6 +11,7 @@ use tokio::{fs, time};
 use crate::{
     rendering::base::run_with_renderer_result,
     rsc::extract_dependencies,
+    runtime::factory::component_ops::is_esm_code,
     server::{
         RegisterClientRequest, RegisterRequest, ServerState,
         core::utils::{
@@ -214,11 +211,7 @@ pub async fn reload_component_from_dist(
         dist_code = new_dist_code;
     }
 
-    let is_esm = dist_code.contains("export ")
-        || dist_code.contains("export{")
-        || dist_code.contains("export {")
-        || dist_code.contains("export\n")
-        || dist_code.contains("export\r");
+    let is_esm = is_esm_code(&dist_code);
 
     let dist_path_display = dist_path.display().to_string();
     let component_id = component_id.to_string();
@@ -228,134 +221,15 @@ pub async fn reload_component_from_dist(
         if is_esm {
             renderer.clear_component_cache(&component_id);
 
-            if let Err(e) = renderer.runtime.clear_module_loader_caches(&component_id).await {
-                tracing::error!("Failed to clear module loader caches for {}: {}", component_id, e);
+            if let Err(e) = renderer.runtime.invalidate_component(&component_id).await {
+                tracing::error!(
+                    component_id = component_id.as_str(),
+                    error = %e,
+                    "Failed to invalidate component during HMR"
+                );
             }
 
-            let timestamp =
-                SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_millis();
-
-            let hmr_specifier = format!("file:///rari_hmr/server/{component_id}.js?v={timestamp}");
-
-            renderer
-                .runtime
-                .add_module_to_loader(&hmr_specifier, dist_code.clone())
-                .await
-                .map_err(|e| {
-                    tracing::error!(
-                        component_id = component_id.as_str(),
-                        error = %e,
-                        "Failed to add HMR module to loader"
-                    );
-                    RariError::js_execution(format!("Failed to add HMR module to loader: {e}"))
-                })?;
-
-            let module_id = renderer.runtime.load_es_module(&component_id).await.map_err(|e| {
-                tracing::error!(
-                    component_id = component_id.as_str(),
-                    error = %e,
-                    "Failed to load ES module during HMR"
-                );
-                RariError::js_execution(format!("Failed to load ES module: {e}"))
-            })?;
-
-            renderer.runtime.evaluate_module(module_id).await.map_err(|e| {
-                tracing::error!(
-                    component_id = component_id.as_str(),
-                    module_id = module_id,
-                    error = %e,
-                    "Failed to evaluate module during HMR"
-                );
-                RariError::js_execution(format!("Failed to evaluate module: {e}"))
-            })?;
-
-            let clear_script = format!(
-                r#"(function() {{
-                const componentId = "{component_id}";
-
-                delete globalThis[componentId];
-
-                if (globalThis['~rsc'] && globalThis['~rsc'].modules) {{
-                    delete globalThis['~rsc'].modules[componentId];
-                }}
-
-                return {{ success: true }};
-            }})()"#
-            );
-
-            renderer
-                .runtime
-                .execute_script(
-                    format!("clear_old_{}.js", component_id.cow_replace('/', "_")),
-                    clear_script,
-                )
-                .await
-                .map_err(|e| {
-                    tracing::error!(
-                        component_id = component_id.as_str(),
-                        error = %e,
-                        "Failed to clear old component"
-                    );
-                    RariError::js_execution(format!("Failed to clear old component: {e}"))
-                })?;
-
-            let registration_script = format!(
-                r#"(async function() {{
-                try {{
-                    const moduleNamespace = await import("{hmr_specifier}");
-                    const componentId = "{component_id}";
-
-                    if (moduleNamespace.default) {{
-                        globalThis[componentId] = moduleNamespace.default;
-                        if (typeof globalThis[componentId] === 'function') {{
-                            globalThis[componentId].__hmr_timestamp = Date.now();
-                            globalThis[componentId].__hmr_specifier = "{hmr_specifier}";
-                        }}
-                    }} else {{
-                        const exports = Object.values(moduleNamespace).filter(v => typeof v === 'function');
-                        if (exports.length > 0) {{
-                            globalThis[componentId] = exports[0];
-                            if (typeof globalThis[componentId] === 'function') {{
-                                globalThis[componentId].__hmr_timestamp = Date.now();
-                                globalThis[componentId].__hmr_specifier = "{hmr_specifier}";
-                            }}
-                        }}
-                    }}
-
-                    for (const [key, value] of Object.entries(moduleNamespace)) {{
-                        if (key !== 'default' && typeof value === 'function') {{
-                            globalThis[key] = value;
-                        }}
-                    }}
-
-                    if (!globalThis['~rsc']) globalThis['~rsc'] = {{}};
-                    if (!globalThis['~rsc'].modules) globalThis['~rsc'].modules = {{}};
-                    globalThis['~rsc'].modules[componentId] = moduleNamespace;
-
-                    const component = globalThis[componentId];
-
-                    return {{ success: true, hasDefault: !!moduleNamespace.default, timestamp: component?.__hmr_timestamp }};
-                }} catch (error) {{
-                    return {{ success: false, error: error.message }};
-                }}
-            }})()"#
-            );
-
-            renderer
-                .runtime
-                .execute_script(
-                    format!("register_esm_{}.js", component_id.cow_replace('/', "_")),
-                    registration_script,
-                )
-                .await
-                .map_err(|e| {
-                    tracing::error!(
-                        component_id = component_id.as_str(),
-                        error = %e,
-                        "Failed to register ESM module exports to globalThis"
-                    );
-                    RariError::js_execution(format!("Failed to register ESM module: {e}"))
-                })?;
+            renderer.runtime.load_component_code(&component_id, &dist_code).await?;
 
             renderer.clear_script_cache();
 

--- a/crates/rari/src/server/vite/rsc.rs
+++ b/crates/rari/src/server/vite/rsc.rs
@@ -219,48 +219,7 @@ pub async fn reload_component_from_dist(
 
     run_with_renderer_result(renderer, move |renderer| async move {
         if is_esm {
-            renderer.clear_component_cache(&component_id);
-
-            if let Err(e) = renderer.runtime.invalidate_component(&component_id).await {
-                tracing::error!(
-                    component_id = component_id.as_str(),
-                    error = %e,
-                    "Failed to invalidate component during HMR"
-                );
-            }
-
             renderer.runtime.load_component_code(&component_id, &dist_code).await?;
-
-            renderer.clear_script_cache();
-
-            let dependencies = extract_dependencies(&dist_code);
-
-            {
-                let mut registry = renderer.component_registry.lock();
-
-                registry.remove_component(&component_id);
-
-                match registry.register_component(
-                    &component_id,
-                    &dist_code,
-                    dist_code.clone(),
-                    dependencies.into_iter().collect(),
-                ) {
-                    Ok(()) => {
-                        registry.mark_component_loaded(&component_id);
-                        registry.mark_component_initially_loaded(&component_id);
-                    }
-                    Err(e) => {
-                        tracing::error!(
-                            component_id = component_id.as_str(),
-                            error = %e,
-                            "Failed to register component during HMR reload"
-                        );
-                        registry.remove_component(&component_id);
-                        return Err(RariError::internal(format!("Failed to register component: {e}")));
-                    }
-                }
-            }
         } else {
             let wrapped_code = wrap_server_action_module(&dist_code, &component_id);
 
@@ -330,9 +289,7 @@ pub async fn reload_component_from_dist(
         };
 
         if let Some(success) = result_json.get("success").and_then(serde_json::Value::as_bool) {
-            if success {
-                Ok(())
-            } else {
+            if !success {
                 let actual_keys = result_json
                     .get("actualKeys")
                     .and_then(|v| v.as_array())
@@ -355,9 +312,9 @@ pub async fn reload_component_from_dist(
                     expected_key,
                     actual_keys
                 );
-                Err(RariError::js_runtime(format!(
+                return Err(RariError::js_runtime(format!(
                     "Component '{component_id}' not found in globalThis after reload. Expected key '{expected_key}' but found keys: [{actual_keys}]. Last known good version will be preserved."
-                )))
+                )));
             }
         } else {
             tracing::error!(
@@ -365,10 +322,46 @@ pub async fn reload_component_from_dist(
                 verification_result = ?result_json,
                 "Invalid verification result format. Last known good version will be preserved."
             );
-            Err(RariError::internal(
+            return Err(RariError::internal(
                 "Invalid verification result format. Last known good version will be preserved."
-            ))
+            ));
         }
+
+        if is_esm {
+            renderer.clear_component_cache(&component_id);
+            renderer.clear_script_cache();
+
+            let dependencies = extract_dependencies(&dist_code);
+
+            {
+                let mut registry = renderer.component_registry.lock();
+
+                registry.remove_component(&component_id);
+
+                match registry.register_component(
+                    &component_id,
+                    &dist_code,
+                    dist_code.clone(),
+                    dependencies.into_iter().collect(),
+                ) {
+                    Ok(()) => {
+                        registry.mark_component_loaded(&component_id);
+                        registry.mark_component_initially_loaded(&component_id);
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            component_id = component_id.as_str(),
+                            error = %e,
+                            "Failed to register component during HMR reload"
+                        );
+                        registry.remove_component(&component_id);
+                        return Err(RariError::internal(format!("Failed to register component: {e}")));
+                    }
+                }
+            }
+        }
+
+        Ok(())
     })
     .await
 }


### PR DESCRIPTION
Introduce multi-isolate pool infra (sticky pick, broadcast, health/heal, timeouts) for upcoming streaming concurrency wiring, and extract shared load/invalidate helpers so the facade, pool, and HMR use one path.

Supersedes #245.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added staged, atomic ES module component hot reload with pending export staging and improved ESM detection.
  * Introduced a pooled JS runtime with round-robin routing, health probing/quarantine recovery, per-slot timeouts, and request-context handling.
  * Added broadcast-style pool APIs for invalidation, loading/evaluating component code, script execution, loader module updates, and cache clearing.
* **Bug Fixes**
  * Updated the reload pipeline to skip pre-invalidation and to error when post-reload verification fails.
  * Improved handling of pending HMR specifiers during module loader registration.
* **Tests**
  * Expanded coverage for pool health transitions, broadcasting/setup-mode behavior, timeouts/quarantine, request-context cleanup, invalidation, and HMR flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->