### PR TITLE
fix(fetch): exclude 5xx responses from the shared fetch cache

### DIFF
--- a/crates/rari/src/server/middleware/request_context.rs
+++ b/crates/rari/src/server/middleware/request_context.rs
@@ -63,6 +63,17 @@ pub struct CachedFetchResult {
     pub was_cached: bool,
     pub tags: Vec<String>,
 }
+
+impl CachedFetchResult {
+    /// 5xx responses are never cached: a transient backend error cached here
+    /// is replayed to every render for the TTL (default 60s), turning a blip
+    /// into a minute of failures. 4xx stays cacheable — a missing article is
+    /// stable data worth deduplicating.
+    fn is_cacheable(&self) -> bool {
+        self.status < 500
+    }
+}
+
 type InFlightFetches =
     Arc<DashMap<String, Arc<TokioMutex<Option<Result<CachedFetchResult, RariError>>>>>>;
 
@@ -278,8 +289,10 @@ impl RequestContext {
                 if let Ok(ref mut cached) = result {
                     cached.tags = Self::merge_and_sort_tags(mem::take(&mut cached.tags), tags);
                     *guard = Some(Ok(cached.clone()));
-                    let mut cache = fetch_cache.lock();
-                    cache.put(cache_key_for_task, cached.clone());
+                    if cached.is_cacheable() {
+                        let mut cache = fetch_cache.lock();
+                        cache.put(cache_key_for_task, cached.clone());
+                    }
                 }
                 return result;
             }
@@ -292,7 +305,9 @@ impl RequestContext {
 
             *guard = Some(fetch_result.clone());
 
-            if let Ok(ref cached_result) = fetch_result {
+            if let Ok(ref cached_result) = fetch_result
+                && cached_result.is_cacheable()
+            {
                 let mut cache = fetch_cache.lock();
                 cache.put(cache_key_for_task, cached_result.clone());
             }


### PR DESCRIPTION
## Problem

`RequestContext::fetch_with_cache` inserts every completed fetch into `GLOBAL_FETCH_CACHE` regardless of status. A transient backend 5xx (deploy blip, brief overload) is cached and replayed to every render sharing that cache key for the full TTL — with the default 60s TTL, a one-request blip becomes a minute of failed renders.

## Fix

Gate both insert sites (the singleflight replay branch and the fresh-fetch branch) on `CachedFetchResult::is_cacheable()` — `status < 500`. 4xx stays cacheable on purpose: a missing article is stable data worth deduplicating; 5xx is transient and should be retried on the next render.

`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features` clean.