### PR TITLE
feat(cache): byte budget for the memory cache handler

### DIFF
--- a/crates/rari/src/rendering/layout/core.rs
+++ b/crates/rari/src/rendering/layout/core.rs
@@ -129,7 +129,7 @@ impl LayoutHtmlCache {
     }
 
     pub fn from_config(layer: &CacheLayerConfig, registry: &CacheHandlerRegistry) -> Self {
-        let handler = registry.resolve(&layer.handler);
+        let handler = registry.resolve_configured(&layer.handler, &layer.memory_config());
         Self::with_ttl(handler, layer.default_ttl_secs)
     }
 

--- a/crates/rari/src/rendering/layout/core.rs
+++ b/crates/rari/src/rendering/layout/core.rs
@@ -122,7 +122,7 @@ impl LayoutHtmlCache {
             Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
                 max_entries: 5000,
                 default_ttl: 3600,
-                max_bytes: 0,
+                ..Default::default()
             })),
             3600,
         )

--- a/crates/rari/src/rendering/layout/core.rs
+++ b/crates/rari/src/rendering/layout/core.rs
@@ -122,6 +122,7 @@ impl LayoutHtmlCache {
             Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
                 max_entries: 5000,
                 default_ttl: 3600,
+                max_bytes: 0,
             })),
             3600,
         )

--- a/crates/rari/src/runtime/ext/rari/cache/mod.rs
+++ b/crates/rari/src/runtime/ext/rari/cache/mod.rs
@@ -36,6 +36,7 @@ mod tests {
             url: url.map(String::from),
             max_entries: 1000,
             default_ttl_secs: 60,
+            max_bytes: 0,
         }
     }
 

--- a/crates/rari/src/runtime/ext/rari/cache/mod.rs
+++ b/crates/rari/src/runtime/ext/rari/cache/mod.rs
@@ -36,7 +36,7 @@ mod tests {
             url: url.map(String::from),
             max_entries: 1000,
             default_ttl_secs: 60,
-            max_bytes: 0,
+            ..Default::default()
         }
     }
 

--- a/crates/rari/src/runtime/module_loader/cache.rs
+++ b/crates/rari/src/runtime/module_loader/cache.rs
@@ -59,7 +59,7 @@ impl ModuleCaching {
     }
 
     pub fn from_config(layer: &CacheLayerConfig, registry: &CacheHandlerRegistry) -> Self {
-        let handler = registry.resolve(&layer.handler);
+        let handler = registry.resolve_configured(&layer.handler, &layer.memory_config());
         Self::with_handler(layer.max_entries, layer.default_ttl_secs, handler)
     }
 

--- a/crates/rari/src/runtime/module_loader/cache.rs
+++ b/crates/rari/src/runtime/module_loader/cache.rs
@@ -45,6 +45,7 @@ impl ModuleCaching {
             Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
                 max_entries: cache_size.max(1),
                 default_ttl: ttl_secs,
+                max_bytes: 0,
             })),
         )
     }

--- a/crates/rari/src/runtime/module_loader/cache.rs
+++ b/crates/rari/src/runtime/module_loader/cache.rs
@@ -45,7 +45,7 @@ impl ModuleCaching {
             Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
                 max_entries: cache_size.max(1),
                 default_ttl: ttl_secs,
-                max_bytes: 0,
+                ..Default::default()
             })),
         )
     }

--- a/crates/rari/src/runtime/module_loader/core.rs
+++ b/crates/rari/src/runtime/module_loader/core.rs
@@ -174,7 +174,7 @@ impl RariModuleLoader {
             url: None,
             max_entries: config.cache_size_limit,
             default_ttl_secs: DEFAULT_TTL_SECS,
-            max_bytes: 0,
+            ..Default::default()
         };
         let module_caching = ModuleCaching::from_config(&layer, registry);
         let node_resolver = resolver.node_resolver();

--- a/crates/rari/src/runtime/module_loader/core.rs
+++ b/crates/rari/src/runtime/module_loader/core.rs
@@ -174,6 +174,7 @@ impl RariModuleLoader {
             url: None,
             max_entries: config.cache_size_limit,
             default_ttl_secs: DEFAULT_TTL_SECS,
+            max_bytes: 0,
         };
         let module_caching = ModuleCaching::from_config(&layer, registry);
         let node_resolver = resolver.node_resolver();

--- a/crates/rari/src/server/cache/handler.rs
+++ b/crates/rari/src/server/cache/handler.rs
@@ -72,6 +72,12 @@ pub trait CacheHandler: Send + Sync + fmt::Debug {
     }
 
     fn get_all_keys(&self) -> Vec<String>;
