### PR TITLE
fix(fetch): treat non-2xx responses as completed fetches in simple path

### DIFF
--- a/crates/rari/src/runtime/ops.rs
+++ b/crates/rari/src/runtime/ops.rs
@@ -573,7 +573,12 @@ pub async fn op_fetch_with_cache(
     } else {
         match perform_simple_fetch(&url, &options).await {
             Ok((status, body, headers)) => Ok(serde_json::json!({
-                "ok": (200..300).contains(&status),
+                // Any completed HTTP exchange is ok — a 404/500 response is
+                // data for the caller, not a fetch failure. Gating ok on 2xx
+                // made the JS wrapper throw bare "Fetch failed" for every
+                // non-2xx and re-fetch the same URL through the fallback path.
+                // Matches the request-context branch above.
+                "ok": true,
                 "status": status,
                 "statusText": http_status_text(status),
                 "body": body,


### PR DESCRIPTION
## Problem

`op_fetch_with_cache` has two branches. With a request context, a completed exchange always returns `ok: true` and the caller inspects `status`. The simple path (no request context) instead gates `ok` on 2xx:

```rust
"ok": (200..300).contains(&status),
```

The JS wrapper treats `ok: false` as a transport failure: it throws a bare "Fetch failed" for every non-2xx response and re-fetches the same URL through the fallback path — a double backend hit per miss, and the caller never sees the actual status/body (e.g. a 404 it wanted to handle).

## Fix

Return `ok: true` for any completed HTTP exchange in the simple path, matching the request-context branch. A 404/500 response is data for the caller, not a fetch failure; transport errors still surface as op exceptions.

The `ok` field is kept (always `true` on completed exchanges) for wire-format compatibility with the request-context branch, which shares the same JS consumer.

`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in fetch responses by reporting completed HTTP exchanges as successful, including responses with non-2xx status codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->