### PR TITLE
fix(cache): cap layout HTML cache TTL at the route's Cache-Control max-age

### DIFF
--- a/crates/rari/src/rendering/layout/core.rs
+++ b/crates/rari/src/rendering/layout/core.rs
@@ -1116,12 +1116,7 @@ impl LayoutRenderer {
                 });
                 let _ = self
                     .html_cache
-                    .insert_with_tags(
-                        cache_key,
-                        html.clone(),
-                        &layout_cache_tags,
-                        route_max_age,
-                    )
+                    .insert_with_tags(cache_key, html.clone(), &layout_cache_tags, route_max_age)
                     .await;
             }
 

--- a/crates/rari/src/rendering/layout/core.rs
+++ b/crates/rari/src/rendering/layout/core.rs
@@ -164,17 +164,25 @@ impl LayoutHtmlCache {
     }
 
     pub async fn insert(&self, key: u64, html: String) -> Result<(), CacheError> {
-        self.insert_with_tags(key, html, &[]).await
+        self.insert_with_tags(key, html, &[], None).await
     }
 
+    /// `route_max_age_secs` is the route's declared Cache-Control max-age, if
+    /// any. Entries never outlive the route's own freshness contract: the
+    /// effective TTL is min(route max-age, layer default), so a max-age=60
+    /// route can't be served hour-old layout HTML. Routes without a max-age
+    /// keep the layer default.
     pub async fn insert_with_tags(
         &self,
         key: u64,
         html: String,
         tags: &[String],
+        route_max_age_secs: Option<u64>,
     ) -> Result<(), CacheError> {
+        let ttl_secs =
+            route_max_age_secs.map_or(self.default_ttl_secs, |m| m.min(self.default_ttl_secs));
         self.handler
-            .set_with_tags(&Self::namespaced(key), html.into_bytes(), self.default_ttl_secs, tags)
+            .set_with_tags(&Self::namespaced(key), html.into_bytes(), ttl_secs, tags)
             .await?;
         Ok(())
     }
@@ -1097,9 +1105,19 @@ impl LayoutRenderer {
                 if !layout_cache_tags.iter().any(|tag| tag == &route_path) {
                     layout_cache_tags.push(route_path);
                 }
+                let route_max_age = Config::get().and_then(|config| {
+                    RouteCachePolicy::max_age_from_cache_control(
+                        config.get_cache_control_for_route(&route_match.pathname),
+                    )
+                });
                 let _ = self
                     .html_cache
-                    .insert_with_tags(cache_key, html.clone(), &layout_cache_tags)
+                    .insert_with_tags(
+                        cache_key,
+                        html.clone(),
+                        &layout_cache_tags,
+                        route_max_age,
+                    )
                     .await;
             }
 