+
+    /// Exact total payload bytes currently stored, when the backend can
+    /// report it. `None` when the backend cannot.
+    fn total_bytes(&self) -> Option<usize> {
+        None
+    }
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -94,11 +100,15 @@ struct MemEntry {
 pub struct MemoryConfig {
     pub max_entries: usize,
     pub default_ttl: u64,
+    /// Total payload byte budget across all entries. `0` = unlimited
+    /// (entry-count LRU only). Entry counts alone don't bound memory:
+    /// 1000 multi-MB pages is gigabytes resident.
+    pub max_bytes: usize,
 }
 
 impl Default for MemoryConfig {
     fn default() -> Self {
-        Self { max_entries: 1000, default_ttl: 31_536_000 }
+        Self { max_entries: 1000, default_ttl: 31_536_000, max_bytes: 0 }
     }
 }
 
@@ -108,6 +118,8 @@ pub struct MemoryCacheHandler {
     lru: Mutex<LruCache<String, ()>>,
     tag_index: DashMap<String, Vec<String>>,
     max_entries: usize,
+    max_bytes: usize,
+    total_bytes: std::sync::atomic::AtomicUsize,
 }
 
 impl MemoryCacheHandler {
@@ -124,6 +136,8 @@ impl MemoryCacheHandler {
             lru: Mutex::new(LruCache::new(max_entries)),
             tag_index: DashMap::new(),
             max_entries: max_entries.get(),
+            max_bytes: config.max_bytes,
+            total_bytes: std::sync::atomic::AtomicUsize::new(0),
         }
     }
 
@@ -137,6 +151,10 @@ impl MemoryCacheHandler {
 
     pub fn max_entries(&self) -> usize {
         self.max_entries
+    }
+
+    fn stored_bytes(&self) -> usize {
+        self.total_bytes.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     fn expires_at(ttl_secs: u64) -> Option<Instant> {
@@ -159,6 +177,7 @@ impl MemoryCacheHandler {
         let (_key, entry) = self.cache.remove(key)?;
         self.remove_from_tag_index(key, &entry.tags);
         self.lru.lock().pop(key);
+        self.total_bytes.fetch_sub(entry.bytes.len(), std::sync::atomic::Ordering::Relaxed);
         Some(entry)
     }
 
@@ -275,6 +294,27 @@ impl CacheHandler for MemoryCacheHandler {
         let mut evicted = 0usize;
         let mut evicted_bytes = 0usize;
 
+        // A single value larger than the whole byte budget can never fit;
+        // storing it would evict everything else for a guaranteed-evicted
+        // entry. Skip caching it.
+        if self.max_bytes > 0 && value.len() > self.max_bytes {
+            tracing::warn!(
+                key = %key,
+                size_bytes = value.len(),
+                max_bytes = self.max_bytes,
+                "memory cache value exceeds byte budget; not cached"
+            );
+            return Ok(SetOutcome { replaced, evicted, evicted_bytes });
+        }
+
+        // Evict LRU entries until the new value fits the byte budget.
+        while self.max_bytes > 0 && self.stored_bytes().saturating_add(value.len()) > self.max_bytes
+        {
+            let Some(entry) = self.evict_lru_with_entry() else { break };
+            evicted += 1;
+            evicted_bytes = evicted_bytes.saturating_add(entry.bytes.len());
+        }
+
         let mut lru = self.lru.lock();
         if !replaced && lru.len() >= self.max_entries {
             drop(lru);
@@ -285,6 +325,7 @@ impl CacheHandler for MemoryCacheHandler {
             lru = self.lru.lock();
         }
 
+        self.total_bytes.fetch_add(value.len(), std::sync::atomic::Ordering::Relaxed);
         let entry =
             MemEntry { bytes: value, expires_at: Self::expires_at(ttl_secs), tags: tags.to_vec() };
         self.cache.insert(key.to_string(), entry);
@@ -330,6 +371,7 @@ impl CacheHandler for MemoryCacheHandler {
         let n = self.cache.len();
         self.cache.clear();
         self.tag_index.clear();
+        self.total_bytes.store(0, std::sync::atomic::Ordering::Relaxed);
         let mut lru = self.lru.lock();
         lru.clear();
         tracing::debug!(cleared_entries = n, "memory cache clear");
@@ -339,14 +381,17 @@ impl CacheHandler for MemoryCacheHandler {
     async fn clear_prefix(&self, prefix: &str) -> Result<usize, CacheError> {
         let prefix = prefix.to_owned();
         let mut removed_entries: Vec<(String, Vec<String>)> = Vec::new();
+        let mut removed_bytes = 0usize;
         self.cache.retain(|key, entry| {
             if key.starts_with(&prefix) {
                 removed_entries.push((key.clone(), entry.tags.clone()));
+                removed_bytes = removed_bytes.saturating_add(entry.bytes.len());
                 false
             } else {
                 true
             }
         });
+        self.total_bytes.fetch_sub(removed_bytes, std::sync::atomic::Ordering::Relaxed);
         let removed = removed_entries.len();
         {
             let mut lru = self.lru.lock();
@@ -365,6 +410,10 @@ impl CacheHandler for MemoryCacheHandler {
 
     fn get_all_keys(&self) -> Vec<String> {
         self.cache.iter().map(|e| e.key().clone()).collect()
+    }
+
+    fn total_bytes(&self) -> Option<usize> {
+        Some(self.stored_bytes())
     }
 }
 
@@ -497,8 +546,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_memory_lru_eviction() {
-        let handler =
-            MemoryCacheHandler::with_config(&MemoryConfig { max_entries: 2, default_ttl: 60 });
+        let handler = MemoryCacheHandler::with_config(&MemoryConfig {
+            max_entries: 2,
+            default_ttl: 60,
+            max_bytes: 0,
+        });
         handler.set("a", b"1".to_vec(), 60).await.unwrap();
         handler.set("b", b"2".to_vec(), 60).await.unwrap();
         let _ = handler.get("a").await.unwrap();
@@ -506,6 +558,69 @@ mod tests {
         assert_eq!(handler.get("a").await.unwrap(), Some(b"1".to_vec()));
         assert_eq!(handler.get("b").await.unwrap(), None);
         assert_eq!(handler.get("c").await.unwrap(), Some(b"3".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn test_byte_budget_evicts_lru_until_fit() {
+        let handler = MemoryCacheHandler::with_config(&MemoryConfig {
+            max_entries: 100,
+            default_ttl: 60,
+            max_bytes: 10,
+        });
+        handler.set("a", vec![0u8; 4], 60).await.unwrap();
+        handler.set("b", vec![0u8; 4], 60).await.unwrap();
+        // "a" is LRU; inserting 4 more bytes exceeds the 10-byte budget.
+        let outcome = handler.set("c", vec![0u8; 4], 60).await.unwrap();
+
+        assert_eq!(outcome.evicted, 1);
+        assert_eq!(outcome.evicted_bytes, 4);
+        assert_eq!(handler.get("a").await.unwrap(), None);
+        assert!(handler.get("b").await.unwrap().is_some());
+        assert!(handler.get("c").await.unwrap().is_some());
+        assert_eq!(handler.total_bytes(), Some(8));
+    }
+
+    #[tokio::test]
+    async fn test_byte_budget_rejects_oversized_value() {
+        let handler = MemoryCacheHandler::with_config(&MemoryConfig {
+            max_entries: 100,
+            default_ttl: 60,
+            max_bytes: 10,
+        });
+        handler.set("small", vec![0u8; 4], 60).await.unwrap();
+        // Larger than the whole budget: not cached, existing entries survive.
+        let outcome = handler.set("huge", vec![0u8; 11], 60).await.unwrap();
+
+        assert_eq!(outcome.evicted, 0);
+        assert_eq!(handler.get("huge").await.unwrap(), None);
+        assert!(handler.get("small").await.unwrap().is_some());
+        assert_eq!(handler.total_bytes(), Some(4));
+    }
+
+    #[tokio::test]
+    async fn test_total_bytes_tracks_all_removal_paths() {
+        let handler = MemoryCacheHandler::default();
+        handler.set("a", vec![0u8; 3], 60).await.unwrap();
+        handler.set_with_tags("b", vec![0u8; 5], 60, &["t".to_string()]).await.unwrap();
+        handler.set("p:c", vec![0u8; 7], 60).await.unwrap();
+        assert_eq!(handler.total_bytes(), Some(15));
+
+        // replace
+        handler.set("a", vec![0u8; 4], 60).await.unwrap();
+        assert_eq!(handler.total_bytes(), Some(16));
+
+        // invalidate + by-tag + prefix
+        handler.invalidate("a").await.unwrap();
+        assert_eq!(handler.total_bytes(), Some(12));
+        handler.invalidate_by_tag("t").await.unwrap();
+        assert_eq!(handler.total_bytes(), Some(7));
+        handler.clear_prefix("p:").await.unwrap();
+        assert_eq!(handler.total_bytes(), Some(0));
+
+        // clear
+        handler.set("d", vec![0u8; 9], 60).await.unwrap();
+        handler.clear().await.unwrap();
+        assert_eq!(handler.total_bytes(), Some(0));
     }
 
     #[tokio::test]

--- a/crates/rari/src/server/cache/handler.rs
+++ b/crates/rari/src/server/cache/handler.rs
@@ -93,7 +93,13 @@ pub trait CacheHandler: Send + Sync + fmt::Debug {
 pub struct SetOutcome {
     pub replaced: bool,
     pub evicted: usize,
+    /// Bytes removed from the cache by this set: LRU/byte-budget evictions
+    /// plus any replaced entry under the same key. Callers mirroring their
+    /// own byte accounting subtract this.
     pub evicted_bytes: usize,
+    /// `false` when the value was not admitted (e.g. larger than the whole
+    /// byte budget); callers that pre-counted the value must back it out.
+    pub stored: bool,
 }
 
 #[derive(Debug)]
@@ -309,9 +315,10 @@ impl CacheHandler for MemoryCacheHandler {
             tag_count = tags.len(),
             "memory cache set_with_tags"
         );
-        let replaced = self.remove_entry(key).is_some();
+        let old_bytes = self.remove_entry(key).map(|e| e.bytes.len());
+        let replaced = old_bytes.is_some();
         let mut evicted = 0usize;
-        let mut evicted_bytes = 0usize;
+        let mut evicted_bytes = old_bytes.unwrap_or(0);
 
         // A single value larger than the whole byte budget can never fit;
         // storing it would evict everything else for a guaranteed-evicted
@@ -325,7 +332,7 @@ impl CacheHandler for MemoryCacheHandler {
                 max_bytes = self.max_bytes,
                 "memory cache value exceeds byte budget; not cached"
             );
-            return Ok(SetOutcome { replaced, evicted, evicted_bytes });
+            return Ok(SetOutcome { replaced, evicted, evicted_bytes, stored: false });
         }
 
         // Evict LRU entries until the new value fits the byte budget.
@@ -365,7 +372,7 @@ impl CacheHandler for MemoryCacheHandler {
             }
         }
 
-        Ok(SetOutcome { replaced, evicted, evicted_bytes })
+        Ok(SetOutcome { replaced, evicted, evicted_bytes, stored: true })
     }
 
     async fn invalidate(&self, key: &str) -> Result<bool, CacheError> {

--- a/crates/rari/src/server/cache/handler.rs
+++ b/crates/rari/src/server/cache/handler.rs
@@ -566,6 +566,23 @@ impl CacheHandlerRegistry {
             Arc::clone(&entry)
         })
     }
+
+    pub fn resolve_configured(
+        &self,
+        configured_name: &str,
+        memory: &MemoryConfig,
+    ) -> Arc<dyn CacheHandler> {
+        if configured_name == "memory" {
+            return Arc::new(MemoryCacheHandler::with_config(memory));
+        }
+        self.get(configured_name).unwrap_or_else(|| {
+            tracing::warn!(
+                configured = %configured_name,
+                "configured cache handler not registered; falling back to memory"
+            );
+            Arc::new(MemoryCacheHandler::with_config(memory))
+        })
+    }
 }
 
 #[cfg(test)]
@@ -783,6 +800,23 @@ mod tests {
         let handler = registry.resolve("no-such-handler");
         handler.set("k", b"v".to_vec(), 60).await.unwrap();
         assert_eq!(handler.get("k").await.unwrap(), Some(b"v".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_configured_applies_byte_budget() {
+        let registry = CacheHandlerRegistry::default_with_memory();
+        let memory = MemoryConfig { max_entries: 8, default_ttl: 60, max_bytes: 9 };
+        let handler = registry.resolve_configured("memory", &memory);
+        let first =
+            handler.set("a", b"12345".to_vec(), 60).await.expect("first set should succeed");
+        assert!(first.stored);
+        let second =
+            handler.set("b", b"67890".to_vec(), 60).await.expect("second set should succeed");
+        assert!(second.stored);
+        assert_eq!(second.evicted, 1);
+        assert_eq!(handler.total_bytes(), Some(5));
+        assert_eq!(handler.get("a").await.unwrap(), None);
+        assert_eq!(handler.get("b").await.unwrap(), Some(b"67890".to_vec()));
     }
 
     #[tokio::test]

--- a/crates/rari/src/server/cache/handler.rs
+++ b/crates/rari/src/server/cache/handler.rs
@@ -78,6 +78,14 @@ pub trait CacheHandler: Send + Sync + fmt::Debug {
     fn total_bytes(&self) -> Option<usize> {
         None
     }
+
+    /// Exact payload bytes stored under `prefix`, when the backend can
+    /// report it. `None` when the backend cannot. Callers sharing one
+    /// handler across cache layers need this instead of `total_bytes`,
+    /// which counts every layer's entries.
+    fn prefix_bytes(&self, _prefix: &str) -> Option<usize> {
+        None
+    }
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -307,7 +315,9 @@ impl CacheHandler for MemoryCacheHandler {
 
         // A single value larger than the whole byte budget can never fit;
         // storing it would evict everything else for a guaranteed-evicted
-        // entry. Skip caching it.
+        // entry. Skip caching it. The old entry stays removed on purpose:
+        // set() means the old value is outdated, and a miss beats serving
+        // stale data.
         if self.max_bytes > 0 && value.len() > self.max_bytes {
             tracing::warn!(
                 key = %key,
@@ -425,6 +435,16 @@ impl CacheHandler for MemoryCacheHandler {
 
     fn total_bytes(&self) -> Option<usize> {
         Some(self.stored_bytes())
+    }
+
+    fn prefix_bytes(&self, prefix: &str) -> Option<usize> {
+        Some(
+            self.cache
+                .iter()
+                .filter(|e| e.key().starts_with(prefix))
+                .map(|e| e.value().bytes.len())
+                .sum(),
+        )
     }
 }
 

--- a/crates/rari/src/server/cache/handler.rs
+++ b/crates/rari/src/server/cache/handler.rs
@@ -157,6 +157,17 @@ impl MemoryCacheHandler {
         self.total_bytes.load(std::sync::atomic::Ordering::Relaxed)
     }
 
+    /// Saturating subtraction: a raw `fetch_sub` wraps on underflow, and a
+    /// wrapped counter makes the byte-budget check pass forever. Any
+    /// accounting drift saturates at 0 instead of disabling the budget.
+    fn sub_stored_bytes(&self, n: usize) {
+        let _ = self.total_bytes.fetch_update(
+            std::sync::atomic::Ordering::Relaxed,
+            std::sync::atomic::Ordering::Relaxed,
+            |current| Some(current.saturating_sub(n)),
+        );
+    }
+
     fn expires_at(ttl_secs: u64) -> Option<Instant> {
         if ttl_secs == 0 {
             Some(Instant::now())
@@ -177,7 +188,7 @@ impl MemoryCacheHandler {
         let (_key, entry) = self.cache.remove(key)?;
         self.remove_from_tag_index(key, &entry.tags);
         self.lru.lock().pop(key);
-        self.total_bytes.fetch_sub(entry.bytes.len(), std::sync::atomic::Ordering::Relaxed);
+        self.sub_stored_bytes(entry.bytes.len());
         Some(entry)
     }
 
@@ -391,7 +402,7 @@ impl CacheHandler for MemoryCacheHandler {
                 true
             }
         });
-        self.total_bytes.fetch_sub(removed_bytes, std::sync::atomic::Ordering::Relaxed);
+        self.sub_stored_bytes(removed_bytes);
         let removed = removed_entries.len();
         {
             let mut lru = self.lru.lock();
@@ -549,7 +560,7 @@ mod tests {
         let handler = MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: 2,
             default_ttl: 60,
-            max_bytes: 0,
+            ..Default::default()
         });
         handler.set("a", b"1".to_vec(), 60).await.unwrap();
         handler.set("b", b"2".to_vec(), 60).await.unwrap();

--- a/crates/rari/src/server/cache/handler.rs
+++ b/crates/rari/src/server/cache/handler.rs
@@ -393,6 +393,7 @@ impl CacheHandler for MemoryCacheHandler {
     }
 
     async fn invalidate(&self, key: &str) -> Result<bool, CacheError> {
+        let _mutate = self.mutate.lock();
         if self.remove_entry(key).is_none() {
             tracing::debug!(key = %key, "memory cache invalidate (no-op, not present)");
             return Ok(false);
@@ -404,11 +405,12 @@ impl CacheHandler for MemoryCacheHandler {
     }
 
     async fn invalidate_by_tag(&self, tag: &str) -> Result<(), CacheError> {
+        let _mutate = self.mutate.lock();
         let keys: Vec<String> =
             self.tag_index.get(tag).map(|e| e.value().clone()).unwrap_or_default();
         tracing::debug!(tag = %tag, key_count = keys.len(), "memory cache invalidate_by_tag");
         for key in keys {
-            self.invalidate(&key).await?;
+            let _ = self.remove_entry(&key);
         }
         let empty = self.tag_index.get(tag).map(|e| e.value().is_empty()).unwrap_or(true);
         if empty {

--- a/crates/rari/src/server/cache/handler.rs
+++ b/crates/rari/src/server/cache/handler.rs
@@ -349,7 +349,12 @@ impl CacheHandler for MemoryCacheHandler {
         self.total_bytes.fetch_add(value.len(), std::sync::atomic::Ordering::Relaxed);
         let entry =
             MemEntry { bytes: value, expires_at: Self::expires_at(ttl_secs), tags: tags.to_vec() };
-        self.cache.insert(key.to_string(), entry);
+        // A concurrent set of the same key can land between the remove_entry
+        // above and this insert; the overwritten entry's bytes must come off
+        // the counter or they leak until the byte budget is exhausted.
+        if let Some(old_entry) = self.cache.insert(key.to_string(), entry) {
+            self.sub_stored_bytes(old_entry.bytes.len());
+        }
         self.insert_tag_index(key, tags);
 
         if let Some((evicted_key, ())) = lru.push(key.to_string(), ()) {

--- a/crates/rari/src/server/cache/handler.rs
+++ b/crates/rari/src/server/cache/handler.rs
@@ -161,7 +161,7 @@ impl MemoryCacheHandler {
     /// wrapped counter makes the byte-budget check pass forever. Any
     /// accounting drift saturates at 0 instead of disabling the budget.
     fn sub_stored_bytes(&self, n: usize) {
-        let _ = self.total_bytes.fetch_update(
+        let _ = self.total_bytes.try_update(
             std::sync::atomic::Ordering::Relaxed,
             std::sync::atomic::Ordering::Relaxed,
             |current| Some(current.saturating_sub(n)),

--- a/crates/rari/src/server/cache/handler.rs
+++ b/crates/rari/src/server/cache/handler.rs
@@ -14,7 +14,10 @@ use std::{
     fmt,
     io::Error,
     num::NonZeroUsize,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
     time::{Duration, Instant},
 };
 
@@ -86,6 +89,14 @@ pub trait CacheHandler: Send + Sync + fmt::Debug {
     fn prefix_bytes(&self, _prefix: &str) -> Option<usize> {
         None
     }
+
+    /// Entry count and optional payload bytes under `prefix` in one pass.
+    /// Default walks keys then asks `prefix_bytes`; backends that can should
+    /// override with a single scan.
+    fn prefix_stats(&self, prefix: &str) -> (usize, Option<usize>) {
+        let count = self.get_all_keys().iter().filter(|k| k.starts_with(prefix)).count();
+        (count, self.prefix_bytes(prefix))
+    }
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -133,7 +144,7 @@ pub struct MemoryCacheHandler {
     tag_index: DashMap<String, Vec<String>>,
     max_entries: usize,
     max_bytes: usize,
-    total_bytes: std::sync::atomic::AtomicUsize,
+    total_bytes: AtomicUsize,
 }
 
 impl MemoryCacheHandler {
@@ -151,7 +162,7 @@ impl MemoryCacheHandler {
             tag_index: DashMap::new(),
             max_entries: max_entries.get(),
             max_bytes: config.max_bytes,
-            total_bytes: std::sync::atomic::AtomicUsize::new(0),
+            total_bytes: AtomicUsize::new(0),
         }
     }
 
@@ -168,18 +179,16 @@ impl MemoryCacheHandler {
     }
 
     fn stored_bytes(&self) -> usize {
-        self.total_bytes.load(std::sync::atomic::Ordering::Relaxed)
+        self.total_bytes.load(Ordering::Relaxed)
     }
 
     /// Saturating subtraction: a raw `fetch_sub` wraps on underflow, and a
     /// wrapped counter makes the byte-budget check pass forever. Any
     /// accounting drift saturates at 0 instead of disabling the budget.
     fn sub_stored_bytes(&self, n: usize) {
-        let _ = self.total_bytes.try_update(
-            std::sync::atomic::Ordering::Relaxed,
-            std::sync::atomic::Ordering::Relaxed,
-            |current| Some(current.saturating_sub(n)),
-        );
+        let _ = self.total_bytes.try_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+            Some(current.saturating_sub(n))
+        });
     }
 
     fn expires_at(ttl_secs: u64) -> Option<Instant> {
@@ -353,14 +362,17 @@ impl CacheHandler for MemoryCacheHandler {
             lru = self.lru.lock();
         }
 
-        self.total_bytes.fetch_add(value.len(), std::sync::atomic::Ordering::Relaxed);
+        self.total_bytes.fetch_add(value.len(), Ordering::Relaxed);
         let entry =
             MemEntry { bytes: value, expires_at: Self::expires_at(ttl_secs), tags: tags.to_vec() };
         // A concurrent set of the same key can land between the remove_entry
         // above and this insert; the overwritten entry's bytes must come off
         // the counter or they leak until the byte budget is exhausted.
         if let Some(old_entry) = self.cache.insert(key.to_string(), entry) {
-            self.sub_stored_bytes(old_entry.bytes.len());
+            let overwritten = old_entry.bytes.len();
+            self.sub_stored_bytes(overwritten);
+            evicted += 1;
+            evicted_bytes = evicted_bytes.saturating_add(overwritten);
         }
         self.insert_tag_index(key, tags);
 
@@ -464,6 +476,18 @@ impl CacheHandler for MemoryCacheHandler {
                 .map(|e| e.value().bytes.len())
                 .sum(),
         )
+    }
+
+    fn prefix_stats(&self, prefix: &str) -> (usize, Option<usize>) {
+        let mut count = 0usize;
+        let mut bytes = 0usize;
+        for entry in &self.cache {
+            if entry.key().starts_with(prefix) {
+                count += 1;
+                bytes = bytes.saturating_add(entry.value().bytes.len());
+            }
+        }
+        (count, Some(bytes))
     }
 }
 

--- a/crates/rari/src/server/cache/handler.rs
+++ b/crates/rari/src/server/cache/handler.rs
@@ -395,9 +395,16 @@ impl CacheHandler for MemoryCacheHandler {
 
     async fn clear(&self) -> Result<(), CacheError> {
         let n = self.cache.len();
-        self.cache.clear();
+        // Subtract exactly what was removed instead of store(0): a concurrent
+        // set landing around the reset would leave its inserted bytes
+        // untracked (or tracked twice) forever.
+        let mut removed_bytes = 0usize;
+        self.cache.retain(|_, entry| {
+            removed_bytes = removed_bytes.saturating_add(entry.bytes.len());
+            false
+        });
         self.tag_index.clear();
-        self.total_bytes.store(0, std::sync::atomic::Ordering::Relaxed);
+        self.sub_stored_bytes(removed_bytes);
         let mut lru = self.lru.lock();
         lru.clear();
         tracing::debug!(cleared_entries = n, "memory cache clear");

--- a/crates/rari/src/server/cache/handler.rs
+++ b/crates/rari/src/server/cache/handler.rs
@@ -142,6 +142,7 @@ pub struct MemoryCacheHandler {
     cache: DashMap<String, MemEntry>,
     lru: Mutex<LruCache<String, ()>>,
     tag_index: DashMap<String, Vec<String>>,
+    mutate: Mutex<()>,
     max_entries: usize,
     max_bytes: usize,
     total_bytes: AtomicUsize,
@@ -160,6 +161,7 @@ impl MemoryCacheHandler {
             cache: DashMap::new(),
             lru: Mutex::new(LruCache::new(max_entries)),
             tag_index: DashMap::new(),
+            mutate: Mutex::new(()),
             max_entries: max_entries.get(),
             max_bytes: config.max_bytes,
             total_bytes: AtomicUsize::new(0),
@@ -324,6 +326,7 @@ impl CacheHandler for MemoryCacheHandler {
             tag_count = tags.len(),
             "memory cache set_with_tags"
         );
+        let _mutate = self.mutate.lock();
         let old_bytes = self.remove_entry(key).map(|e| e.bytes.len());
         let replaced = old_bytes.is_some();
         let mut evicted = 0usize;
@@ -371,6 +374,8 @@ impl CacheHandler for MemoryCacheHandler {
         if let Some(old_entry) = self.cache.insert(key.to_string(), entry) {
             let overwritten = old_entry.bytes.len();
             self.sub_stored_bytes(overwritten);
+            self.remove_from_tag_index(key, &old_entry.tags);
+            lru.pop(key);
             evicted += 1;
             evicted_bytes = evicted_bytes.saturating_add(overwritten);
         }
@@ -413,6 +418,7 @@ impl CacheHandler for MemoryCacheHandler {
     }
 
     async fn clear(&self) -> Result<(), CacheError> {
+        let _mutate = self.mutate.lock();
         let n = self.cache.len();
         // Subtract exactly what was removed instead of store(0): a concurrent
         // set landing around the reset would leave its inserted bytes
@@ -424,13 +430,13 @@ impl CacheHandler for MemoryCacheHandler {
         });
         self.tag_index.clear();
         self.sub_stored_bytes(removed_bytes);
-        let mut lru = self.lru.lock();
-        lru.clear();
+        self.lru.lock().clear();
         tracing::debug!(cleared_entries = n, "memory cache clear");
         Ok(())
     }
 
     async fn clear_prefix(&self, prefix: &str) -> Result<usize, CacheError> {
+        let _mutate = self.mutate.lock();
         let prefix = prefix.to_owned();
         let mut removed_entries: Vec<(String, Vec<String>)> = Vec::new();
         let mut removed_bytes = 0usize;

--- a/crates/rari/src/server/cache/response.rs
+++ b/crates/rari/src/server/cache/response.rs
@@ -196,6 +196,8 @@ pub struct CacheConfig {
     pub max_entries: usize,
     pub default_ttl: u64,
     pub enabled: bool,
+    /// Total payload byte budget for the memory handler. `0` = unlimited.
+    pub max_bytes: usize,
 }
 
 impl CacheConfig {
@@ -217,6 +219,10 @@ impl CacheConfig {
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(is_production),
+            max_bytes: env::var("RARI_CACHE_MAX_BYTES")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(0),
         }
     }
 
@@ -234,6 +240,10 @@ impl CacheConfig {
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(is_production),
+            max_bytes: env::var("RARI_CACHE_MAX_BYTES")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(layer.max_bytes),
         }
     }
 }
@@ -305,7 +315,7 @@ impl RouteCachePolicy {
 
 impl Default for CacheConfig {
     fn default() -> Self {
-        Self { max_entries: 1000, default_ttl: 60, enabled: true }
+        Self { max_entries: 1000, default_ttl: 60, enabled: true, max_bytes: 0 }
     }
 }
 
@@ -339,6 +349,7 @@ impl ResponseCache {
         let handler = MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: config.max_entries,
             default_ttl: config.default_ttl,
+            max_bytes: config.max_bytes,
         });
         Self::new_with_handler(config, Arc::new(handler))
     }
@@ -625,9 +636,12 @@ impl ResponseCache {
 
     fn update_entry_count_metrics(&self) {
         let n = self.entry_count.load(Ordering::Relaxed);
+        // Exact when the backend reports payload bytes; rough per-entry
+        // estimate otherwise.
+        let usage = self.handler.total_bytes().unwrap_or(n * 10_000);
         let mut metrics = self.metrics.lock();
         metrics.total_entries = n;
-        metrics.memory_usage_bytes = n * 10_000;
+        metrics.memory_usage_bytes = usage;
     }
 
     fn resync_entry_count(&self) {
@@ -768,7 +782,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_basic_operations() {
-        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true };
+        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, max_bytes: 0 };
         let cache = ResponseCache::new(config);
 
         assert!(cache.get("test-key").await.is_none());
@@ -788,7 +802,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_expiration() {
-        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true };
+        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, max_bytes: 0 };
         let cache = ResponseCache::new(config);
 
         let response = create_test_response("test body", 0);
@@ -801,7 +815,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_invalidation() {
-        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true };
+        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, max_bytes: 0 };
         let cache = ResponseCache::new(config);
 
         let response = create_test_response("test body", 60);
@@ -816,7 +830,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_tag_invalidation() {
-        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true };
+        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, max_bytes: 0 };
         let cache = ResponseCache::new(config);
 
         let mut response1 = create_test_response("body1", 60);
@@ -839,7 +853,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_lru_eviction() {
-        let config = CacheConfig { max_entries: 2, default_ttl: 60, enabled: true };
+        let config = CacheConfig { max_entries: 2, default_ttl: 60, enabled: true, max_bytes: 0 };
         let cache = ResponseCache::new(config);
 
         cache.set("key1".to_string(), create_test_response("body1", 60)).await;
@@ -857,7 +871,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_disabled() {
-        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: false };
+        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: false, max_bytes: 0 };
         let cache = ResponseCache::new(config);
 
         let response = create_test_response("test body", 60);
@@ -868,7 +882,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_clear() {
-        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true };
+        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, max_bytes: 0 };
         let cache = ResponseCache::new(config);
 
         cache.set("key1".to_string(), create_test_response("body1", 60)).await;
@@ -885,7 +899,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_clear_percentage() {
-        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true };
+        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, max_bytes: 0 };
         let cache = ResponseCache::new(config);
 
         for i in 0..10 {
@@ -903,7 +917,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_memory_pressure_detection() {
-        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true };
+        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, max_bytes: 0 };
         let cache = ResponseCache::new(config);
 
         for i in 0..8 {
@@ -1061,7 +1075,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_handler_is_memory_by_default() {
-        let config = CacheConfig { max_entries: 2, default_ttl: 60, enabled: true };
+        let config = CacheConfig { max_entries: 2, default_ttl: 60, enabled: true, max_bytes: 0 };
         let cache = ResponseCache::new(config);
 
         cache.set("a".to_string(), create_test_response("body-a", 60)).await;
@@ -1075,7 +1089,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_new_with_custom_handler() {
         let stub = Arc::new(StubHandler::default());
-        let config = CacheConfig { max_entries: 100, default_ttl: 60, enabled: true };
+        let config = CacheConfig { max_entries: 100, default_ttl: 60, enabled: true, max_bytes: 0 };
         let cache = ResponseCache::new_with_handler(config, stub.clone());
 
         cache.set("k".to_string(), create_test_response("v", 60)).await;
@@ -1096,10 +1110,11 @@ mod tests {
             Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
                 max_entries: 32,
                 default_ttl: 60,
+                max_bytes: 0,
             }));
 
         let response_cache = ResponseCache::new_with_handler(
-            CacheConfig { max_entries: 32, default_ttl: 60, enabled: true },
+            CacheConfig { max_entries: 32, default_ttl: 60, enabled: true, max_bytes: 0 },
             shared.clone(),
         );
         let test_dir = env::temp_dir().join("rari-test-cache-namespace");
@@ -1131,7 +1146,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_serialized_response_round_trip() {
-        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true };
+        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, max_bytes: 0 };
         let cache = ResponseCache::new(config);
 
         let mut headers = HeaderMap::new();
@@ -1176,7 +1191,7 @@ mod tests {
         // paths like `update_in_place` that re-serialize an existing
         // `CachedResponse` would silently reset `cached_at` to the moment of
         // the call, extending the entry's effective TTL.
-        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true };
+        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, max_bytes: 0 };
         let cache = ResponseCache::new(config);
 
         // Backdate `cached_at` so the age is clearly distinguishable from "now".

--- a/crates/rari/src/server/cache/response.rs
+++ b/crates/rari/src/server/cache/response.rs
@@ -1000,12 +1000,8 @@ mod tests {
 
     #[test]
     fn test_memory_config_carries_byte_budget() {
-        let config = CacheConfig {
-            max_entries: 50,
-            default_ttl: 120,
-            enabled: true,
-            max_bytes: 1_048_576,
-        };
+        let config =
+            CacheConfig { max_entries: 50, default_ttl: 120, enabled: true, max_bytes: 1_048_576 };
         let memory = config.memory_config();
         assert_eq!(memory.max_entries, 50);
         assert_eq!(memory.default_ttl, 120);

--- a/crates/rari/src/server/cache/response.rs
+++ b/crates/rari/src/server/cache/response.rs
@@ -637,8 +637,10 @@ impl ResponseCache {
     fn update_entry_count_metrics(&self) {
         let n = self.entry_count.load(Ordering::Relaxed);
         // Exact when the backend reports payload bytes; rough per-entry
-        // estimate otherwise.
-        let usage = self.handler.total_bytes().unwrap_or(n * 10_000);
+        // estimate otherwise. Scoped to this cache's key prefix: the handler
+        // may be shared with other cache layers (image, OG), whose bytes
+        // must not count here.
+        let usage = self.handler.prefix_bytes(Self::KEY_PREFIX).unwrap_or(n * 10_000);
         let mut metrics = self.metrics.lock();
         metrics.total_entries = n;
         metrics.memory_usage_bytes = usage;

--- a/crates/rari/src/server/cache/response.rs
+++ b/crates/rari/src/server/cache/response.rs
@@ -782,7 +782,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_basic_operations() {
-        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, max_bytes: 0 };
+        let config =
+            CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, ..Default::default() };
         let cache = ResponseCache::new(config);
 
         assert!(cache.get("test-key").await.is_none());
@@ -802,7 +803,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_expiration() {
-        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, max_bytes: 0 };
+        let config =
+            CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, ..Default::default() };
         let cache = ResponseCache::new(config);
 
         let response = create_test_response("test body", 0);
@@ -815,7 +817,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_invalidation() {
-        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, max_bytes: 0 };
+        let config =
+            CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, ..Default::default() };
         let cache = ResponseCache::new(config);
 
         let response = create_test_response("test body", 60);
@@ -830,7 +833,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_tag_invalidation() {
-        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, max_bytes: 0 };
+        let config =
+            CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, ..Default::default() };
         let cache = ResponseCache::new(config);
 
         let mut response1 = create_test_response("body1", 60);
@@ -853,7 +857,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_lru_eviction() {
-        let config = CacheConfig { max_entries: 2, default_ttl: 60, enabled: true, max_bytes: 0 };
+        let config =
+            CacheConfig { max_entries: 2, default_ttl: 60, enabled: true, ..Default::default() };
         let cache = ResponseCache::new(config);
 
         cache.set("key1".to_string(), create_test_response("body1", 60)).await;
@@ -871,7 +876,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_disabled() {
-        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: false, max_bytes: 0 };
+        let config =
+            CacheConfig { max_entries: 10, default_ttl: 60, enabled: false, ..Default::default() };
         let cache = ResponseCache::new(config);
 
         let response = create_test_response("test body", 60);
@@ -882,7 +888,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_clear() {
-        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, max_bytes: 0 };
+        let config =
+            CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, ..Default::default() };
         let cache = ResponseCache::new(config);
 
         cache.set("key1".to_string(), create_test_response("body1", 60)).await;
@@ -899,7 +906,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_clear_percentage() {
-        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, max_bytes: 0 };
+        let config =
+            CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, ..Default::default() };
         let cache = ResponseCache::new(config);
 
         for i in 0..10 {
@@ -917,7 +925,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_memory_pressure_detection() {
-        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, max_bytes: 0 };
+        let config =
+            CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, ..Default::default() };
         let cache = ResponseCache::new(config);
 
         for i in 0..8 {
@@ -1075,7 +1084,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_handler_is_memory_by_default() {
-        let config = CacheConfig { max_entries: 2, default_ttl: 60, enabled: true, max_bytes: 0 };
+        let config =
+            CacheConfig { max_entries: 2, default_ttl: 60, enabled: true, ..Default::default() };
         let cache = ResponseCache::new(config);
 
         cache.set("a".to_string(), create_test_response("body-a", 60)).await;
@@ -1089,7 +1099,8 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_new_with_custom_handler() {
         let stub = Arc::new(StubHandler::default());
-        let config = CacheConfig { max_entries: 100, default_ttl: 60, enabled: true, max_bytes: 0 };
+        let config =
+            CacheConfig { max_entries: 100, default_ttl: 60, enabled: true, ..Default::default() };
         let cache = ResponseCache::new_with_handler(config, stub.clone());
 
         cache.set("k".to_string(), create_test_response("v", 60)).await;
@@ -1110,11 +1121,11 @@ mod tests {
             Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
                 max_entries: 32,
                 default_ttl: 60,
-                max_bytes: 0,
+                ..Default::default()
             }));
 
         let response_cache = ResponseCache::new_with_handler(
-            CacheConfig { max_entries: 32, default_ttl: 60, enabled: true, max_bytes: 0 },
+            CacheConfig { max_entries: 32, default_ttl: 60, enabled: true, ..Default::default() },
             shared.clone(),
         );
         let test_dir = env::temp_dir().join("rari-test-cache-namespace");
@@ -1146,7 +1157,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_serialized_response_round_trip() {
-        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, max_bytes: 0 };
+        let config =
+            CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, ..Default::default() };
         let cache = ResponseCache::new(config);
 
         let mut headers = HeaderMap::new();
@@ -1191,7 +1203,8 @@ mod tests {
         // paths like `update_in_place` that re-serialize an existing
         // `CachedResponse` would silently reset `cached_at` to the moment of
         // the call, extending the entry's effective TTL.
-        let config = CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, max_bytes: 0 };
+        let config =
+            CacheConfig { max_entries: 10, default_ttl: 60, enabled: true, ..Default::default() };
         let cache = ResponseCache::new(config);
 
         // Backdate `cached_at` so the age is clearly distinguishable from "now".

--- a/crates/rari/src/server/cache/response.rs
+++ b/crates/rari/src/server/cache/response.rs
@@ -343,6 +343,7 @@ pub struct ResponseCache {
     pub config: CacheConfig,
     metrics: Arc<Mutex<CacheMetrics>>,
     entry_count: Arc<AtomicUsize>,
+    payload_bytes: Arc<AtomicUsize>,
 }
 
 impl ResponseCache {
@@ -364,6 +365,7 @@ impl ResponseCache {
             config,
             metrics: Arc::new(Mutex::new(CacheMetrics::default())),
             entry_count: Arc::new(AtomicUsize::new(0)),
+            payload_bytes: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -519,12 +521,16 @@ impl ResponseCache {
             self.handler.set_with_tags(&ns_key, bytes, ttl, &tags).await
         };
 
-        if let Err(e) = result {
-            tracing::warn!(error = %e, key = %key, "cache set failed");
-            return;
+        match result {
+            Err(e) => {
+                tracing::warn!(error = %e, key = %key, "cache set failed");
+            }
+            Ok(outcome) => {
+                if outcome.stored || outcome.replaced || outcome.evicted > 0 {
+                    self.resync_entry_count();
+                }
+            }
         }
-
-        self.resync_entry_count();
     }
 
     pub async fn update_in_place(&self, key: &str, response: CachedResponse) {
@@ -547,10 +553,16 @@ impl ResponseCache {
         } else {
             self.handler.set_with_tags(&ns_key, bytes, ttl, &tags).await
         };
-        if let Err(e) = result {
-            tracing::warn!(error = %e, key = %key, "cache update_in_place failed");
+        match result {
+            Err(e) => {
+                tracing::warn!(error = %e, key = %key, "cache update_in_place failed");
+            }
+            Ok(outcome) => {
+                if outcome.stored || outcome.replaced || outcome.evicted > 0 {
+                    self.resync_entry_count();
+                }
+            }
         }
-        self.resync_entry_count();
     }
 
     pub async fn invalidate(&self, key: &str) {
@@ -640,20 +652,17 @@ impl ResponseCache {
 
     fn update_entry_count_metrics(&self) {
         let n = self.entry_count.load(Ordering::Relaxed);
-        // Exact when the backend reports payload bytes; rough per-entry
-        // estimate otherwise. Scoped to this cache's key prefix: the handler
-        // may be shared with other cache layers (image, OG), whose bytes
-        // must not count here.
-        let usage = self.handler.prefix_bytes(Self::KEY_PREFIX).unwrap_or(n * 10_000);
+        let usage = self.payload_bytes.load(Ordering::Relaxed);
         let mut metrics = self.metrics.lock();
         metrics.total_entries = n;
         metrics.memory_usage_bytes = usage;
     }
 
     fn resync_entry_count(&self) {
-        let live =
-            self.handler.get_all_keys().iter().filter(|k| k.starts_with(Self::KEY_PREFIX)).count();
+        let (live, exact_bytes) = self.handler.prefix_stats(Self::KEY_PREFIX);
+        let usage = exact_bytes.unwrap_or(live.saturating_mul(10_000));
         self.entry_count.store(live, Ordering::Relaxed);
+        self.payload_bytes.store(usage, Ordering::Relaxed);
         self.update_entry_count_metrics();
     }
 }

--- a/crates/rari/src/server/cache/response.rs
+++ b/crates/rari/src/server/cache/response.rs
@@ -1057,7 +1057,7 @@ mod tests {
         ) -> Result<SetOutcome, CacheError> {
             self.set_calls.lock().push(key.to_string());
             let replaced = self.map.lock().insert(key.to_string(), value).is_some();
-            Ok(SetOutcome { replaced, evicted: 0, evicted_bytes: 0 })
+            Ok(SetOutcome { replaced, evicted: 0, evicted_bytes: 0, stored: true })
         }
         async fn set_with_tags(
             &self,

--- a/crates/rari/src/server/cache/response.rs
+++ b/crates/rari/src/server/cache/response.rs
@@ -246,6 +246,14 @@ impl CacheConfig {
                 .unwrap_or(layer.max_bytes),
         }
     }
+
+    pub fn memory_config(&self) -> MemoryConfig {
+        MemoryConfig {
+            max_entries: self.max_entries.max(1),
+            default_ttl: self.default_ttl,
+            max_bytes: self.max_bytes,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -346,11 +354,7 @@ impl ResponseCache {
     }
 
     pub fn new(config: CacheConfig) -> Self {
-        let handler = MemoryCacheHandler::with_config(&MemoryConfig {
-            max_entries: config.max_entries,
-            default_ttl: config.default_ttl,
-            max_bytes: config.max_bytes,
-        });
+        let handler = MemoryCacheHandler::with_config(&config.memory_config());
         Self::new_with_handler(config, Arc::new(handler))
     }
 
@@ -992,6 +996,20 @@ mod tests {
 
         let config = CacheConfig::from_env(false);
         assert!(!config.enabled);
+    }
+
+    #[test]
+    fn test_memory_config_carries_byte_budget() {
+        let config = CacheConfig {
+            max_entries: 50,
+            default_ttl: 120,
+            enabled: true,
+            max_bytes: 1_048_576,
+        };
+        let memory = config.memory_config();
+        assert_eq!(memory.max_entries, 50);
+        assert_eq!(memory.default_ttl, 120);
+        assert_eq!(memory.max_bytes, 1_048_576);
     }
 
     #[test]

--- a/crates/rari/src/server/config.rs
+++ b/crates/rari/src/server/config.rs
@@ -1397,7 +1397,7 @@ mod tests {
             url: None,
             max_entries: 500,
             default_ttl_secs: 60,
-            max_bytes: 0,
+            ..Default::default()
         };
         let json = serde_json::to_value(&layer).unwrap();
         assert_eq!(json["handler"], "memory");

--- a/crates/rari/src/server/config.rs
+++ b/crates/rari/src/server/config.rs
@@ -94,11 +94,19 @@ pub struct CacheLayerConfig {
     pub url: Option<String>,
     pub max_entries: usize,
     pub default_ttl_secs: u64,
+    /// Total payload byte budget for memory layers. `0` = unlimited.
+    pub max_bytes: usize,
 }
 
 impl Default for CacheLayerConfig {
     fn default() -> Self {
-        Self { handler: "memory".to_string(), url: None, max_entries: 1000, default_ttl_secs: 60 }
+        Self {
+            handler: "memory".to_string(),
+            url: None,
+            max_entries: 1000,
+            default_ttl_secs: 60,
+            max_bytes: 0,
+        }
     }
 }
 
@@ -1389,6 +1397,7 @@ mod tests {
             url: None,
             max_entries: 500,
             default_ttl_secs: 60,
+            max_bytes: 0,
         };
         let json = serde_json::to_value(&layer).unwrap();
         assert_eq!(json["handler"], "memory");

--- a/crates/rari/src/server/config.rs
+++ b/crates/rari/src/server/config.rs
@@ -14,7 +14,10 @@ use http::HeaderValue;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
-use crate::server::{image::ImageConfig, rendering::html_bots::compile_html_limited_bots_pattern};
+use crate::server::{
+    cache::handler::MemoryConfig, image::ImageConfig,
+    rendering::html_bots::compile_html_limited_bots_pattern,
+};
 
 pub static GLOBAL_CONFIG: OnceLock<Config> = OnceLock::new();
 
@@ -106,6 +109,16 @@ impl Default for CacheLayerConfig {
             max_entries: 1000,
             default_ttl_secs: 60,
             max_bytes: 0,
+        }
+    }
+}
+
+impl CacheLayerConfig {
+    pub fn memory_config(&self) -> MemoryConfig {
+        MemoryConfig {
+            max_entries: self.max_entries.max(1),
+            default_ttl: self.default_ttl_secs,
+            max_bytes: self.max_bytes,
         }
     }
 }
@@ -1309,6 +1322,11 @@ mod tests {
         assert_eq!(layer.handler, "memory");
         assert_eq!(layer.max_entries, 1000);
         assert_eq!(layer.default_ttl_secs, 60);
+        assert_eq!(layer.max_bytes, 0);
+        let memory = layer.memory_config();
+        assert_eq!(memory.max_entries, 1000);
+        assert_eq!(memory.default_ttl, 60);
+        assert_eq!(memory.max_bytes, 0);
     }
 
     #[test]

--- a/crates/rari/src/server/config.rs
+++ b/crates/rari/src/server/config.rs
@@ -1415,15 +1415,25 @@ mod tests {
             url: None,
             max_entries: 500,
             default_ttl_secs: 60,
-            ..Default::default()
+            max_bytes: 1_048_576,
         };
         let json = serde_json::to_value(&layer).unwrap();
         assert_eq!(json["handler"], "memory");
         assert_eq!(json["maxEntries"], 500);
         assert_eq!(json["defaultTtlSecs"], 60);
+        assert_eq!(json["maxBytes"], 1_048_576);
 
         let round_trip: CacheLayerConfig = serde_json::from_value(json).unwrap();
         assert_eq!(round_trip.max_entries, 500);
         assert_eq!(round_trip.default_ttl_secs, 60);
+        assert_eq!(round_trip.max_bytes, 1_048_576);
+
+        let omitted: CacheLayerConfig = serde_json::from_value(serde_json::json!({
+            "handler": "memory",
+            "maxEntries": 10,
+            "defaultTtlSecs": 30
+        }))
+        .unwrap();
+        assert_eq!(omitted.max_bytes, 0);
     }
 }

--- a/crates/rari/src/server/core/mod.rs
+++ b/crates/rari/src/server/core/mod.rs
@@ -39,7 +39,7 @@ use crate::{
     server::{
         actions::{handle_page_server_action, handle_server_action},
         cache::{
-            handler::{CacheHandler, CacheHandlerRegistry, MemoryCacheHandler},
+            handler::CacheHandlerRegistry,
             loader::CacheLoader,
             response,
             revalidate::revalidate_by_path,
@@ -194,19 +194,18 @@ impl Server {
         let response_layer = config.cache.layer(CACHE_LAYER_RESPONSE);
         let cache_config =
             response::CacheConfig::from_layer(&response_layer, config.is_production());
-        let response_handler: Arc<dyn CacheHandler> = if response_layer.handler == "memory" {
-            Arc::new(MemoryCacheHandler::with_config(&cache_config.memory_config()))
-        } else {
-            cache_registry.resolve(&response_layer.handler)
-        };
+        let response_handler = cache_registry
+            .resolve_configured(&response_layer.handler, &cache_config.memory_config());
         let response_cache =
             Arc::new(response::ResponseCache::new_with_handler(cache_config, response_handler));
 
         let image_layer = config.cache.layer(CACHE_LAYER_IMAGE);
-        let image_handler = cache_registry.resolve(&image_layer.handler);
+        let image_handler =
+            cache_registry.resolve_configured(&image_layer.handler, &image_layer.memory_config());
 
         let og_layer = config.cache.layer(CACHE_LAYER_OG);
-        let og_handler = cache_registry.resolve(&og_layer.handler);
+        let og_handler =
+            cache_registry.resolve_configured(&og_layer.handler, &og_layer.memory_config());
 
         let og_generator = {
             let runtime = Arc::clone(&js_runtime);

--- a/crates/rari/src/server/core/mod.rs
+++ b/crates/rari/src/server/core/mod.rs
@@ -39,11 +39,8 @@ use crate::{
     server::{
         actions::{handle_page_server_action, handle_server_action},
         cache::{
-            handler::CacheHandlerRegistry,
-            loader::CacheLoader,
-            response,
-            revalidate::revalidate_by_path,
-            warmup,
+            handler::CacheHandlerRegistry, loader::CacheLoader, response,
+            revalidate::revalidate_by_path, warmup,
         },
         config::{
             CACHE_LAYER_IMAGE, CACHE_LAYER_LAYOUT, CACHE_LAYER_OG, CACHE_LAYER_RESPONSE, Config,

--- a/crates/rari/src/server/core/mod.rs
+++ b/crates/rari/src/server/core/mod.rs
@@ -39,8 +39,11 @@ use crate::{
     server::{
         actions::{handle_page_server_action, handle_server_action},
         cache::{
-            handler::CacheHandlerRegistry, loader::CacheLoader, response,
-            revalidate::revalidate_by_path, warmup,
+            handler::{CacheHandler, CacheHandlerRegistry, MemoryCacheHandler},
+            loader::CacheLoader,
+            response,
+            revalidate::revalidate_by_path,
+            warmup,
         },
         config::{
             CACHE_LAYER_IMAGE, CACHE_LAYER_LAYOUT, CACHE_LAYER_OG, CACHE_LAYER_RESPONSE, Config,
@@ -189,8 +192,13 @@ impl Server {
         let cache_registry = Arc::new(CacheHandlerRegistry::from_env());
 
         let response_layer = config.cache.layer(CACHE_LAYER_RESPONSE);
-        let response_handler = cache_registry.resolve(&response_layer.handler);
-        let cache_config = response::CacheConfig::from_env(config.is_production());
+        let cache_config =
+            response::CacheConfig::from_layer(&response_layer, config.is_production());
+        let response_handler: Arc<dyn CacheHandler> = if response_layer.handler == "memory" {
+            Arc::new(MemoryCacheHandler::with_config(&cache_config.memory_config()))
+        } else {
+            cache_registry.resolve(&response_layer.handler)
+        };
         let response_cache =
             Arc::new(response::ResponseCache::new_with_handler(cache_config, response_handler));
 

--- a/crates/rari/src/server/image/cache.rs
+++ b/crates/rari/src/server/image/cache.rs
@@ -162,11 +162,15 @@ impl ImageCache {
         }
 
         match self.handler.set(&Self::ns(&key), serialized, IMG_TTL_SECS).await {
-            Ok(outcome) if outcome.evicted_bytes > 0 => {
+            Ok(outcome) => {
+                // Mirror the handler: subtract evicted/replaced bytes, and
+                // back out the pre-counted value if it was not admitted.
                 let mut size = self.current_memory_size.lock();
                 *size = size.saturating_sub(outcome.evicted_bytes);
+                if !outcome.stored {
+                    *size = size.saturating_sub(data_size);
+                }
             }
-            Ok(_) => {}
             Err(e) => {
                 tracing::error!("Failed to write image to handler cache: {}", e);
                 let mut size = self.current_memory_size.lock();

--- a/crates/rari/src/server/image/cache.rs
+++ b/crates/rari/src/server/image/cache.rs
@@ -44,6 +44,7 @@ impl ImageCache {
         let handler = MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: capacity.get(),
             default_ttl: 0,
+            max_bytes: 0,
         });
         Self::with_handler(Arc::new(handler), max_memory_size, project_path)
     }
@@ -191,6 +192,7 @@ mod tests {
         let handler = Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: 32,
             default_ttl: 0,
+            max_bytes: 0,
         }));
         ImageCache::with_handler(handler, max_memory_size, &test_project_path(test_name))
     }
@@ -228,6 +230,7 @@ mod tests {
         let handler_a = Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: 32,
             default_ttl: 0,
+            max_bytes: 0,
         }));
         let cache_a = ImageCache::with_handler(handler_a, 1024 * 1024, &project_path);
         let image = sample_image();
@@ -238,6 +241,7 @@ mod tests {
         let handler_b = Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: 32,
             default_ttl: 0,
+            max_bytes: 0,
         }));
         let cache_b = ImageCache::with_handler(
             Arc::clone(&handler_b) as Arc<dyn CacheHandler>,

--- a/crates/rari/src/server/image/cache.rs
+++ b/crates/rari/src/server/image/cache.rs
@@ -41,7 +41,7 @@ impl ImageCache {
         let handler = MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: capacity.get(),
             default_ttl: 0,
-            ..Default::default()
+            max_bytes: max_memory_size,
         });
         Self::with_handler(Arc::new(handler), max_memory_size, project_path)
     }

--- a/crates/rari/src/server/image/cache.rs
+++ b/crates/rari/src/server/image/cache.rs
@@ -44,7 +44,7 @@ impl ImageCache {
         let handler = MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: capacity.get(),
             default_ttl: 0,
-            max_bytes: 0,
+            ..Default::default()
         });
         Self::with_handler(Arc::new(handler), max_memory_size, project_path)
     }
@@ -192,7 +192,7 @@ mod tests {
         let handler = Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: 32,
             default_ttl: 0,
-            max_bytes: 0,
+            ..Default::default()
         }));
         ImageCache::with_handler(handler, max_memory_size, &test_project_path(test_name))
     }
@@ -230,7 +230,7 @@ mod tests {
         let handler_a = Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: 32,
             default_ttl: 0,
-            max_bytes: 0,
+            ..Default::default()
         }));
         let cache_a = ImageCache::with_handler(handler_a, 1024 * 1024, &project_path);
         let image = sample_image();
@@ -241,7 +241,7 @@ mod tests {
         let handler_b = Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: 32,
             default_ttl: 0,
-            max_bytes: 0,
+            ..Default::default()
         }));
         let cache_b = ImageCache::with_handler(
             Arc::clone(&handler_b) as Arc<dyn CacheHandler>,

--- a/crates/rari/src/server/image/cache.rs
+++ b/crates/rari/src/server/image/cache.rs
@@ -7,7 +7,6 @@ use std::{
     sync::Arc,
 };
 
-use parking_lot::Mutex;
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize, rancor};
 use tokio::task;
 
@@ -32,7 +31,6 @@ const KEY_PREFIX: &str = "image:";
 pub struct ImageCache {
     handler: Arc<dyn CacheHandler>,
     cache_dir: PathBuf,
-    current_memory_size: Mutex<usize>,
 }
 
 impl ImageCache {
@@ -48,15 +46,13 @@ impl ImageCache {
         Self::with_handler(Arc::new(handler), max_memory_size, project_path)
     }
 
-    /// The memory budget lives in the handler's entry/byte caps; this type
-    /// only mirrors the handler's usage in `current_memory_size`.
     pub fn with_handler(
         handler: Arc<dyn CacheHandler>,
         _max_memory_size: usize,
         project_path: &Path,
     ) -> Self {
         let cache_dir = Self::resolve_cache_dir(project_path);
-        Self { handler, cache_dir, current_memory_size: Mutex::new(0) }
+        Self { handler, cache_dir }
     }
 
     fn ns(key: &str) -> String {
@@ -119,21 +115,9 @@ impl ImageCache {
         };
 
         let cached_arc = Arc::new(cached);
-        // Track the serialized size: that is what the handler stores and what
-        // its evicted_bytes are denominated in.
-        let serialized_size = read_result.len();
 
-        match self.handler.set(&Self::ns(key), read_result, IMG_TTL_SECS).await {
-            Ok(outcome) => {
-                let mut size = self.current_memory_size.lock();
-                *size = size.saturating_sub(outcome.evicted_bytes);
-                if outcome.stored {
-                    *size = size.saturating_add(serialized_size);
-                }
-            }
-            Err(e) => {
-                tracing::debug!("Image cache write-through to handler failed: {}", e);
-            }
+        if let Err(e) = self.handler.set(&Self::ns(key), read_result, IMG_TTL_SECS).await {
+            tracing::debug!("Image cache write-through to handler failed: {}", e);
         }
 
         Some(cached_arc)
@@ -160,20 +144,8 @@ impl ImageCache {
             Err(e) => tracing::error!("Failed to spawn disk write task: {}", e),
         }
 
-        // Track the serialized size after the set resolves: that is what the
-        // handler stores and what its evicted_bytes are denominated in.
-        let serialized_size = serialized.len();
-        match self.handler.set(&Self::ns(&key), serialized, IMG_TTL_SECS).await {
-            Ok(outcome) => {
-                let mut size = self.current_memory_size.lock();
-                *size = size.saturating_sub(outcome.evicted_bytes);
-                if outcome.stored {
-                    *size = size.saturating_add(serialized_size);
-                }
-            }
-            Err(e) => {
-                tracing::error!("Failed to write image to handler cache: {}", e);
-            }
+        if let Err(e) = self.handler.set(&Self::ns(&key), serialized, IMG_TTL_SECS).await {
+            tracing::error!("Failed to write image to handler cache: {}", e);
         }
     }
 }

--- a/crates/rari/src/server/image/cache.rs
+++ b/crates/rari/src/server/image/cache.rs
@@ -32,7 +32,6 @@ const KEY_PREFIX: &str = "image:";
 pub struct ImageCache {
     handler: Arc<dyn CacheHandler>,
     cache_dir: PathBuf,
-    max_memory_size: usize,
     current_memory_size: Mutex<usize>,
 }
 
@@ -49,13 +48,15 @@ impl ImageCache {
         Self::with_handler(Arc::new(handler), max_memory_size, project_path)
     }
 
+    /// The memory budget lives in the handler's entry/byte caps; this type
+    /// only mirrors the handler's usage in `current_memory_size`.
     pub fn with_handler(
         handler: Arc<dyn CacheHandler>,
-        max_memory_size: usize,
+        _max_memory_size: usize,
         project_path: &Path,
     ) -> Self {
         let cache_dir = Self::resolve_cache_dir(project_path);
-        Self { handler, cache_dir, max_memory_size, current_memory_size: Mutex::new(0) }
+        Self { handler, cache_dir, current_memory_size: Mutex::new(0) }
     }
 
     fn ns(key: &str) -> String {

--- a/crates/rari/src/server/image/cache.rs
+++ b/crates/rari/src/server/image/cache.rs
@@ -118,21 +118,27 @@ impl ImageCache {
         };
 
         let cached_arc = Arc::new(cached);
-        let data_size = cached_arc.data.len();
+        // Track the serialized size: that is what the handler stores and what
+        // its evicted_bytes are denominated in.
+        let serialized_size = read_result.len();
 
-        if let Err(e) = self.handler.set(&Self::ns(key), read_result, IMG_TTL_SECS).await {
-            tracing::debug!("Image cache write-through to handler failed: {}", e);
-        } else {
-            let mut size = self.current_memory_size.lock();
-            *size = size.saturating_add(data_size);
+        match self.handler.set(&Self::ns(key), read_result, IMG_TTL_SECS).await {
+            Ok(outcome) => {
+                let mut size = self.current_memory_size.lock();
+                *size = size.saturating_sub(outcome.evicted_bytes);
+                if outcome.stored {
+                    *size = size.saturating_add(serialized_size);
+                }
+            }
+            Err(e) => {
+                tracing::debug!("Image cache write-through to handler failed: {}", e);
+            }
         }
 
         Some(cached_arc)
     }
 
     pub async fn put(&self, key: String, cached: CachedImage) {
-        let data_size = cached.data.len();
-
         let serialized = match rkyv::to_bytes::<rancor::Error>(&cached) {
             Ok(b) => b.into_vec(),
             Err(e) => {
@@ -153,28 +159,19 @@ impl ImageCache {
             Err(e) => tracing::error!("Failed to spawn disk write task: {}", e),
         }
 
-        {
-            let mut size = self.current_memory_size.lock();
-            *size = size.saturating_add(data_size);
-            if *size > self.max_memory_size {
-                *size = self.max_memory_size;
-            }
-        }
-
+        // Track the serialized size after the set resolves: that is what the
+        // handler stores and what its evicted_bytes are denominated in.
+        let serialized_size = serialized.len();
         match self.handler.set(&Self::ns(&key), serialized, IMG_TTL_SECS).await {
             Ok(outcome) => {
-                // Mirror the handler: subtract evicted/replaced bytes, and
-                // back out the pre-counted value if it was not admitted.
                 let mut size = self.current_memory_size.lock();
                 *size = size.saturating_sub(outcome.evicted_bytes);
-                if !outcome.stored {
-                    *size = size.saturating_sub(data_size);
+                if outcome.stored {
+                    *size = size.saturating_add(serialized_size);
                 }
             }
             Err(e) => {
                 tracing::error!("Failed to write image to handler cache: {}", e);
-                let mut size = self.current_memory_size.lock();
-                *size = size.saturating_sub(data_size);
             }
         }
     }

--- a/crates/rari/src/server/og/cache.rs
+++ b/crates/rari/src/server/og/cache.rs
@@ -31,6 +31,7 @@ impl OgImageCache {
         let handler = MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: memory_capacity.max(1),
             default_ttl: 0,
+            max_bytes: 0,
         });
         Self::with_handler(Arc::new(handler), project_path)
     }
@@ -181,6 +182,7 @@ mod tests {
         let handler = Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: memory_capacity.max(1),
             default_ttl: 0,
+            max_bytes: 0,
         }));
         OgImageCache::with_handler(handler, &test_project_path(test_name))
     }
@@ -235,6 +237,7 @@ mod tests {
         let handler_a = Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: 8,
             default_ttl: 0,
+            max_bytes: 0,
         }));
         let cache_a = OgImageCache::with_handler(handler_a, &project_path);
 
@@ -246,6 +249,7 @@ mod tests {
         let handler_b = Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: 8,
             default_ttl: 0,
+            max_bytes: 0,
         }));
         let cache_b = OgImageCache::with_handler(
             Arc::clone(&handler_b) as Arc<dyn CacheHandler>,

--- a/crates/rari/src/server/og/cache.rs
+++ b/crates/rari/src/server/og/cache.rs
@@ -31,7 +31,7 @@ impl OgImageCache {
         let handler = MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: memory_capacity.max(1),
             default_ttl: 0,
-            max_bytes: 0,
+            ..Default::default()
         });
         Self::with_handler(Arc::new(handler), project_path)
     }
@@ -182,7 +182,7 @@ mod tests {
         let handler = Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: memory_capacity.max(1),
             default_ttl: 0,
-            max_bytes: 0,
+            ..Default::default()
         }));
         OgImageCache::with_handler(handler, &test_project_path(test_name))
     }
@@ -237,7 +237,7 @@ mod tests {
         let handler_a = Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: 8,
             default_ttl: 0,
-            max_bytes: 0,
+            ..Default::default()
         }));
         let cache_a = OgImageCache::with_handler(handler_a, &project_path);
 
@@ -249,7 +249,7 @@ mod tests {
         let handler_b = Arc::new(MemoryCacheHandler::with_config(&MemoryConfig {
             max_entries: 8,
             default_ttl: 0,
-            max_bytes: 0,
+            ..Default::default()
         }));
         let cache_b = OgImageCache::with_handler(
             Arc::clone(&handler_b) as Arc<dyn CacheHandler>,


### PR DESCRIPTION
## Problem

`MemoryCacheHandler` bounds entry count only. Response-cache entries hold the serialized body plus every compressed variant, so 1000 entries of multi-MB pages is gigabytes resident with no way to cap actual memory. The `memory_usage_bytes` metric is a hardcoded estimate (`entries * 10_000`), so the growth is invisible to operators.

## Change

- `MemoryConfig.max_bytes` — total payload byte budget. `0` = unlimited and is the default, so behavior is unchanged unless configured.
- `set_with_tags` evicts LRU entries until the new value fits. A value larger than the whole budget is refused (storing it would evict everything else for a guaranteed-evicted entry) and logged.
- Exact payload accounting on every insert/removal path: replace, invalidate, tag invalidation, expiry, `clear`, `clear_prefix`.
- New `CacheHandler::total_bytes() -> Option<usize>` (default `None` for backends that can't report). `ResponseCache` metrics now report the exact value when available instead of the estimate.
- Config: per-layer `maxBytes` in `CacheLayerConfig`, and `RARI_CACHE_MAX_BYTES` env override for the response cache (same pattern as `RARI_CACHE_MAX_ENTRIES`).
- Byte-counter subtraction saturates at 0 (`fetch_update` + `saturating_sub`): a raw `fetch_sub` wraps on underflow, and a wrapped counter would make the budget check pass forever.

The budget is deliberately soft: the eviction loop is check-then-act on a relaxed atomic, so two concurrent `set`s can briefly overshoot the cap by one value's size. Exact enforcement would need a lock across check+insert on the hot path; the budget's job is preventing unbounded growth, not byte-exact ceilings.

## Tests

- `test_byte_budget_evicts_lru_until_fit` — LRU order eviction until the budget fits, `SetOutcome` eviction counts, exact `total_bytes`.
- `test_byte_budget_rejects_oversized_value` — oversized value not cached, existing entries survive.
- `test_total_bytes_tracks_all_removal_paths` — accounting stays exact across set, replace, invalidate, invalidate_by_tag, clear_prefix, clear.

`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features` (464 passed) clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable in-memory cache payload byte budget (`max_bytes`, `0` = unlimited) via `RARI_CACHE_MAX_BYTES` and per-cache-layer settings.
  - Cache handlers now expose optional resident-byte metrics (total and per-prefix), and cache write results now indicate whether data was actually stored.

- **Bug Fixes**
  - In-memory eviction now evicts until the incoming value fits the byte budget, and oversized values are rejected without triggering the byte-budget workaround.
  - Response-cache memory usage metrics are now scoped to the response-cache key prefix when exact byte counts are available.

- **Chores**
  - Standardized defaulting and propagation of `max_bytes` across cache layers, tests, and image/OG caches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->