### PR TITLE
fix(rendering): treat injected app HTML as literal in root-div injection

### DIFF
--- a/crates/rari/src/rendering/static.rs
+++ b/crates/rari/src/rendering/static.rs
@@ -221,7 +221,11 @@ impl RscHtmlRenderer {
 
         let replacement = format!(r#"<div id="root">{html_content}</div>"#);
 
-        let result = root_div_regex.replace(template, replacement.as_str());
+        // NoExpand: the rendered app HTML is a literal replacement, not a
+        // pattern. Without it, `$0`/`$1`/`$&` in page content (e.g. a "$0.20"
+        // headline) would be interpreted as capture-group references and expand
+        // to the matched root div, corrupting the output.
+        let result = root_div_regex.replace(template, regex::NoExpand(replacement.as_str()));
 
         Ok(result.to_string())
     }
@@ -448,6 +452,36 @@ mod tests {
         let template = r#"<!DOCTYPE html><html><body><div id="root"></div></body></html>"#;
         let html = renderer.inject_into_template("<p>Hello</p>", template).unwrap();
         assert!(html.contains(r#"<div id="root"><p>Hello</p></div>"#));
+    }
+
+    #[test]
+    fn test_inject_into_template_preserves_dollar_sequences() {
+        // Regression: `$0`/`$1`/`$&` in page content must not be expanded as
+        // regex capture references during root-div injection.
+        let runtime = Arc::new(JsExecutionRuntime::new(None));
+        let renderer = RscHtmlRenderer::new(runtime);
+
+        let template = r#"<html><body><div id="root"></div></body></html>"#;
+        let content = r"<h1>XLM eyes $0.20 breakout</h1><p>$1 &amp; $&amp;</p>";
+
+        let html = renderer.inject_into_template(content, template).expect("inject should succeed");
+
+        assert!(
+            html.contains(
+                r#"<div id="root"><h1>XLM eyes $0.20 breakout</h1><p>$1 &amp; $&amp;</p></div>"#
+            ),
+            "dollar sequences must survive verbatim, got: {html}"
+        );
+    }
+
+    #[test]
+    fn test_inject_into_template_self_closing_root_div() {
+        let runtime = Arc::new(JsExecutionRuntime::new(None));
+        let renderer = RscHtmlRenderer::new(runtime);
+
+        let template = r#"<html><body><div id="root"/></body></html>"#;
+        let html = renderer.inject_into_template("<p>Hi</p>", template).unwrap();
+        assert!(html.contains(r#"<div id="root"><p>Hi</p></div>"#));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`inject_into_template` in `crates/rari/src/rendering/static.rs` injects the rendered app HTML into the template with `Regex::replace`, passing the replacement as a plain `&str`. The regex crate interprets `$0`/`$1`/`$&` in a string replacement as capture-group references.

Any page whose content contains a dollar sequence gets corrupted. Real example: a headline "XLM eyes $0.20 breakout" — `$0` expands to the entire matched `<div id="root"></div>`, producing nested root divs and invalid markup/JSON-LD:

```html
<div id="root"><h1>XLM eyes <div id="root"></div>.20 breakout</h1>...
```

## Fix

Wrap the replacement in `regex::NoExpand` so the app HTML is inserted verbatim.

## Tests

- `test_inject_into_template_preserves_dollar_sequences` — fails on main (reproduces the corruption above), passes with the fix.
- `test_inject_into_template_self_closing_root_div` — covers the `<div id="root"/>` template variant.

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all-features` (460 passed) are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed page rendering so dollar-sign sequences in injected content display exactly as entered.
  * Improved compatibility with templates using self-closing root elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->