@@ -1491,10 +1509,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_layout_route_max_age_clamps_ttl() {
+        let handler = Arc::new(MemoryCacheHandler::default());
+        let cache = LayoutHtmlCache::with_ttl(handler, 3600);
+
+        // Route max-age below the layer default wins: max-age=0 expires the
+        // entry immediately instead of living the full 3600s.
+        cache.insert_with_tags(1, "short-lived".to_string(), &[], Some(0)).await.expect("insert");
+        assert!(cache.get(1).await.is_none());
+
+        // A max-age above the default is clamped down to it, never up.
+        cache
+            .insert_with_tags(2, "default-lived".to_string(), &[], Some(999_999))
+            .await
+            .expect("insert");
+        assert!(cache.get(2).await.is_some());
+
+        // No max-age keeps the layer default.
+        cache.insert_with_tags(3, "default".to_string(), &[], None).await.expect("insert");
+        assert!(cache.get(3).await.is_some());
+    }
+
+    #[tokio::test]
     async fn test_layout_invalidate_by_tag() {
         let cache = LayoutHtmlCache::new();
         cache
-            .insert_with_tags(42, "tagged".to_string(), &["products".to_string()])
+            .insert_with_tags(42, "tagged".to_string(), &["products".to_string()], None)
             .await
             .expect("insert");
         assert!(cache.get(42).await.is_some());

--- a/crates/rari/src/rendering/layout/core.rs
+++ b/crates/rari/src/rendering/layout/core.rs
@@ -181,6 +181,10 @@ impl LayoutHtmlCache {
     ) -> Result<(), CacheError> {
         let ttl_secs =
             route_max_age_secs.map_or(self.default_ttl_secs, |m| m.min(self.default_ttl_secs));
+        if ttl_secs == 0 {
+            // max-age=0: the entry would be born expired; skip the write.
+            return Ok(());
+        }
         self.handler
             .set_with_tags(&Self::namespaced(key), html.into_bytes(), ttl_secs, tags)
             .await?;
@@ -1511,12 +1515,13 @@ mod tests {
     #[tokio::test]
     async fn test_layout_route_max_age_clamps_ttl() {
         let handler = Arc::new(MemoryCacheHandler::default());
-        let cache = LayoutHtmlCache::with_ttl(handler, 3600);
+        let cache = LayoutHtmlCache::with_ttl(Arc::clone(&handler) as Arc<_>, 3600);
 
-        // Route max-age below the layer default wins: max-age=0 expires the
-        // entry immediately instead of living the full 3600s.
+        // max-age=0: the entry would be born expired, so the write is skipped
+        // entirely — nothing stored, nothing served.
         cache.insert_with_tags(1, "short-lived".to_string(), &[], Some(0)).await.expect("insert");
         assert!(cache.get(1).await.is_none());
+        assert!(handler.is_empty(), "max-age=0 must not store an entry");
 
         // A max-age above the default is clamped down to it, never up.
         cache

--- a/crates/rari/src/server/cache/response.rs
+++ b/crates/rari/src/server/cache/response.rs
@@ -266,6 +266,13 @@ impl RouteCachePolicy {
         base
     }
 
+    /// The `max-age` value declared in a Cache-Control header, if any.
+    pub fn max_age_from_cache_control(cache_control: &str) -> Option<u64> {
+        cache_control.split(',').find_map(|directive| {
+            directive.trim().strip_prefix("max-age=").and_then(|v| v.trim().parse().ok())
+        })
+    }
+
     pub fn from_cache_control(cache_control: &str, route_path: &str) -> Self {
         let mut policy = Self::default();
         policy.tags.push(route_path.to_string());
@@ -909,6 +916,16 @@ mod tests {
         assert_eq!(policy.ttl, 3600);
         assert!(policy.enabled);
         assert_eq!(policy.tags, vec!["/test".to_string()]);
+    }
+
+    #[test]
+    fn test_max_age_from_cache_control() {
+        let max_age = RouteCachePolicy::max_age_from_cache_control;
+        assert_eq!(max_age("public, max-age=60"), Some(60));
+        assert_eq!(max_age("max-age=3600, stale-while-revalidate=86400"), Some(3600));
+        assert_eq!(max_age("public"), None);
+        assert_eq!(max_age("max-age=garbage"), None);
+        assert_eq!(max_age(""), None);
     }
 
     #[test]

--- a/crates/rari/src/server/cache/response.rs
+++ b/crates/rari/src/server/cache/response.rs
@@ -266,11 +266,18 @@ impl RouteCachePolicy {
         base
     }
 
-    /// The `max-age` value declared in a Cache-Control header, if any.
+    /// The shared-cache freshness lifetime declared in a Cache-Control header,
+    /// if any. `s-maxage` takes precedence over `max-age` (RFC 9111 §5.2.2.10):
+    /// the server-side cache is a shared cache, and `max-age=0, s-maxage=3600`
+    /// means "browsers revalidate, shared caches hold for an hour" — reading
+    /// only `max-age` there would disable caching the route asked for.
     pub fn max_age_from_cache_control(cache_control: &str) -> Option<u64> {
-        cache_control.split(',').find_map(|directive| {
-            directive.trim().strip_prefix("max-age=").and_then(|v| v.trim().parse().ok())
-        })
+        let directive_value = |prefix: &str| {
+            cache_control.split(',').find_map(|directive| {
+                directive.trim().strip_prefix(prefix).and_then(|v| v.trim().parse().ok())
+            })
+        };
+        directive_value("s-maxage=").or_else(|| directive_value("max-age="))
     }
 
     pub fn from_cache_control(cache_control: &str, route_path: &str) -> Self {
@@ -923,6 +930,9 @@ mod tests {
         let max_age = RouteCachePolicy::max_age_from_cache_control;
         assert_eq!(max_age("public, max-age=60"), Some(60));
         assert_eq!(max_age("max-age=3600, stale-while-revalidate=86400"), Some(3600));
+        assert_eq!(max_age("max-age=0, s-maxage=3600"), Some(3600));
+        assert_eq!(max_age("s-maxage=60"), Some(60));
+        assert_eq!(max_age("s-maxage=garbage, max-age=60"), Some(60));
         assert_eq!(max_age("public"), None);
         assert_eq!(max_age("max-age=garbage"), None);
         assert_eq!(max_age(""), None);


### PR DESCRIPTION
## Problem

Layout HTML cache entries always get the layer-wide default TTL (3600s), ignoring the route's own Cache-Control. A route declaring `max-age=60` tells CDNs and browsers its content is stale after a minute, yet the server keeps serving the cached layout HTML for up to an hour — the server violates the freshness contract the route itself declared. The only workaround is lowering the layer-wide `defaultTtlSecs`, which sacrifices hit rate on long-lived routes too.

## Fix

Pass the route's declared max-age (parsed by a new `RouteCachePolicy::max_age_from_cache_control`, extracted from the existing directive parsing) into `LayoutHtmlCache::insert_with_tags` and use **min(route max-age, layer default)** as the entry TTL.

Since the server-side cache is a shared cache, `s-maxage` takes precedence over `max-age` when both are present (RFC 9111 §5.2.2.10). This keeps the common CDN pattern `max-age=0, s-maxage=3600` working: browsers revalidate every time, but the layout cache holds the entry for the hour the route asked shared caches to keep it.

- Routes without a max-age: unchanged, layer default applies.
- Routes with max-age above the default: clamped down to the default — no entry's TTL ever gets *longer* than today.
- Routes with short max-age: layout entries now expire on the route's schedule. This does mean more layout re-renders for those routes — the trade their Cache-Control asked for.
- `no-store`/`no-cache` routes were already excluded by the existing enabled gate; untouched.
- max-age=0 routes: the write is skipped entirely — an entry with TTL 0 is born expired, so storing it is pure churn.

## Tests

- `test_max_age_from_cache_control` — directive parsing (present, absent, garbage, `s-maxage` precedence, garbage `s-maxage` falling back to `max-age`).
- `test_layout_route_max_age_clamps_ttl` — max-age below default expires on route schedule, max-age above default clamps down, no max-age keeps default.

`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features` (466 passed) clean.
