### PR TITLE
feat: wire JS pool into streaming and cut Suspense stream latency

### DIFF
--- a/crates/rari/src/rendering/base/constants.rs
+++ b/crates/rari/src/rendering/base/constants.rs
@@ -16,7 +16,7 @@ pub const DEFAULT_MAX_MEMORY_PER_COMPONENT_MB: usize = 50;
 pub const DEFAULT_MAX_CACHE_SIZE: usize = 1000;
 
 pub const V8_CACHE_CLEAR_SCRIPT: &str = include_str!("js/v8_cache_clear.ts");
-// Embedded action handler scripts (validation core v2: isolate-safe init)
+
 pub const ACTION_FLIGHT_ENCODE_SCRIPT: &str = concat!(
     include_str!("js/action_flight_shared.ts"),
     include_str!("js/action_flight_encode.ts"),
@@ -108,17 +108,24 @@ pub fn resolve_server_functions_for_component(component_id: &str) -> String {
     )
 }
 
-pub fn module_registration_script(module_namespace_json: &str, component_id: &str) -> String {
+pub fn module_registration_script_from_import(
+    module_specifier: &str,
+    component_id: &str,
+) -> String {
+    let specifier_json =
+        serde_json::to_string(module_specifier).unwrap_or_else(|_| "\"\"".to_string());
+    let component_id_json =
+        serde_json::to_string(component_id).unwrap_or_else(|_| "\"\"".to_string());
     format!(
-        r"(function () {{
+        r"(async function () {{
   try {{
-    const moduleNamespace = {module_namespace_json};
+    const moduleNamespace = await import({specifier_json});
     if (typeof globalThis.RscModuleManager?.register === 'function') {{
-      const result = globalThis.RscModuleManager.register(moduleNamespace, '{component_id}');
-      return {{ success: true, module: '{component_id}', exports: result.exportCount }};
+      const result = globalThis.RscModuleManager.register(moduleNamespace, {component_id_json});
+      return {{ success: true, module: {component_id_json}, exports: result.exportCount }};
     }} else if (typeof globalThis.registerModule === 'function') {{
-      const result = globalThis.registerModule(moduleNamespace, '{component_id}');
-      return {{ success: true, module: '{component_id}', exports: result.exportCount }};
+      const result = globalThis.registerModule(moduleNamespace, {component_id_json});
+      return {{ success: true, module: {component_id_json}, exports: result.exportCount }};
     }} else {{
       return {{ success: false, error: 'No module registration function available' }};
     }}

--- a/crates/rari/src/rendering/base/constants.rs
+++ b/crates/rari/src/rendering/base/constants.rs
@@ -41,7 +41,11 @@ pub const GET_RSC_BINARY_B64: &str = r"(function() {
 })()";
 
 pub const FIZZ_RENDER_SCRIPT: &str = include_str!("../layout/js/fizz_render.ts");
-pub const STREAMING_FIZZ_SCRIPT: &str = include_str!("../layout/js/streaming_fizz.ts");
+pub const STREAMING_FIZZ_SCRIPT: &str = concat!(
+    include_str!("../layout/js/html_boundaries.ts"),
+    "\n",
+    include_str!("../layout/js/streaming_fizz.ts"),
+);
 pub const RSC_RENDERER_SCRIPT: &str = include_str!("js/rsc_renderer.ts");
 
 pub const STREAMING_PIPELINE_READY_CHECK: &str = "typeof globalThis['~rari']?.renderStreamingDocument === 'function' \
@@ -127,10 +131,10 @@ pub fn module_registration_script_from_import(
       const result = globalThis.registerModule(moduleNamespace, {component_id_json});
       return {{ success: true, module: {component_id_json}, exports: result.exportCount }};
     }} else {{
-      return {{ success: false, error: 'No module registration function available' }};
+      throw new Error('No module registration function available');
     }}
   }} catch (error) {{
-    return {{ success: false, error: error.message }};
+    throw error;
   }}
 }})()"
     )

--- a/crates/rari/src/rendering/base/js/action_flight_encode.ts
+++ b/crates/rari/src/rendering/base/js/action_flight_encode.ts
@@ -19,6 +19,7 @@
       delete g['~rari'].actionRefreshElement
       delete g['~rari'].actionRefreshSearch
       delete g['~rari'].pendingActionResult
+      delete g['~rari'].capturedElement
     }
   }
 })()

--- a/crates/rari/src/rendering/base/js/action_flight_encode.ts
+++ b/crates/rari/src/rendering/base/js/action_flight_encode.ts
@@ -1,13 +1,24 @@
 /// <reference path="../../types.d.ts" />
+/// <reference path="./action_flight_shared.ts" />
 
 (async () => {
   if (typeof g['~rari']?.loadRscReactVendors === 'function')
     g['~rari'].loadRscReactVendors()
 
   const actionResult = g['~rari']?.pendingActionResult
-  const refreshElement = g['~rari']?.capturedElement
+  const refreshElement = g['~rari']?.actionRefreshElement ?? g['~rari']?.capturedElement
   const renderedSearch = g['~rari']?.actionRefreshSearch ?? ''
 
-  await encodeActionFlightResponse(actionResult, refreshElement, renderedSearch)
-  return { '~actionFlight': true }
+  try {
+    await encodeActionFlightResponse(actionResult, refreshElement, renderedSearch)
+    return { '~actionFlight': true }
+  }
+  finally {
+    if (g['~rari']) {
+      delete g['~rari'].isActionRefreshCompose
+      delete g['~rari'].actionRefreshElement
+      delete g['~rari'].actionRefreshSearch
+      delete g['~rari'].pendingActionResult
+    }
+  }
 })()

--- a/crates/rari/src/rendering/base/renderer.rs
+++ b/crates/rari/src/rendering/base/renderer.rs
@@ -16,7 +16,7 @@ use parking_lot::Mutex;
 use rari_error::RariError;
 use rustc_hash::FxHashSet;
 use serde_json::Value;
-use tokio::{fs, time};
+use tokio::{fs, sync::OnceCell, time};
 
 use super::{
     constants::{
@@ -24,8 +24,8 @@ use super::{
         LOAD_FULL_REACT_VENDORS_SCRIPT, LOAD_RSC_VENDORS_SCRIPT,
         MEMORY_PRESSURE_RENDER_THRESHOLD_DEN, MEMORY_PRESSURE_RENDER_THRESHOLD_NUM,
         RSC_RENDERER_SCRIPT, SERVER_FUNCTION_RESOLVER, STREAMING_FIZZ_SCRIPT,
-        STREAMING_PIPELINE_READY_CHECK, V8_CACHE_CLEAR_SCRIPT, module_registration_script,
-        resolve_server_functions_for_component,
+        STREAMING_PIPELINE_READY_CHECK, V8_CACHE_CLEAR_SCRIPT,
+        module_registration_script_from_import, resolve_server_functions_for_component,
     },
     types::{ResourceLimits, ResourceMetrics, ResourceTracker},
     utils::transform_imports_for_hmr,
@@ -33,7 +33,7 @@ use super::{
 use crate::{
     rendering::base::loader::{RscJsLoader, RscModuleOperation},
     rsc::{self, ComponentRegistry},
-    runtime::JsExecutionRuntime,
+    runtime::{JsExecutionRuntime, factory::JsRuntimeInterface},
     server::middleware::request_context::RequestContext,
     utils::cast,
 };
@@ -46,6 +46,8 @@ pub struct RscRenderer {
     pub(crate) script_cache: DashMap<String, String>,
     pub(crate) resource_limits: ResourceLimits,
     pub(crate) resource_tracker: Arc<ResourceTracker>,
+    streaming_pipeline: OnceCell<()>,
+    rsc_pipeline: OnceCell<()>,
 }
 
 impl RscRenderer {
@@ -65,6 +67,8 @@ impl RscRenderer {
             script_cache: DashMap::new(),
             resource_limits,
             resource_tracker: Arc::new(ResourceTracker::new()),
+            streaming_pipeline: OnceCell::new(),
+            rsc_pipeline: OnceCell::new(),
         }
     }
 
@@ -234,43 +238,22 @@ globalThis['~errors'].batch.push({{
 
     async fn load_js_script(&self, name: &str, script: &str) -> Result<(), RariError> {
         self.runtime
-            .execute_script(name.to_string(), script.to_string())
+            .broadcast_script(name, script)
             .await
-            .map(|_| ())
             .map_err(|e| RariError::internal(format!("Failed to load {name}: {e}")))
     }
 
-    async fn is_streaming_pipeline_ready(&self) -> Result<bool, RariError> {
-        let check = self
-            .runtime
-            .execute_script(
-                "check_streaming_fizz".to_string(),
-                STREAMING_PIPELINE_READY_CHECK.to_string(),
-            )
-            .await?;
-
-        Ok(check.as_bool() == Some(true))
-    }
-
-    async fn has_fizz_vendors(&self) -> Result<bool, RariError> {
-        let check = self
-            .runtime
-            .execute_script(
-                "check_fizz_vendor".to_string(),
-                "typeof globalThis['~reactServer']?.renderToReadableStream === 'function'"
-                    .to_string(),
-            )
-            .await?;
-
-        Ok(check.as_bool() == Some(true))
-    }
-
     async fn try_load_full_react_vendors(&self) -> Result<bool, RariError> {
+        self.runtime
+            .broadcast_script("setup_react_vendors", LOAD_FULL_REACT_VENDORS_SCRIPT)
+            .await
+            .map_err(|e| RariError::internal(format!("Failed to load React vendors: {e}")))?;
         let result = self
             .runtime
             .execute_script(
-                "setup_react_vendors".to_string(),
-                LOAD_FULL_REACT_VENDORS_SCRIPT.to_string(),
+                "check_react_vendors".to_string(),
+                "typeof globalThis['~reactServer']?.renderToReadableStream === 'function'"
+                    .to_string(),
             )
             .await
             .map_err(|e| RariError::internal(format!("Failed to load React vendors: {e}")))?;
@@ -324,23 +307,24 @@ globalThis['~errors'].batch.push({{
         }
 
         self.runtime
-            .execute_script(
-                "init_rsc_namespace".to_string(),
+            .broadcast_script(
+                "init_rsc_namespace",
                 r"(function() {
                     if (!globalThis['~rsc']) globalThis['~rsc'] = {};
                     if (!globalThis['~rsc'].modules) globalThis['~rsc'].modules = {};
                     if (!globalThis['~rsc'].functions) globalThis['~rsc'].functions = {};
-                })()"
-                    .to_string(),
+                })()",
             )
             .await?;
 
-        self.runtime
-            .execute_script("extension-checks".to_string(), EXTENSION_CHECKS.to_string())
-            .await?;
+        self.runtime.broadcast_script("extension-checks", EXTENSION_CHECKS).await?;
 
         match self.try_load_full_react_vendors().await {
-            Ok(true) => self.load_all_layout_scripts().await?,
+            Ok(true) => {
+                self.load_all_layout_scripts().await?;
+                let _ = self.streaming_pipeline.set(());
+                let _ = self.rsc_pipeline.set(());
+            }
             Ok(false) => {
                 tracing::warn!("React Fizz module load returned failure");
             }
@@ -357,49 +341,133 @@ globalThis['~errors'].batch.push({{
     }
 
     pub async fn ensure_rsc_pipeline(&self) -> Result<(), RariError> {
-        let check_result = self
-            .runtime
-            .execute_script(
-                "<check_rsc>".to_string(),
-                "typeof globalThis.renderToRsc === 'function'".to_string(),
-            )
+        self.rsc_pipeline
+            .get_or_try_init(|| async { self.ensure_rsc_pipeline_uncached().await })
             .await?;
+        Ok(())
+    }
 
-        if check_result.as_bool() == Some(true) {
-            return Ok(());
-        }
-
-        let result = self
-            .runtime
-            .execute_script("<load_react_server>".to_string(), LOAD_RSC_VENDORS_SCRIPT.to_string())
+    async fn ensure_rsc_pipeline_uncached(&self) -> Result<(), RariError> {
+        self.runtime
+            .broadcast_script("<load_react_server>", LOAD_RSC_VENDORS_SCRIPT)
             .await
             .map_err(|e| {
                 RariError::internal(format!("Failed to load React Server renderer: {e}"))
             })?;
 
-        if result.as_bool() != Some(true) {
+        self.load_js_script("load_rsc_renderer.ts", RSC_RENDERER_SCRIPT).await?;
+
+        let ready = self
+            .runtime
+            .execute_script(
+                "<check_rsc>".to_string(),
+                "typeof globalThis.renderToRsc === 'function'".to_string(),
+            )
+            .await
+            .map_err(|e| {
+                RariError::internal(format!("Failed to verify React Server renderer: {e}"))
+            })?;
+        if ready.as_bool() != Some(true) {
             return Err(RariError::internal(
                 "React Server renderer module failed to initialize".to_string(),
             ));
         }
+        Ok(())
+    }
 
-        self.load_js_script("load_rsc_renderer.ts", RSC_RENDERER_SCRIPT).await
+    async fn ensure_streaming_pipeline_uncached(&self) -> Result<(), RariError> {
+        self.load_full_react_vendors().await?;
+        self.load_js_script("fizz_render.ts", FIZZ_RENDER_SCRIPT).await?;
+        self.load_js_script("rsc_renderer.ts", RSC_RENDERER_SCRIPT).await?;
+        self.load_js_script("streaming_fizz.ts", STREAMING_FIZZ_SCRIPT).await?;
+        self.verify_streaming_pipeline_ready().await
     }
 
     pub async fn ensure_streaming_pipeline(&self) -> Result<(), RariError> {
-        if self.is_streaming_pipeline_ready().await? {
-            return Ok(());
+        self.streaming_pipeline
+            .get_or_try_init(|| async { self.ensure_streaming_pipeline_uncached().await })
+            .await?;
+        Ok(())
+    }
+
+    pub async fn resync_slot(&self, runtime: Arc<dyn JsRuntimeInterface>) -> Result<(), RariError> {
+        let vendors = runtime
+            .execute_script(
+                "<resync_load_react_server>".to_string(),
+                LOAD_RSC_VENDORS_SCRIPT.to_string(),
+            )
+            .await
+            .map_err(|e| RariError::internal(format!("resync: load RSC vendors failed: {e}")))?;
+        if vendors.as_bool() == Some(false) {
+            let _ = runtime
+                .execute_script(
+                    "resync_setup_react_vendors".to_string(),
+                    LOAD_FULL_REACT_VENDORS_SCRIPT.to_string(),
+                )
+                .await?;
         }
 
-        if self.has_fizz_vendors().await? {
-            self.ensure_rsc_pipeline().await?;
-        } else {
-            self.load_full_react_vendors().await?;
-            self.load_fizz_and_rsc_scripts().await?;
+        runtime
+            .execute_script("resync_rsc_renderer.ts".to_string(), RSC_RENDERER_SCRIPT.to_string())
+            .await
+            .map_err(|e| RariError::internal(format!("resync: RSC renderer failed: {e}")))?;
+
+        let _ = runtime
+            .execute_script("resync_fizz_render.ts".to_string(), FIZZ_RENDER_SCRIPT.to_string())
+            .await;
+        let _ = runtime
+            .execute_script(
+                "resync_streaming_fizz.ts".to_string(),
+                STREAMING_FIZZ_SCRIPT.to_string(),
+            )
+            .await;
+
+        let components: Vec<(String, String, Vec<String>)> = {
+            let registry = self.component_registry.lock();
+            registry
+                .get_loaded_component_ids()
+                .into_iter()
+                .filter_map(|id| {
+                    let component = registry.get_component(&id)?;
+                    Some((
+                        id,
+                        component.transformed_source.clone(),
+                        component.dependencies.iter().cloned().collect(),
+                    ))
+                })
+                .collect()
+        };
+
+        for (component_id, transformed_source, dependencies) in components {
+            let isolation_script = RscJsLoader::create_isolation_init_script(&component_id);
+            runtime
+                .execute_script(format!("resync_isolation_{component_id}.js"), isolation_script)
+                .await?;
+
+            let module_specifier_js = format!("file:///rari_component/{component_id}.js");
+            runtime.add_module_to_loader(&module_specifier_js, transformed_source).await?;
+
+            let dependencies_json =
+                serde_json::to_string(&dependencies).unwrap_or_else(|_| "[]".to_string());
+            let register_exports_script = RscJsLoader::create_module_operation_script(
+                &component_id,
+                RscModuleOperation::Register { dependencies_json },
+            );
+            runtime
+                .execute_script(
+                    format!("resync_register_exports_{component_id}.js"),
+                    register_exports_script,
+                )
+                .await?;
+
+            let load_script = RscJsLoader::create_module_operation_script(
+                &component_id,
+                RscModuleOperation::Load { module_specifier: module_specifier_js },
+            );
+            runtime.execute_script(format!("resync_load_{component_id}.js"), load_script).await?;
         }
 
-        self.load_streaming_fizz_script().await?;
-        self.verify_streaming_pipeline_ready().await
+        Ok(())
     }
 
     pub async fn register_component(
@@ -458,9 +526,9 @@ globalThis['~errors'].batch.push({{
             V8_CACHE_CLEAR_SCRIPT.cow_replace("{component_id}", component_id).into_owned();
 
         self.runtime
-            .execute_script(
-                format!("force_v8_cache_clear_{component_id}.ts"),
-                force_v8_cache_clear_script,
+            .broadcast_script(
+                &format!("force_v8_cache_clear_{component_id}.ts"),
+                &force_v8_cache_clear_script,
             )
             .await?;
 
@@ -615,7 +683,10 @@ globalThis['~errors'].batch.push({{
         );
 
         self.runtime
-            .execute_script(format!("register_exports_{component_id}.js"), register_exports_script)
+            .broadcast_script(
+                &format!("register_exports_{component_id}.js"),
+                &register_exports_script,
+            )
             .await?;
 
         Ok(())
@@ -635,7 +706,7 @@ globalThis['~errors'].batch.push({{
             let isolation_script = RscJsLoader::create_isolation_init_script(component_id);
 
             self.runtime
-                .execute_script(format!("isolation_{component_id}.js"), isolation_script)
+                .broadcast_script(&format!("isolation_{component_id}.js"), &isolation_script)
                 .await?;
 
             let (transformed_source, dependencies) = {
@@ -660,9 +731,9 @@ globalThis['~errors'].batch.push({{
             );
 
             self.runtime
-                .execute_script(
-                    format!("register_exports_{component_id}.js"),
-                    register_exports_script,
+                .broadcast_script(
+                    &format!("register_exports_{component_id}.js"),
+                    &register_exports_script,
                 )
                 .await?;
         }
@@ -675,9 +746,12 @@ globalThis['~errors'].batch.push({{
                 RscModuleOperation::Load { module_specifier: module_specifier_js },
             );
 
-            match self.runtime.execute_script(format!("load_{component_id}.js"), load_script).await
+            match self
+                .runtime
+                .broadcast_script(&format!("load_{component_id}.js"), &load_script)
+                .await
             {
-                Ok(_) => {
+                Ok(()) => {
                     let verify_script = Self::create_component_verification_script(component_id);
                     self.execute_verification_script(component_id, verify_script).await?;
 
@@ -705,36 +779,24 @@ globalThis['~errors'].batch.push({{
         component_id: &str,
         verify_script: String,
     ) -> Result<(), RariError> {
-        let result = self
-            .runtime
-            .execute_script(format!("verify_{component_id}.js"), verify_script)
+        let checked_script = format!(
+            r"(function() {{
+                const result = {verify_script};
+                if (!result || result.success !== true) {{
+                    throw new Error(String(result?.details || result?.error || 'verification failed'));
+                }}
+                return true;
+            }})()"
+        );
+
+        self.runtime
+            .broadcast_script(&format!("verify_{component_id}.js"), &checked_script)
             .await
             .map_err(|e| {
                 RariError::js_execution(format!(
-                    "Verification script execution failed for '{component_id}': {e}"
+                    "Component verification failed for '{component_id}': {e}"
                 ))
-            })?;
-
-        let success = result.get("success").and_then(Value::as_bool).unwrap_or(false);
-
-        if success {
-            return Ok(());
-        }
-
-        let error_details =
-            result.get("details").and_then(|v| v.as_str()).map(ToString::to_string).unwrap_or_else(
-                || {
-                    result
-                        .get("error")
-                        .and_then(|v| v.as_str())
-                        .map(ToString::to_string)
-                        .unwrap_or_else(|| "No error details available".to_string())
-                },
-            );
-
-        Err(RariError::js_execution(format!(
-            "Component verification failed for '{component_id}': {error_details}"
-        )))
+            })
     }
 
     pub fn component_exists(&self, component_id: &str) -> bool {
@@ -1017,7 +1079,7 @@ globalThis['~errors'].batch.push({{
 
         let isolation_script = RscJsLoader::create_isolation_init_script(component_id);
         self.runtime
-            .execute_script(format!("isolation_{component_id}.js"), isolation_script)
+            .broadcast_script(&format!("isolation_{component_id}.js"), &isolation_script)
             .await?;
 
         let timestamp =
@@ -1034,41 +1096,26 @@ globalThis['~errors'].batch.push({{
         let needs_initial_load = !force_reload;
 
         if needs_initial_load {
-            let module_id = self
-                .runtime
-                .load_es_module(component_id)
+            self.runtime.load_and_evaluate_module(component_id).await.map_err(|e| {
+                RariError::js_execution(format!(
+                    "Failed to load/evaluate ES module for component '{component_id}' (specifier: '{module_specifier_js}'): {e}"
+                ))
+            })?;
+
+            let register_from_import_script =
+                module_registration_script_from_import(&module_specifier_js, component_id);
+
+            self.runtime
+                .broadcast_script(
+                    &format!("load_from_import_{component_id}.js"),
+                    &register_from_import_script,
+                )
                 .await
                 .map_err(|e| {
                     RariError::js_execution(format!(
-                        "Failed to load ES module for component '{component_id}' (specifier: '{module_specifier_js}'): {e}"
+                        "Failed to register module namespace for component '{component_id}': {e}"
                     ))
                 })?;
-            self.runtime.evaluate_module(module_id).await.map_err(|e| {
-                RariError::js_execution(format!(
-                    "Failed to evaluate ES module '{module_specifier_js}': {e}"
-                ))
-            })?;
-            let module_namespace =
-                self.runtime
-                    .get_module_namespace(module_id)
-                    .await
-                    .map_err(|e| {
-                        RariError::js_execution(format!(
-                            "Failed to get module namespace for component '{component_id}' (module_id: {module_id}): {e}"
-                        ))
-                    })?;
-
-            let module_namespace_json =
-                serde_json::to_string(&module_namespace).unwrap_or_else(|_| "null".to_string());
-            let register_from_namespace_script =
-                module_registration_script(&module_namespace_json, component_id);
-
-            self.runtime
-                .execute_script(
-                    format!("load_from_namespace_{component_id}.js"),
-                    register_from_namespace_script,
-                )
-                .await?;
 
             self.component_registry.lock().mark_component_initially_loaded(component_id);
         } else {
@@ -1084,7 +1131,10 @@ globalThis['~errors'].batch.push({{
         );
 
         self.runtime
-            .execute_script(format!("register_exports_{component_id}.js"), register_exports_script)
+            .broadcast_script(
+                &format!("register_exports_{component_id}.js"),
+                &register_exports_script,
+            )
             .await?;
 
         if force_reload {
@@ -1133,7 +1183,7 @@ globalThis['~rsc'].functions['{component_id}'] = {component_id};
 
             let execution_result = self
                 .runtime
-                .execute_script(format!("direct_execution_{component_id}.js"), eval_safe_source)
+                .broadcast_script(&format!("direct_execution_{component_id}.js"), &eval_safe_source)
                 .await;
 
             if let Err(e) = execution_result {
@@ -1151,7 +1201,7 @@ globalThis['~rsc'].functions['{component_id}'] = {component_id};
             RscModuleOperation::PostRegister,
         );
         self.runtime
-            .execute_script(format!("post_register_{component_id}.js"), post_register_script)
+            .broadcast_script(&format!("post_register_{component_id}.js"), &post_register_script)
             .await?;
 
         let verify_script = Self::create_component_verification_script(component_id);

--- a/crates/rari/src/rendering/layout/core.rs
+++ b/crates/rari/src/rendering/layout/core.rs
@@ -1184,7 +1184,6 @@ impl LayoutRenderer {
         ))
     }
 
-    #[expect(clippy::too_many_lines)]
     pub fn build_composition_script(
         route_match: &AppRouteMatch,
         context: &LayoutRenderContext,

--- a/crates/rari/src/rendering/layout/core.rs
+++ b/crates/rari/src/rendering/layout/core.rs
@@ -241,11 +241,18 @@ async fn queue_streaming_script(
     (Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>>, StreamingSlotGuard),
     RariError,
 > {
-    let (handle, stream_lease) = runtime.pick_runtime_for_streaming().await?;
+    let err_sender = chunk_sender.clone();
+    let (handle, stream_lease) = match runtime.pick_runtime_for_streaming().await {
+        Ok(picked) => picked,
+        Err(e) => {
+            let _ = err_sender.send(Err(e.clone())).await;
+            return Err(e);
+        }
+    };
     if let Some(context) = request_context {
         let request_id = context.request_id().to_string();
         let wrapped = wrap_streaming_script(Some(&request_id), &stream_id, &script);
-        let completion = handle
+        let completion = match handle
             .queue_script_for_streaming(
                 stream_id,
                 script_name,
@@ -253,7 +260,14 @@ async fn queue_streaming_script(
                 chunk_sender,
                 Some(Arc::clone(&context)),
             )
-            .await?;
+            .await
+        {
+            Ok(completion) => completion,
+            Err(e) => {
+                let _ = err_sender.send(Err(e.clone())).await;
+                return Err(e);
+            }
+        };
         let completion = Box::pin(async move {
             let result = completion.await;
             let clear_result = handle.unregister_request_context(&request_id).await;
@@ -263,9 +277,16 @@ async fn queue_streaming_script(
         Ok((completion, stream_lease))
     } else {
         let wrapped = wrap_streaming_script(None, &stream_id, &script);
-        let completion = handle
+        let completion = match handle
             .queue_script_for_streaming(stream_id, script_name, wrapped, chunk_sender, None)
-            .await?;
+            .await
+        {
+            Ok(completion) => completion,
+            Err(e) => {
+                let _ = err_sender.send(Err(e.clone())).await;
+                return Err(e);
+            }
+        };
         Ok((completion, stream_lease))
     }
 }
@@ -470,15 +491,63 @@ impl LayoutRenderer {
             let runtime = Arc::clone(&renderer.runtime);
             runtime
                 .with_request_context(request_context, move |rt| async move {
-                    rt.execute_script("set_action_refresh_search".to_string(), set_search_script)
-                        .await?;
-                    rt.execute_script("action_refresh_compose".to_string(), composition_script)
-                        .await?;
-                    Ok(())
+                    Self::run_action_refresh_scripts(&rt, set_search_script, composition_script)
+                        .await
                 })
                 .await
         })
         .await
+    }
+
+    pub async fn compose_route_for_action_refresh_on(
+        &self,
+        runtime: &Arc<dyn JsRuntimeInterface>,
+        route_match: &AppRouteMatch,
+        context: &LayoutRenderContext,
+        action_refresh_search: String,
+    ) -> Result<(), RariError> {
+        let loading_enabled = Config::get().map(|config| config.loading.enabled).unwrap_or(true);
+
+        let loading_component_id = if loading_enabled {
+            route_match
+                .loading
+                .as_ref()
+                .map(|loading_entry| utils::create_component_id(&loading_entry.file_path))
+        } else {
+            None
+        };
+
+        let composition_script = Self::build_composition_script(
+            route_match,
+            context,
+            loading_component_id.as_deref(),
+            false,
+            true,
+        )?;
+
+        let set_search_script = format!(
+            "globalThis['~rari'] = globalThis['~rari'] || {{}}; globalThis['~rari'].actionRefreshSearch = {};",
+            serde_json::to_string(&action_refresh_search)
+                .map_err(|e| RariError::serialization(e.to_string()))?
+        );
+
+        let renderer = Arc::clone(&self.renderer);
+        let runtime = Arc::clone(runtime);
+        run_with_renderer_result(renderer, move |renderer| async move {
+            renderer.ensure_rsc_pipeline().await?;
+            Self::run_action_refresh_scripts(&runtime, set_search_script, composition_script).await
+        })
+        .await
+    }
+
+    async fn run_action_refresh_scripts(
+        runtime: &Arc<dyn JsRuntimeInterface>,
+        set_search_script: String,
+        composition_script: String,
+    ) -> Result<(), RariError> {
+        runtime.execute_script("set_action_refresh_search".to_string(), set_search_script).await?;
+        runtime.execute_script("action_refresh_compose".to_string(), composition_script).await?;
+        Ok(())
     }
 
     #[expect(clippy::too_many_lines)]

--- a/crates/rari/src/rendering/layout/core.rs
+++ b/crates/rari/src/rendering/layout/core.rs
@@ -1,18 +1,16 @@
 #![expect(clippy::missing_errors_doc)]
 
-use std::{env, sync::Arc};
+use std::{env, future::Future, pin::Pin, sync::Arc};
 
 use base64::{Engine, engine::general_purpose::STANDARD};
 use bytes::Bytes;
 use rari_error::RariError;
 use serde_json::Value;
-use tokio::{
-    sync::{Mutex, mpsc},
-    task,
-};
+use tokio::sync::{Mutex, mpsc, oneshot};
+use uuid::Uuid;
 
 use super::{
-    types::{ChunkedContentType, LayoutRenderContext, RenderResult},
+    types::{ChunkedContentType, LayoutRenderContext, PageMetadata, RenderResult},
     utils,
 };
 use crate::{
@@ -24,7 +22,10 @@ use crate::{
             route_composer::{ErrorBoundaryInfo, TemplateInfo},
         },
     },
-    runtime::JsExecutionRuntime,
+    runtime::{
+        JsExecutionRuntime,
+        factory::{JsRuntimeInterface, StreamingSlotGuard},
+    },
     server::{
         cache::{
             handler::{
@@ -34,6 +35,7 @@ use crate::{
         },
         config::{CacheLayerConfig, Config},
         middleware::request_context::RequestContext,
+        rendering::metadata_injection::merge_streaming_head_content,
         routing::app_router::AppRouteMatch,
     },
     utils::path::path_to_file_url,
@@ -67,12 +69,12 @@ const FIZZ_STREAM_ERROR_HELPER: &str = r"
                         async function injectRariErrorFromCaught() {
                             if (rariErrorInjected || caughtErrors.length === 0) return;
                             rariErrorInjected = true;
-                            await globalThis['~rari']?.injectStreamError?.(caughtErrors);
+                            await globalThis['~rari']?.injectStreamError?.(caughtErrors, __RARI_STREAM_ID__);
                         }
 ";
 
 const FIZZ_STREAM_ERROR_INJECTION: &str = r"
-                        await injectRariErrorFromCaught();
+                        if (caughtErrors.length > 0) await injectRariErrorFromCaught();
 ";
 
 const FIZZ_CHUNK_PUMP_HELPER: &str = r"
@@ -80,7 +82,13 @@ const FIZZ_CHUNK_PUMP_HELPER: &str = r"
                         async function rariPumpFizzChunk(text) {
                             if (!text || rariStreamDisconnected) return false;
                             try {
-                                await Deno.core.ops.op_fizz_chunk(text);
+                                const status = Deno.core.ops.op_fizz_chunk_try(__RARI_STREAM_ID__, text);
+                                if (status === 0) return true;
+                                if (status === 2) {
+                                    rariStreamDisconnected = true;
+                                    return false;
+                                }
+                                await Deno.core.ops.op_fizz_chunk(__RARI_STREAM_ID__, text);
                                 return true;
                             } catch (e) {
                                 if (String(e?.message || e).includes('disconnected')) {
@@ -181,20 +189,84 @@ impl LayoutHtmlCache {
     }
 }
 
+fn wrap_streaming_script(request_id: Option<&str>, stream_id: &str, script: &str) -> String {
+    let request_id_json = serde_json::to_string(request_id.unwrap_or(stream_id))
+        .unwrap_or_else(|_| "\"\"".to_string());
+    let stream_id_json = serde_json::to_string(stream_id).unwrap_or_else(|_| "\"\"".to_string());
+    format!(
+        r"(async function() {{
+            const __RARI_REQUEST_ID__ = {request_id_json};
+            const __RARI_STREAM_ID__ = {stream_id_json};
+            const storage = globalThis['~rari']?.requestStorage;
+            const body = async () => await ({script});
+            if (storage && typeof storage.run === 'function') {{
+                return await storage.run(
+                    {{ requestId: __RARI_REQUEST_ID__, streamId: __RARI_STREAM_ID__ }},
+                    body,
+                );
+            }}
+            return await body();
+        }})()"
+    )
+}
+
 async fn run_streaming_script(
     runtime: &Arc<JsExecutionRuntime>,
     request_context: Option<Arc<RequestContext>>,
     script_name: String,
+    stream_id: String,
     script: String,
     chunk_sender: mpsc::Sender<Result<Vec<u8>, RariError>>,
 ) -> Result<(), RariError> {
-    let execute_stream =
-        async { runtime.execute_script_for_streaming(script_name, script, chunk_sender).await };
+    let (completion, _stream_lease) = queue_streaming_script(
+        runtime,
+        request_context,
+        script_name,
+        stream_id,
+        script,
+        chunk_sender,
+    )
+    .await?;
+    completion.await
+}
 
+async fn queue_streaming_script(
+    runtime: &Arc<JsExecutionRuntime>,
+    request_context: Option<Arc<RequestContext>>,
+    script_name: String,
+    stream_id: String,
+    script: String,
+    chunk_sender: mpsc::Sender<Result<Vec<u8>, RariError>>,
+) -> Result<
+    (Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>>, StreamingSlotGuard),
+    RariError,
+> {
+    let (handle, stream_lease) = runtime.pick_runtime_for_streaming().await?;
     if let Some(context) = request_context {
-        runtime.execute_with_request_context(context, execute_stream).await
+        let request_id = context.request_id().to_string();
+        let wrapped = wrap_streaming_script(Some(&request_id), &stream_id, &script);
+        let completion = handle
+            .queue_script_for_streaming(
+                stream_id,
+                script_name,
+                wrapped,
+                chunk_sender,
+                Some(Arc::clone(&context)),
+            )
+            .await?;
+        let completion = Box::pin(async move {
+            let result = completion.await;
+            let clear_result = handle.unregister_request_context(&request_id).await;
+            result?;
+            clear_result
+        }) as Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>>;
+        Ok((completion, stream_lease))
     } else {
-        execute_stream.await
+        let wrapped = wrap_streaming_script(None, &stream_id, &script);
+        let completion = handle
+            .queue_script_for_streaming(stream_id, script_name, wrapped, chunk_sender, None)
+            .await?;
+        Ok((completion, stream_lease))
     }
 }
 
@@ -321,7 +393,7 @@ impl LayoutRenderer {
             None
         };
 
-        let composition_script = self.build_composition_script(
+        let composition_script = Self::build_composition_script(
             route_match,
             context,
             loading_component_id.as_deref(),
@@ -331,14 +403,21 @@ impl LayoutRenderer {
 
         let renderer = Arc::clone(&self.renderer);
         run_with_renderer_result(renderer, move |renderer| async move {
-            let render_operation = async {
-                Self::execute_composition_and_serialize(&renderer, composition_script).await
-            };
-
+            renderer.ensure_rsc_pipeline().await?;
             if let Some(ctx) = request_context {
-                renderer.runtime.execute_with_request_context(ctx, render_operation).await
+                let runtime = Arc::clone(&renderer.runtime);
+                runtime
+                    .with_request_context(ctx, move |rt| async move {
+                        Self::execute_composition_and_serialize_on(
+                            &renderer,
+                            Some(rt),
+                            composition_script,
+                        )
+                        .await
+                    })
+                    .await
             } else {
-                render_operation.await
+                Self::execute_composition_and_serialize(&renderer, composition_script).await
             }
         })
         .await
@@ -358,6 +437,7 @@ impl LayoutRenderer {
         route_match: &AppRouteMatch,
         context: &LayoutRenderContext,
         request_context: Arc<RequestContext>,
+        action_refresh_search: String,
     ) -> Result<(), RariError> {
         let loading_enabled = Config::get().map(|config| config.loading.enabled).unwrap_or(true);
 
@@ -370,7 +450,7 @@ impl LayoutRenderer {
             None
         };
 
-        let composition_script = self.build_composition_script(
+        let composition_script = Self::build_composition_script(
             route_match,
             context,
             loading_component_id.as_deref(),
@@ -378,17 +458,25 @@ impl LayoutRenderer {
             true,
         )?;
 
+        let set_search_script = format!(
+            "globalThis['~rari'] = globalThis['~rari'] || {{}}; globalThis['~rari'].actionRefreshSearch = {};",
+            serde_json::to_string(&action_refresh_search)
+                .map_err(|e| RariError::serialization(e.to_string()))?
+        );
+
         let renderer = Arc::clone(&self.renderer);
         run_with_renderer_result(renderer, move |renderer| async move {
-            let compose_operation = async {
-                renderer
-                    .runtime
-                    .execute_script("action_refresh_compose".to_string(), composition_script)
-                    .await?;
-                Ok(())
-            };
-
-            renderer.runtime.execute_with_request_context(request_context, compose_operation).await
+            renderer.ensure_rsc_pipeline().await?;
+            let runtime = Arc::clone(&renderer.runtime);
+            runtime
+                .with_request_context(request_context, move |rt| async move {
+                    rt.execute_script("set_action_refresh_search".to_string(), set_search_script)
+                        .await?;
+                    rt.execute_script("action_refresh_compose".to_string(), composition_script)
+                        .await?;
+                    Ok(())
+                })
+                .await
         })
         .await
     }
@@ -400,6 +488,7 @@ impl LayoutRenderer {
         context: &LayoutRenderContext,
         request_context: Option<Arc<RequestContext>>,
         return_rsc_on_fallback: bool,
+        metadata_rx: Option<oneshot::Receiver<Option<PageMetadata>>>,
     ) -> Result<RenderResult, RariError> {
         let cookie_header = request_context.as_deref().and_then(|ctx| ctx.cookie_header.as_deref());
         let cache_key = utils::generate_cache_key(route_match, context, cookie_header);
@@ -430,7 +519,7 @@ impl LayoutRenderer {
 
         if return_rsc_on_fallback {
             if needs_streaming {
-                let composition_script = self.build_composition_script(
+                let composition_script = Self::build_composition_script(
                     route_match,
                     context,
                     loading_component_id.as_deref(),
@@ -439,14 +528,9 @@ impl LayoutRenderer {
                 )?;
 
                 let (chunk_sender, chunk_receiver) =
-                    mpsc::channel::<Result<Vec<u8>, RariError>>(32);
+                    mpsc::channel::<Result<Vec<u8>, RariError>>(128);
 
-                let runtime =
-                    run_with_renderer_result(Arc::clone(&self.renderer), |renderer| async move {
-                        renderer.ensure_streaming_pipeline().await?;
-                        Ok(Arc::clone(&renderer.runtime))
-                    })
-                    .await?;
+                let stream_id = Uuid::new_v4().to_string();
 
                 let script = format!(
                     r"(async function() {{
@@ -470,24 +554,43 @@ impl LayoutRenderer {
                         }} catch(e) {{
                             console.error('[rari] RSC streaming navigation fatal error:', e);
                         }} finally {{
-                            Deno.core.ops.op_fizz_done();
+                            Deno.core.ops.op_fizz_done(__RARI_STREAM_ID__);
                         }}
                     }})()",
                 );
 
-                let runtime_clone = Arc::clone(&runtime);
+                let renderer = Arc::clone(&self.renderer);
                 let request_context_for_stream = request_context.clone();
                 tokio::spawn(async move {
-                    if let Err(e) = run_streaming_script(
-                        &runtime_clone,
-                        request_context_for_stream,
-                        "rsc_streaming_nav".to_string(),
-                        script,
-                        chunk_sender,
-                    )
-                    .await
-                    {
-                        tracing::error!("RSC streaming navigation failed: {e}");
+                    let prepared = run_with_renderer_result(renderer, |renderer| async move {
+                        renderer.ensure_streaming_pipeline().await?;
+                        Ok(Arc::clone(&renderer.runtime))
+                    })
+                    .await;
+
+                    match prepared {
+                        Ok(runtime) => {
+                            if let Err(e) = run_streaming_script(
+                                &runtime,
+                                request_context_for_stream,
+                                "rsc_streaming_nav".to_string(),
+                                stream_id,
+                                script,
+                                chunk_sender,
+                            )
+                            .await
+                            {
+                                tracing::error!("RSC streaming navigation failed: {e}");
+                            }
+                        }
+                        Err(e) => {
+                            tracing::error!("RSC streaming navigation setup failed: {e}");
+                            let _ = chunk_sender
+                                .send(Err(RariError::internal(format!(
+                                    "RSC streaming setup failed: {e}"
+                                ))))
+                                .await;
+                        }
                     }
                 });
 
@@ -499,7 +602,7 @@ impl LayoutRenderer {
                 });
             }
 
-            let composition_script = self.build_composition_script(
+            let composition_script = Self::build_composition_script(
                 route_match,
                 context,
                 loading_component_id.as_deref(),
@@ -509,22 +612,45 @@ impl LayoutRenderer {
 
             let rsc_payload =
                 run_with_renderer_result(Arc::clone(&self.renderer), move |renderer| async move {
-                    let render_and_capture = async {
-                        let result = Self::run_composition(&renderer, composition_script).await?;
+                    renderer.ensure_rsc_pipeline().await?;
+                    if let Some(ctx) = request_context {
+                        let runtime = Arc::clone(&renderer.runtime);
+                        runtime
+                            .with_request_context(ctx, move |rt| async move {
+                                let result = Self::run_composition_on(
+                                    &renderer,
+                                    Some(Arc::clone(&rt)),
+                                    composition_script,
+                                )
+                                .await?;
 
-                        if let Some(bytes) = Self::capture_last_rsc_binary(&renderer).await?
+                                if let Some(bytes) =
+                                    Self::capture_last_rsc_binary_on(Some(rt)).await?
+                                    && !bytes.is_empty()
+                                {
+                                    return Ok(RscNavPayload::Binary(bytes));
+                                }
+
+                                Ok(RscNavPayload::Text(Self::extract_flight_text(&result)?))
+                            })
+                            .await
+                    } else {
+                        let handle = renderer.runtime.pick_runtime().await?;
+                        let rt = Arc::clone(handle.runtime());
+                        let result = Self::run_composition_on(
+                            &renderer,
+                            Some(Arc::clone(&rt)),
+                            composition_script,
+                        )
+                        .await?;
+
+                        if let Some(bytes) = Self::capture_last_rsc_binary_on(Some(rt)).await?
                             && !bytes.is_empty()
                         {
                             return Ok(RscNavPayload::Binary(bytes));
                         }
 
                         Ok(RscNavPayload::Text(Self::extract_flight_text(&result)?))
-                    };
-
-                    if let Some(ctx) = request_context {
-                        renderer.runtime.execute_with_request_context(ctx, render_and_capture).await
-                    } else {
-                        render_and_capture.await
                     }
                 })
                 .await?;
@@ -538,42 +664,84 @@ impl LayoutRenderer {
                 Config::get().ok_or_else(|| RariError::internal("Config not available"))?;
 
             if needs_streaming {
-                let composition_script = self.build_composition_script(
-                    route_match,
-                    context,
+                let (chunk_sender, chunk_receiver) =
+                    mpsc::channel::<Result<Vec<u8>, RariError>>(128);
+
+                let stream_id = Uuid::new_v4().to_string();
+                let shell = Bytes::from_static(b"<!DOCTYPE html>");
+                let closing = Bytes::new();
+
+                let renderer = Arc::clone(&self.renderer);
+                let route_match = route_match.clone();
+                let mut context = context.clone();
+                let loading_component_id = loading_component_id.clone();
+                let config = config.clone();
+                let request_context_for_stream = request_context.clone();
+
+                if let Some(mut rx) = metadata_rx {
+                    match rx.try_recv() {
+                        Ok(metadata) => context.metadata = metadata,
+                        Err(
+                            oneshot::error::TryRecvError::Empty
+                            | oneshot::error::TryRecvError::Closed,
+                        ) => {}
+                    }
+                }
+
+                let composition_script = match Self::build_composition_script(
+                    &route_match,
+                    &context,
                     loading_component_id.as_deref(),
                     true,
                     true,
-                )?;
+                ) {
+                    Ok(script) => script,
+                    Err(e) => {
+                        tracing::error!("Fizz streaming composition error: {e}");
+                        let _ = chunk_sender
+                            .send(Err(RariError::internal(format!(
+                                "Fizz streaming composition failed: {e}"
+                            ))))
+                            .await;
+                        return Ok(RenderResult::Chunked {
+                            content_type: ChunkedContentType::Html,
+                            shell,
+                            closing,
+                            chunks: chunk_receiver,
+                        });
+                    }
+                };
 
-                let runtime =
-                    run_with_renderer_result(Arc::clone(&self.renderer), |renderer| async move {
+                let prepared = run_with_renderer_result(renderer, move |renderer| {
+                    async move {
                         renderer.ensure_streaming_pipeline().await?;
-                        Ok(Arc::clone(&renderer.runtime))
-                    })
-                    .await?;
 
-                let html_renderer = RscHtmlRenderer::new(Arc::clone(&runtime));
-                let css_links = RscHtmlRenderer::css_links_for_route(route_match);
-                let cache_template = config.rsc_html.cache_template;
-                let is_dev_mode = config.is_development();
-                let template = html_renderer.load_template(cache_template, is_dev_mode).await?;
-                let template = RscHtmlRenderer::inject_css_links(&template, &css_links);
+                        let html_renderer = RscHtmlRenderer::new(Arc::clone(&renderer.runtime));
+                        let css_links = RscHtmlRenderer::css_links_for_route(&route_match);
+                        let cache_template = config.rsc_html.cache_template;
+                        let is_dev_mode = config.is_development();
+                        let template =
+                            html_renderer.load_template(cache_template, is_dev_mode).await?;
+                        let template = RscHtmlRenderer::inject_css_links(&template, &css_links);
 
-                let head_content = template
-                    .find("<head>")
-                    .and_then(|start| template.find("</head>").map(|end| &template[start + 6..end]))
-                    .unwrap_or("")
-                    .to_string();
+                        let head_content = {
+                            let template_head = template
+                                .find("<head>")
+                                .and_then(|start| {
+                                    template.find("</head>").map(|end| &template[start + 6..end])
+                                })
+                                .unwrap_or("");
+                            merge_streaming_head_content(
+                                template_head,
+                                context.streaming_head_extra.as_deref(),
+                            )
+                        };
 
-                let (chunk_sender, chunk_receiver) =
-                    mpsc::channel::<Result<Vec<u8>, RariError>>(32);
+                        let head_content_json = serde_json::to_string(&head_content)
+                            .unwrap_or_else(|_| "\"\"".to_string());
 
-                let head_content_json =
-                    serde_json::to_string(&head_content).unwrap_or_else(|_| "\"\"".to_string());
-
-                let script = format!(
-                    r"(async function() {{
+                        let script = format!(
+                            r"(async function() {{
                         let caughtErrors = [];
                         {FIZZ_STREAM_ERROR_HELPER}
                         try {{
@@ -583,7 +751,7 @@ impl LayoutRenderer {
 
                         const capturedElement = globalThis['~rari']?.capturedElement;
                         if (!capturedElement) {{
-                            Deno.core.ops.op_fizz_done();
+                            Deno.core.ops.op_fizz_done(__RARI_STREAM_ID__);
                             return;
                         }}
 
@@ -596,49 +764,63 @@ impl LayoutRenderer {
                             capturedElement,
                             headContent: {head_content_json},
                             caughtErrors,
+                            streamId: __RARI_STREAM_ID__,
                         }});
 
                         {FIZZ_STREAM_ERROR_INJECTION}
 
-                        await globalThis['~rari']?.pumpStreamingCompleteScript?.();
-
-                        Deno.core.ops.op_fizz_done();
+                        Deno.core.ops.op_fizz_done(__RARI_STREAM_ID__);
 
                         }} catch(outerError) {{
                             console.error('[rari] Fizz streaming pipeline fatal error:', outerError);
                             const displayError = caughtErrors.length > 0 ? caughtErrors[0] : outerError;
                             const errMsg = String(displayError?.message || outerError?.message || 'Unknown error').split('<').join('&lt;');
                             const errorHtml = '<!doctype html><html><head></head><body><div id=root><div class=rari-error style=color:red;border:1px_solid_red;padding:10px;border-radius:4px;background-color:#fff5f5><strong>Error loading content: </strong>' + errMsg + '</div></div></body></html>';
-                            const pump = globalThis['~rari']?.pumpFizzChunk;
-                            if (typeof pump === 'function') {{
-                                await pump(errorHtml);
-                            }} else {{
-                                await Deno.core.ops.op_fizz_chunk(errorHtml);
-                            }}
-                            Deno.core.ops.op_fizz_done();
+                            await Deno.core.ops.op_fizz_chunk(__RARI_STREAM_ID__, errorHtml);
+                            Deno.core.ops.op_fizz_done(__RARI_STREAM_ID__);
                         }}
                     }})()",
-                );
+                        );
 
-                let shell = Bytes::from_static(b"<!DOCTYPE html>");
-                let closing = Bytes::new();
-
-                let runtime_clone = Arc::clone(&runtime);
-                let request_context_for_stream = request_context.clone();
-                tokio::spawn(async move {
-                    task::yield_now().await;
-                    if let Err(e) = run_streaming_script(
-                        &runtime_clone,
-                        request_context_for_stream,
-                        "fizz_direct_stream".to_string(),
-                        script,
-                        chunk_sender,
-                    )
-                    .await
-                    {
-                        tracing::error!("Fizz direct streaming error: {e}");
+                        Ok((Arc::clone(&renderer.runtime), script))
                     }
-                });
+                })
+                .await;
+
+                match prepared {
+                    Ok((runtime, script)) => {
+                        match queue_streaming_script(
+                            &runtime,
+                            request_context_for_stream,
+                            "fizz_direct_stream".to_string(),
+                            stream_id,
+                            script,
+                            chunk_sender,
+                        )
+                        .await
+                        {
+                            Ok((completion, stream_lease)) => {
+                                tokio::spawn(async move {
+                                    let _stream_lease = stream_lease;
+                                    if let Err(e) = completion.await {
+                                        tracing::error!("Fizz direct streaming error: {e}");
+                                    }
+                                });
+                            }
+                            Err(e) => {
+                                tracing::error!("Fizz streaming queue error: {e}");
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!("Fizz streaming setup error: {e}");
+                        let _ = chunk_sender
+                            .send(Err(RariError::internal(format!(
+                                "Fizz streaming setup failed: {e}"
+                            ))))
+                            .await;
+                    }
+                }
 
                 return Ok(RenderResult::Chunked {
                     content_type: ChunkedContentType::Html,
@@ -649,7 +831,7 @@ impl LayoutRenderer {
             }
 
             let html = {
-                let composition_script = self.build_composition_script(
+                let composition_script = Self::build_composition_script(
                     route_match,
                     context,
                     loading_component_id.as_deref(),
@@ -664,7 +846,7 @@ impl LayoutRenderer {
                 run_with_renderer_result(Arc::clone(&self.renderer), move |renderer| async move {
                     renderer.ensure_streaming_pipeline().await?;
 
-                    let html_renderer = RscHtmlRenderer::new(Arc::clone(&renderer.runtime));
+                    let html_renderer = Arc::new(RscHtmlRenderer::new(Arc::clone(&renderer.runtime)));
                     let css_links = RscHtmlRenderer::css_links_for_route(&route_match);
                     let cache_template = config.rsc_html.cache_template;
                     let is_dev_mode = config.is_development();
@@ -706,69 +888,114 @@ impl LayoutRenderer {
                                 caughtErrors,
                             }});
 
-                            return {{ ok: true, html }};
+                            const isDynamic = (globalThis['~rari']?.useCacheDynamicDepth ?? 0) > 0;
+                            let pageCacheTags = [];
+                            if (!isDynamic) {{
+                                const tags = new Set(
+                                    globalThis['~rari']?.pageCacheTags ? [...globalThis['~rari'].pageCacheTags] : [],
+                                );
+                                const fromRegistry = globalThis.__rariGetActiveUseCacheTags?.() ?? [];
+                                for (const tag of fromRegistry)
+                                    tags.add(tag);
+                                pageCacheTags = [...tags];
+                            }}
+
+                            return {{ ok: true, html, isDynamic, pageCacheTags }};
                         }} catch(e) {{
                             return {{ ok: false, error: String(e?.message || e) }};
                         }}
                     }})()",
                     );
 
-                    let render_operation = async {
-                        let result = renderer
-                            .runtime
-                            .execute_script("static_document_render".to_string(), script)
-                            .await?;
+                    let render_static = {
+                        let script = script.clone();
+                        let html_renderer = Arc::clone(&html_renderer);
+                        let css_links = css_links.clone();
+                        move |rt: Arc<dyn JsRuntimeInterface>| {
+                            let script = script.clone();
+                            let html_renderer = Arc::clone(&html_renderer);
+                            let css_links = css_links.clone();
+                            async move {
+                                let result = rt
+                                    .execute_script("static_document_render".to_string(), script)
+                                    .await?;
 
-                        let ok = result.get("ok").and_then(Value::as_bool).unwrap_or(false);
-                        if !ok {
-                            let err =
-                                result.get("error").and_then(|v| v.as_str()).unwrap_or("unknown");
-                            return Err(RariError::internal(format!(
-                                "Static document render failed: {err}"
-                            )));
+                                let ok = result.get("ok").and_then(Value::as_bool).unwrap_or(false);
+                                if !ok {
+                                    let err = result
+                                        .get("error")
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("unknown");
+                                    return Err(RariError::internal(format!(
+                                        "Static document render failed: {err}"
+                                    )));
+                                }
+
+                                let html = result
+                                    .get("html")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or_default()
+                                    .to_string();
+
+                                let assembled = html_renderer
+                                    .assemble_document(
+                                        html,
+                                        cache_template,
+                                        is_dev_mode,
+                                        &css_links,
+                                    )
+                                    .await?;
+
+                                let is_dynamic = result
+                                    .get("isDynamic")
+                                    .and_then(Value::as_bool)
+                                    .unwrap_or(false);
+
+                                let page_cache_tags = if is_dynamic {
+                                    Vec::new()
+                                } else {
+                                    result
+                                        .get("pageCacheTags")
+                                        .and_then(|v| {
+                                            v.as_array().map(|arr| {
+                                                arr.iter()
+                                                    .filter_map(|item| {
+                                                        item.as_str().map(str::to_string)
+                                                    })
+                                                    .collect::<Vec<_>>()
+                                            })
+                                        })
+                                        .unwrap_or_default()
+                                };
+
+                                Ok((assembled, is_dynamic, page_cache_tags))
+                            }
                         }
-
-                        let html = result
-                            .get("html")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or_default()
-                            .to_string();
-
-                        html_renderer
-                            .assemble_document(html, cache_template, is_dev_mode, &css_links)
-                            .await
                     };
 
                     if let Some(ctx) = request_context {
-                        renderer.runtime.execute_with_request_context(ctx, render_operation).await
+                        let runtime = Arc::clone(&renderer.runtime);
+                        runtime.with_request_context(ctx, render_static).await
                     } else {
-                        render_operation.await
+                        let handle = renderer.runtime.pick_runtime().await?;
+                        render_static(Arc::clone(handle.runtime())).await
                     }
                 })
                 .await?
             };
 
-            if layout_cache_enabled && route_match.not_found.is_none() {
-                let runtime = {
-                    let renderer = self.renderer.lock().await;
-                    Arc::clone(&renderer.runtime)
-                };
+            let (html, is_dynamic_render, page_cache_tags) = html;
 
-                let is_dynamic_render = runtime.is_dynamic_render().await.unwrap_or(false);
-
-                if !is_dynamic_render {
-                    let page_cache_tags =
-                        runtime.collect_page_cache_tags().await.unwrap_or_default();
-                    let mut layout_cache_tags = page_cache_tags;
-                    let route_path = route_match.route.path.clone();
-                    if !layout_cache_tags.iter().any(|tag| tag == &route_path) {
-                        layout_cache_tags.push(route_path);
-                    }
-                    let _ = self
-                        .html_cache
-                        .insert_with_tags(cache_key, html.clone(), &layout_cache_tags)
-                        .await;
+            if layout_cache_enabled && route_match.not_found.is_none() && !is_dynamic_render {
+                let mut layout_cache_tags = page_cache_tags;
+                let route_path = route_match.route.path.clone();
+                if !layout_cache_tags.iter().any(|tag| tag == &route_path) {
+                    layout_cache_tags.push(route_path);
                 }
+                let _ = self
+                    .html_cache
+                    .insert_with_tags(cache_key, html.clone(), &layout_cache_tags)
+                    .await;
             }
 
             Ok(RenderResult::Static(html))
@@ -779,34 +1006,48 @@ impl LayoutRenderer {
         renderer: &RscRenderer,
         composition_script: String,
     ) -> Result<String, RariError> {
-        let result = Self::run_composition(renderer, composition_script).await?;
+        Self::execute_composition_and_serialize_on(renderer, None, composition_script).await
+    }
+
+    async fn execute_composition_and_serialize_on(
+        renderer: &RscRenderer,
+        runtime: Option<Arc<dyn JsRuntimeInterface>>,
+        composition_script: String,
+    ) -> Result<String, RariError> {
+        let result = Self::run_composition_on(renderer, runtime, composition_script).await?;
         Self::extract_flight_text(&result)
     }
 
-    async fn run_composition(
+    async fn run_composition_on(
         renderer: &RscRenderer,
+        runtime: Option<Arc<dyn JsRuntimeInterface>>,
         composition_script: String,
     ) -> Result<Value, RariError> {
-        renderer.ensure_rsc_pipeline().await?;
+        let rt = if let Some(rt) = runtime {
+            rt
+        } else {
+            renderer.ensure_rsc_pipeline().await?;
+            let handle = renderer.runtime.pick_runtime().await?;
+            Arc::clone(handle.runtime())
+        };
 
-        let promise_result = renderer
-            .runtime
-            .execute_script("compose_and_render".to_string(), composition_script)
-            .await?;
+        let promise_result =
+            rt.execute_script("compose_and_render".to_string(), composition_script).await?;
 
         if promise_result.is_object() && promise_result.get("rsc_data").is_some() {
             Ok(promise_result)
         } else {
-            renderer
-                .runtime
-                .execute_script("get_result".to_string(), JS_GET_RESULT.to_string())
-                .await
+            rt.execute_script("get_result".to_string(), JS_GET_RESULT.to_string()).await
         }
     }
 
-    async fn capture_last_rsc_binary(renderer: &RscRenderer) -> Result<Option<Vec<u8>>, RariError> {
-        let result = renderer
-            .runtime
+    async fn capture_last_rsc_binary_on(
+        runtime: Option<Arc<dyn JsRuntimeInterface>>,
+    ) -> Result<Option<Vec<u8>>, RariError> {
+        let Some(rt) = runtime else {
+            return Ok(None);
+        };
+        let result = rt
             .execute_script("get_rsc_binary_b64".to_string(), GET_RSC_BINARY_B64.to_string())
             .await?;
 
@@ -837,7 +1078,6 @@ impl LayoutRenderer {
 
     #[expect(clippy::too_many_lines)]
     pub fn build_composition_script(
-        &self,
         route_match: &AppRouteMatch,
         context: &LayoutRenderContext,
         loading_component_id: Option<&str>,

--- a/crates/rari/src/rendering/layout/core.rs
+++ b/crates/rari/src/rendering/layout/core.rs
@@ -324,6 +324,17 @@ impl LayoutRenderer {
         route_match: &AppRouteMatch,
         context: &LayoutRenderContext,
     ) -> Result<bool, RariError> {
+        self.check_page_not_found_on(route_match, context, None).await
+    }
+
+    /// Prefer [`Self::check_page_not_found_on`] with a sticky runtime when the caller
+    /// already holds a pool slot lease — using the pool here would re-acquire it and deadlock.
+    pub async fn check_page_not_found_on(
+        &self,
+        route_match: &AppRouteMatch,
+        context: &LayoutRenderContext,
+        sticky_runtime: Option<&Arc<dyn JsRuntimeInterface>>,
+    ) -> Result<bool, RariError> {
         let page_props = utils::create_page_props(route_match, context)?;
         let page_props_json = serde_json::to_string(&page_props)?;
 
@@ -365,11 +376,14 @@ impl LayoutRenderer {
             "#
         );
 
-        let renderer = self.renderer.lock().await;
-        let runtime = Arc::clone(&renderer.runtime);
-        drop(renderer);
-
-        let result = runtime.execute_script("check_not_found".to_string(), check_script).await?;
+        let result = if let Some(runtime) = sticky_runtime {
+            runtime.execute_script("check_not_found".to_string(), check_script).await?
+        } else {
+            let renderer = self.renderer.lock().await;
+            let runtime = Arc::clone(&renderer.runtime);
+            drop(renderer);
+            runtime.execute_script("check_not_found".to_string(), check_script).await?
+        };
 
         let not_found =
             result.get("notFound").and_then(serde_json::Value::as_bool).unwrap_or(false);

--- a/crates/rari/src/rendering/layout/core.rs
+++ b/crates/rari/src/rendering/layout/core.rs
@@ -423,25 +423,27 @@ impl LayoutRenderer {
         )?;
 
         let renderer = Arc::clone(&self.renderer);
-        run_with_renderer_result(renderer, move |renderer| async move {
-            renderer.ensure_rsc_pipeline().await?;
-            if let Some(ctx) = request_context {
-                let runtime = Arc::clone(&renderer.runtime);
-                runtime
-                    .with_request_context(ctx, move |rt| async move {
-                        Self::execute_composition_and_serialize_on(
-                            &renderer,
-                            Some(rt),
-                            composition_script,
-                        )
+        let runtime = {
+            run_with_renderer_result(Arc::clone(&renderer), move |renderer| async move {
+                renderer.ensure_rsc_pipeline().await?;
+                Ok(Arc::clone(&renderer.runtime))
+            })
+            .await?
+        };
+
+        if let Some(ctx) = request_context {
+            runtime
+                .with_request_context(ctx, move |rt| async move {
+                    Self::execute_composition_and_serialize_on(None, Some(rt), composition_script)
                         .await
-                    })
-                    .await
-            } else {
+                })
+                .await
+        } else {
+            run_with_renderer_result(renderer, move |renderer| async move {
                 Self::execute_composition_and_serialize(&renderer, composition_script).await
-            }
-        })
-        .await
+            })
+            .await
+        }
     }
 
     pub async fn render_route_by_mode(
@@ -480,23 +482,25 @@ impl LayoutRenderer {
         )?;
 
         let set_search_script = format!(
-            "globalThis['~rari'] = globalThis['~rari'] || {{}}; globalThis['~rari'].actionRefreshSearch = {};",
+            "globalThis['~rari'] = globalThis['~rari'] || {{}}; globalThis['~rari'].isActionRefreshCompose = true; globalThis['~rari'].actionRefreshSearch = {};",
             serde_json::to_string(&action_refresh_search)
                 .map_err(|e| RariError::serialization(e.to_string()))?
         );
 
-        let renderer = Arc::clone(&self.renderer);
-        run_with_renderer_result(renderer, move |renderer| async move {
-            renderer.ensure_rsc_pipeline().await?;
-            let runtime = Arc::clone(&renderer.runtime);
-            runtime
-                .with_request_context(request_context, move |rt| async move {
-                    Self::run_action_refresh_scripts(&rt, set_search_script, composition_script)
-                        .await
-                })
-                .await
-        })
-        .await
+        let runtime = {
+            let renderer = Arc::clone(&self.renderer);
+            run_with_renderer_result(renderer, move |renderer| async move {
+                renderer.ensure_rsc_pipeline().await?;
+                Ok(Arc::clone(&renderer.runtime))
+            })
+            .await?
+        };
+
+        runtime
+            .with_request_context(request_context, move |rt| async move {
+                Self::run_action_refresh_scripts(&rt, set_search_script, composition_script).await
+            })
+            .await
     }
 
     pub async fn compose_route_for_action_refresh_on(
@@ -526,18 +530,12 @@ impl LayoutRenderer {
         )?;
 
         let set_search_script = format!(
-            "globalThis['~rari'] = globalThis['~rari'] || {{}}; globalThis['~rari'].actionRefreshSearch = {};",
+            "globalThis['~rari'] = globalThis['~rari'] || {{}}; globalThis['~rari'].isActionRefreshCompose = true; globalThis['~rari'].actionRefreshSearch = {};",
             serde_json::to_string(&action_refresh_search)
                 .map_err(|e| RariError::serialization(e.to_string()))?
         );
 
-        let renderer = Arc::clone(&self.renderer);
-        let runtime = Arc::clone(runtime);
-        run_with_renderer_result(renderer, move |renderer| async move {
-            renderer.ensure_rsc_pipeline().await?;
-            Self::run_action_refresh_scripts(&runtime, set_search_script, composition_script).await
-        })
-        .await
+        Self::run_action_refresh_scripts(runtime, set_search_script, composition_script).await
     }
 
     async fn run_action_refresh_scripts(
@@ -588,18 +586,18 @@ impl LayoutRenderer {
 
         if return_rsc_on_fallback {
             if needs_streaming {
-                let composition_script = Self::build_composition_script(
+                let (chunk_sender, chunk_receiver) =
+                    mpsc::channel::<Result<Vec<u8>, RariError>>(128);
+
+                let stream_id = Uuid::new_v4().to_string();
+                let composition_script = Self::build_composition_script_with_stream(
                     route_match,
                     context,
                     loading_component_id.as_deref(),
                     true,
                     true,
+                    Some(&stream_id),
                 )?;
-
-                let (chunk_sender, chunk_receiver) =
-                    mpsc::channel::<Result<Vec<u8>, RariError>>(128);
-
-                let stream_id = Uuid::new_v4().to_string();
 
                 let script = format!(
                     r"(async function() {{
@@ -609,7 +607,12 @@ impl LayoutRenderer {
                             console.error('[rari] Composition error in RSC streaming nav:', e);
                         }}
 
-                        const capturedElement = globalThis['~rari']?.capturedElement;
+                        const byStream = globalThis['~rari']?.capturedByStream;
+                        const capturedElement = (byStream && __RARI_STREAM_ID__ in byStream)
+                            ? byStream[__RARI_STREAM_ID__]
+                            : globalThis['~rari']?.capturedElement;
+                        if (byStream && __RARI_STREAM_ID__ in byStream)
+                            delete byStream[__RARI_STREAM_ID__];
                         if (!capturedElement) {{
                             return;
                         }}
@@ -679,50 +682,53 @@ impl LayoutRenderer {
                 false,
             )?;
 
-            let rsc_payload =
-                run_with_renderer_result(Arc::clone(&self.renderer), move |renderer| async move {
-                    renderer.ensure_rsc_pipeline().await?;
-                    if let Some(ctx) = request_context {
-                        let runtime = Arc::clone(&renderer.runtime);
-                        runtime
-                            .with_request_context(ctx, move |rt| async move {
-                                let result = Self::run_composition_on(
-                                    &renderer,
-                                    Some(Arc::clone(&rt)),
-                                    composition_script,
-                                )
-                                .await?;
+            let rsc_payload = {
+                let runtime = {
+                    run_with_renderer_result(
+                        Arc::clone(&self.renderer),
+                        move |renderer| async move {
+                            renderer.ensure_rsc_pipeline().await?;
+                            Ok(Arc::clone(&renderer.runtime))
+                        },
+                    )
+                    .await?
+                };
 
-                                if let Some(bytes) =
-                                    Self::capture_last_rsc_binary_on(Some(rt)).await?
-                                    && !bytes.is_empty()
-                                {
-                                    return Ok(RscNavPayload::Binary(bytes));
-                                }
+                if let Some(ctx) = request_context {
+                    runtime
+                        .with_request_context(ctx, move |rt| async move {
+                            let result = Self::run_composition_on(
+                                None,
+                                Some(Arc::clone(&rt)),
+                                composition_script,
+                            )
+                            .await?;
 
-                                Ok(RscNavPayload::Text(Self::extract_flight_text(&result)?))
-                            })
-                            .await
+                            if let Some(bytes) = Self::capture_last_rsc_binary_on(Some(rt)).await?
+                                && !bytes.is_empty()
+                            {
+                                return Ok(RscNavPayload::Binary(bytes));
+                            }
+
+                            Ok(RscNavPayload::Text(Self::extract_flight_text(&result)?))
+                        })
+                        .await?
+                } else {
+                    let handle = runtime.pick_runtime().await?;
+                    let rt = Arc::clone(handle.runtime());
+                    let result =
+                        Self::run_composition_on(None, Some(Arc::clone(&rt)), composition_script)
+                            .await?;
+
+                    if let Some(bytes) = Self::capture_last_rsc_binary_on(Some(rt)).await?
+                        && !bytes.is_empty()
+                    {
+                        RscNavPayload::Binary(bytes)
                     } else {
-                        let handle = renderer.runtime.pick_runtime().await?;
-                        let rt = Arc::clone(handle.runtime());
-                        let result = Self::run_composition_on(
-                            &renderer,
-                            Some(Arc::clone(&rt)),
-                            composition_script,
-                        )
-                        .await?;
-
-                        if let Some(bytes) = Self::capture_last_rsc_binary_on(Some(rt)).await?
-                            && !bytes.is_empty()
-                        {
-                            return Ok(RscNavPayload::Binary(bytes));
-                        }
-
-                        Ok(RscNavPayload::Text(Self::extract_flight_text(&result)?))
+                        RscNavPayload::Text(Self::extract_flight_text(&result)?)
                     }
-                })
-                .await?;
+                }
+            };
 
             match rsc_payload {
                 RscNavPayload::Binary(bytes) => Ok(RenderResult::StaticBinary(bytes)),
@@ -757,12 +763,13 @@ impl LayoutRenderer {
                     }
                 }
 
-                let composition_script = match Self::build_composition_script(
+                let composition_script = match Self::build_composition_script_with_stream(
                     &route_match,
                     &context,
                     loading_component_id.as_deref(),
                     true,
                     true,
+                    Some(&stream_id),
                 ) {
                     Ok(script) => script,
                     Err(e) => {
@@ -818,7 +825,12 @@ impl LayoutRenderer {
                             console.error('[rari] Composition error in streaming:', e);
                         }}
 
-                        const capturedElement = globalThis['~rari']?.capturedElement;
+                        const byStream = globalThis['~rari']?.capturedByStream;
+                        const capturedElement = (byStream && __RARI_STREAM_ID__ in byStream)
+                            ? byStream[__RARI_STREAM_ID__]
+                            : globalThis['~rari']?.capturedElement;
+                        if (byStream && __RARI_STREAM_ID__ in byStream)
+                            delete byStream[__RARI_STREAM_ID__];
                         if (!capturedElement) {{
                             Deno.core.ops.op_fizz_done(__RARI_STREAM_ID__);
                             return;
@@ -912,29 +924,34 @@ impl LayoutRenderer {
                 let config = config.clone();
                 let request_context = request_context.clone();
 
-                run_with_renderer_result(Arc::clone(&self.renderer), move |renderer| async move {
-                    renderer.ensure_streaming_pipeline().await?;
+                let prepared = {
+                    let composition_script = composition_script.clone();
+                    run_with_renderer_result(Arc::clone(&self.renderer), move |renderer| async move {
+                        renderer.ensure_streaming_pipeline().await?;
 
-                    let html_renderer = Arc::new(RscHtmlRenderer::new(Arc::clone(&renderer.runtime)));
-                    let css_links = RscHtmlRenderer::css_links_for_route(&route_match);
-                    let cache_template = config.rsc_html.cache_template;
-                    let is_dev_mode = config.is_development();
-                    let template = html_renderer.load_template(cache_template, is_dev_mode).await?;
-                    let template = RscHtmlRenderer::inject_css_links(&template, &css_links);
+                        let runtime = Arc::clone(&renderer.runtime);
+                        let html_renderer =
+                            Arc::new(RscHtmlRenderer::new(Arc::clone(&renderer.runtime)));
+                        let css_links = RscHtmlRenderer::css_links_for_route(&route_match);
+                        let cache_template = config.rsc_html.cache_template;
+                        let is_dev_mode = config.is_development();
+                        let template =
+                            html_renderer.load_template(cache_template, is_dev_mode).await?;
+                        let template = RscHtmlRenderer::inject_css_links(&template, &css_links);
 
-                    let head_content = template
-                        .find("<head>")
-                        .and_then(|start| {
-                            template.find("</head>").map(|end| &template[start + 6..end])
-                        })
-                        .unwrap_or("")
-                        .to_string();
+                        let head_content = template
+                            .find("<head>")
+                            .and_then(|start| {
+                                template.find("</head>").map(|end| &template[start + 6..end])
+                            })
+                            .unwrap_or("")
+                            .to_string();
 
-                    let head_content_json =
-                        serde_json::to_string(&head_content).unwrap_or_else(|_| "\"\"".to_string());
+                        let head_content_json = serde_json::to_string(&head_content)
+                            .unwrap_or_else(|_| "\"\"".to_string());
 
-                    let script = format!(
-                        r"(async function() {{
+                        let script = format!(
+                            r"(async function() {{
                         let caughtErrors = [];
                         try {{
                             try {{ await ({composition_script}); }} catch(e) {{
@@ -974,83 +991,88 @@ impl LayoutRenderer {
                             return {{ ok: false, error: String(e?.message || e) }};
                         }}
                     }})()",
-                    );
+                        );
 
-                    let render_static = {
+                        Ok((
+                            runtime,
+                            html_renderer,
+                            css_links,
+                            script,
+                            cache_template,
+                            is_dev_mode,
+                        ))
+                    })
+                    .await?
+                };
+
+                let (runtime, html_renderer, css_links, script, cache_template, is_dev_mode) =
+                    prepared;
+
+                let render_static = {
+                    let script = script.clone();
+                    let html_renderer = Arc::clone(&html_renderer);
+                    let css_links = css_links.clone();
+                    move |rt: Arc<dyn JsRuntimeInterface>| {
                         let script = script.clone();
                         let html_renderer = Arc::clone(&html_renderer);
                         let css_links = css_links.clone();
-                        move |rt: Arc<dyn JsRuntimeInterface>| {
-                            let script = script.clone();
-                            let html_renderer = Arc::clone(&html_renderer);
-                            let css_links = css_links.clone();
-                            async move {
-                                let result = rt
-                                    .execute_script("static_document_render".to_string(), script)
-                                    .await?;
+                        async move {
+                            let result = rt
+                                .execute_script("static_document_render".to_string(), script)
+                                .await?;
 
-                                let ok = result.get("ok").and_then(Value::as_bool).unwrap_or(false);
-                                if !ok {
-                                    let err = result
-                                        .get("error")
-                                        .and_then(|v| v.as_str())
-                                        .unwrap_or("unknown");
-                                    return Err(RariError::internal(format!(
-                                        "Static document render failed: {err}"
-                                    )));
-                                }
-
-                                let html = result
-                                    .get("html")
+                            let ok = result.get("ok").and_then(Value::as_bool).unwrap_or(false);
+                            if !ok {
+                                let err = result
+                                    .get("error")
                                     .and_then(|v| v.as_str())
-                                    .unwrap_or_default()
-                                    .to_string();
-
-                                let assembled = html_renderer
-                                    .assemble_document(
-                                        html,
-                                        cache_template,
-                                        is_dev_mode,
-                                        &css_links,
-                                    )
-                                    .await?;
-
-                                let is_dynamic = result
-                                    .get("isDynamic")
-                                    .and_then(Value::as_bool)
-                                    .unwrap_or(false);
-
-                                let page_cache_tags = if is_dynamic {
-                                    Vec::new()
-                                } else {
-                                    result
-                                        .get("pageCacheTags")
-                                        .and_then(|v| {
-                                            v.as_array().map(|arr| {
-                                                arr.iter()
-                                                    .filter_map(|item| {
-                                                        item.as_str().map(str::to_string)
-                                                    })
-                                                    .collect::<Vec<_>>()
-                                            })
-                                        })
-                                        .unwrap_or_default()
-                                };
-
-                                Ok((assembled, is_dynamic, page_cache_tags))
+                                    .unwrap_or("unknown");
+                                return Err(RariError::internal(format!(
+                                    "Static document render failed: {err}"
+                                )));
                             }
-                        }
-                    };
 
-                    if let Some(ctx) = request_context {
-                        let runtime = Arc::clone(&renderer.runtime);
-                        runtime.with_request_context(ctx, render_static).await
-                    } else {
-                        let handle = renderer.runtime.pick_runtime().await?;
-                        render_static(Arc::clone(handle.runtime())).await
+                            let html = result
+                                .get("html")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or_default()
+                                .to_string();
+
+                            let assembled = html_renderer
+                                .assemble_document(html, cache_template, is_dev_mode, &css_links)
+                                .await?;
+
+                            let is_dynamic =
+                                result.get("isDynamic").and_then(Value::as_bool).unwrap_or(false);
+
+                            let page_cache_tags = if is_dynamic {
+                                Vec::new()
+                            } else {
+                                result
+                                    .get("pageCacheTags")
+                                    .and_then(|v| {
+                                        v.as_array().map(|arr| {
+                                            arr.iter()
+                                                .filter_map(|item| {
+                                                    item.as_str().map(str::to_string)
+                                                })
+                                                .collect::<Vec<_>>()
+                                        })
+                                    })
+                                    .unwrap_or_default()
+                            };
+
+                            Ok((assembled, is_dynamic, page_cache_tags))
+                        }
                     }
-                })
-                .await?
+                };
+
+                if let Some(ctx) = request_context {
+                    runtime.with_request_context(ctx, render_static).await?
+                } else {
+                    let handle = runtime.pick_runtime().await?;
+                    render_static(Arc::clone(handle.runtime())).await?
+                }
             };
 
             let (html, is_dynamic_render, page_cache_tags) = html;
@@ -1075,11 +1097,11 @@ impl LayoutRenderer {
         renderer: &RscRenderer,
         composition_script: String,
     ) -> Result<String, RariError> {
-        Self::execute_composition_and_serialize_on(renderer, None, composition_script).await
+        Self::execute_composition_and_serialize_on(Some(renderer), None, composition_script).await
     }
 
     async fn execute_composition_and_serialize_on(
-        renderer: &RscRenderer,
+        renderer: Option<&RscRenderer>,
         runtime: Option<Arc<dyn JsRuntimeInterface>>,
         composition_script: String,
     ) -> Result<String, RariError> {
@@ -1088,13 +1110,16 @@ impl LayoutRenderer {
     }
 
     async fn run_composition_on(
-        renderer: &RscRenderer,
+        renderer: Option<&RscRenderer>,
         runtime: Option<Arc<dyn JsRuntimeInterface>>,
         composition_script: String,
     ) -> Result<Value, RariError> {
         let rt = if let Some(rt) = runtime {
             rt
         } else {
+            let renderer = renderer.ok_or_else(|| {
+                RariError::internal("run_composition_on requires renderer or runtime")
+            })?;
             renderer.ensure_rsc_pipeline().await?;
             let handle = renderer.runtime.pick_runtime().await?;
             Arc::clone(handle.runtime())
@@ -1152,6 +1177,25 @@ impl LayoutRenderer {
         loading_component_id: Option<&str>,
         use_suspense: bool,
         defer_rsc: bool,
+    ) -> Result<String, RariError> {
+        Self::build_composition_script_with_stream(
+            route_match,
+            context,
+            loading_component_id,
+            use_suspense,
+            defer_rsc,
+            None,
+        )
+    }
+
+    #[expect(clippy::too_many_lines)]
+    pub fn build_composition_script_with_stream(
+        route_match: &AppRouteMatch,
+        context: &LayoutRenderContext,
+        loading_component_id: Option<&str>,
+        use_suspense: bool,
+        defer_rsc: bool,
+        capture_stream_id: Option<&str>,
     ) -> Result<String, RariError> {
         let page_props = utils::create_page_props(route_match, context).map_err(|e| {
             tracing::error!(
@@ -1305,6 +1349,7 @@ impl LayoutRenderer {
             &metadata_json,
             defer_rsc,
             &action_post_url_json,
+            capture_stream_id,
         );
 
         Ok(script)

--- a/crates/rari/src/rendering/layout/js/html_boundaries.ts
+++ b/crates/rari/src/rendering/layout/js/html_boundaries.ts
@@ -1,0 +1,104 @@
+// eslint-disable-next-line unused-imports/no-unused-vars
+function rariCreateHtmlBoundaryTracker() {
+  let htmlState = 'outside'
+  let pendingTagText = ''
+  let pendingClosePrefix = ''
+  let pendingRawTextClose = ''
+
+  function reset() {
+    htmlState = 'outside'
+    pendingTagText = ''
+    pendingClosePrefix = ''
+    pendingRawTextClose = ''
+  }
+
+  function safeToInjectFlight() {
+    return htmlState === 'outside'
+  }
+
+  function trackHtmlBoundaries(text: string) {
+    let work = text
+    if (htmlState === 'in_tag' && pendingTagText) {
+      work = pendingTagText + text
+      pendingTagText = ''
+    }
+    else if (
+      (htmlState === 'in_inline_script' || htmlState === 'in_raw_text')
+      && pendingClosePrefix
+    ) {
+      work = pendingClosePrefix + text
+      pendingClosePrefix = ''
+    }
+
+    let i = 0
+    const lower = work.toLowerCase()
+
+    while (i < work.length) {
+      switch (htmlState) {
+        case 'outside': {
+          const openAt = lower.indexOf('<', i)
+          if (openAt === -1)
+            return true
+          htmlState = 'in_tag'
+          i = openAt
+          break
+        }
+        case 'in_tag': {
+          const closeAt = work.indexOf('>', i)
+          if (closeAt === -1) {
+            pendingTagText = work.slice(i)
+            return false
+          }
+          const openTag = work.slice(i, closeAt + 1)
+          pendingTagText = ''
+          const rawTextTag = /^<(style|title|textarea|xmp)\b/i.exec(openTag)
+          if (rawTextTag) {
+            htmlState = 'in_raw_text'
+            pendingRawTextClose = `</${rawTextTag[1].toLowerCase()}>`
+          }
+          else {
+            const isInlineScript = /^<script/i.test(openTag) && !/\bsrc\s*=/.test(openTag)
+            htmlState = isInlineScript ? 'in_inline_script' : 'outside'
+          }
+          i = closeAt + 1
+          break
+        }
+        case 'in_raw_text': {
+          const closeTag = pendingRawTextClose
+          const closeAt = lower.indexOf(closeTag, i)
+          if (closeAt === -1) {
+            const maxKeep = Math.max(closeTag.length - 1, 0)
+            pendingClosePrefix = work.slice(Math.max(i, work.length - maxKeep))
+            return false
+          }
+          htmlState = 'outside'
+          pendingRawTextClose = ''
+          pendingClosePrefix = ''
+          i = closeAt + closeTag.length
+          break
+        }
+        case 'in_inline_script': {
+          const closeAt = lower.indexOf('</script>', i)
+          if (closeAt === -1) {
+            const maxKeep = '</script>'.length - 1
+            pendingClosePrefix = work.slice(Math.max(i, work.length - maxKeep))
+            return false
+          }
+          htmlState = 'outside'
+          pendingClosePrefix = ''
+          i = closeAt + 9
+          break
+        }
+      }
+    }
+
+    return safeToInjectFlight()
+  }
+
+  return {
+    reset,
+    safeToInjectFlight,
+    trackHtmlBoundaries,
+    getState: () => htmlState,
+  }
+}

--- a/crates/rari/src/rendering/layout/js/streaming_fizz.ts
+++ b/crates/rari/src/rendering/layout/js/streaming_fizz.ts
@@ -398,11 +398,29 @@ declare function rariCreateHtmlBoundaryTracker(): {
     return createElement(RariStreamingApp, null)
   }
 
+  function rariFormatCaughtErrorHtml(caughtErrors: unknown[]): string {
+    if (caughtErrors.length === 0)
+      return ''
+    const displayError = caughtErrors.find((e) => {
+      if (!e || typeof e !== 'object' || !('message' in e))
+        return false
+      const message = String((e as { message: unknown }).message)
+      return message && !message.includes('omitted in production')
+    }) || caughtErrors[0]
+    const errMsg = String(
+      displayError && typeof displayError === 'object' && 'message' in displayError
+        ? (displayError as { message: unknown }).message
+        : 'Unknown error',
+    ).split('<').join('&lt;')
+    return `<div class=rari-error style=color:red;border:1px_solid_red;padding:10px;border-radius:4px;background-color:#fff5f5><strong>Error loading content: </strong>${errMsg}</div>`
+  }
+
   async function rariPumpLiveMux(
     session: RariFizzSession,
     fizzStream: ReadableStream & { allReady?: Promise<void> },
     liveFlight: ReturnType<typeof rariCreateLiveFlightSource>,
     ensureSourceComplete?: () => Promise<void>,
+    caughtErrors?: unknown[],
   ) {
     const reader = fizzStream.getReader()
     const decoder = new TextDecoder()
@@ -419,6 +437,14 @@ declare function rariCreateHtmlBoundaryTracker(): {
         return ''
       flightBootstrapped = true
       return rariFormatFlightScriptPush(0)
+    }
+
+    const takeErrorHtml = (): string => {
+      if (!caughtErrors || caughtErrors.length === 0)
+        return ''
+      const html = rariFormatCaughtErrorHtml(caughtErrors)
+      caughtErrors.length = 0
+      return html
     }
 
     const collectPendingFlight = (): string => {
@@ -500,7 +526,7 @@ declare function rariCreateHtmlBoundaryTracker(): {
       const flight = takeFlightBootstrap() + await liveFlight.collectAllRemainingText()
       if (before)
         session.trackHtmlBoundaries(before)
-      const combined = before + flight + takeCompleteScript() + after
+      const combined = before + flight + takeErrorHtml() + takeCompleteScript() + after
       if (!combined)
         return true
 
@@ -554,7 +580,7 @@ declare function rariCreateHtmlBoundaryTracker(): {
           await ensureSourceComplete()
         const flight = takeFlightBootstrap() + await liveFlight.collectAllRemainingText()
         const complete = takeCompleteScript()
-        const tail = flight + complete
+        const tail = takeErrorHtml() + flight + complete
         if (tail) {
           const status = Deno.core.ops.op_fizz_chunk_try(session.streamId, tail)
           if (status === 2) {
@@ -588,20 +614,10 @@ declare function rariCreateHtmlBoundaryTracker(): {
   }
 
   async function injectStreamError(caughtErrors: unknown[], streamId: string) {
-    if (caughtErrors.length === 0)
+    const errorHtml = rariFormatCaughtErrorHtml(caughtErrors)
+    if (!errorHtml)
       return
-    const displayError = caughtErrors.find((e) => {
-      if (!e || typeof e !== 'object' || !('message' in e))
-        return false
-      const message = String((e as { message: unknown }).message)
-      return message && !message.includes('omitted in production')
-    }) || caughtErrors[0]
-    const errMsg = String(
-      displayError && typeof displayError === 'object' && 'message' in displayError
-        ? (displayError as { message: unknown }).message
-        : 'Unknown error',
-    ).split('<').join('&lt;')
-    const errorHtml = `<div class=rari-error style=color:red;border:1px_solid_red;padding:10px;border-radius:4px;background-color:#fff5f5><strong>Error loading content: </strong>${errMsg}</div>`
+    caughtErrors.length = 0
     const session = rariCreateFizzSession(streamId)
     await session.pumpFizzChunk(errorHtml)
   }
@@ -674,7 +690,7 @@ declare function rariCreateHtmlBoundaryTracker(): {
     }) as ReadableStream & { allReady?: Promise<void> }
     rariStreamLog('fizz.stream.ready')
 
-    await rariPumpLiveMux(session, fizzStream, liveFlight, ensureSourceComplete)
+    await rariPumpLiveMux(session, fizzStream, liveFlight, ensureSourceComplete, caughtErrors)
     rariStreamLog('render.done')
   }
 

--- a/crates/rari/src/rendering/layout/js/streaming_fizz.ts
+++ b/crates/rari/src/rendering/layout/js/streaming_fizz.ts
@@ -1,5 +1,12 @@
 /// <reference path="../../types.d.ts" />
 
+declare function rariCreateHtmlBoundaryTracker(): {
+  reset: () => void
+  safeToInjectFlight: () => boolean
+  trackHtmlBoundaries: (text: string) => boolean
+  getState: () => string
+}
+
 ;(() => {
   if (typeof g['~rari']?.renderStreamingDocument === 'function')
     return
@@ -65,87 +72,25 @@
   interface RariFizzSession {
     streamId: string
     disconnected: boolean
-    htmlState: RariHtmlStreamState
-    pendingTagStart: number
-    pendingRawTextClose: string
     resetHtmlState: () => void
     safeToInjectFlight: () => boolean
     trackHtmlBoundaries: (text: string) => boolean
     pumpFizzChunk: (text: string) => Promise<boolean>
   }
 
-  type RariHtmlStreamState = 'outside' | 'in_tag' | 'in_inline_script' | 'in_raw_text'
-
   function rariCreateFizzSession(streamId: string): RariFizzSession {
+    const boundaries = rariCreateHtmlBoundaryTracker()
     const session: RariFizzSession = {
       streamId,
       disconnected: false,
-      htmlState: 'outside',
-      pendingTagStart: -1,
-      pendingRawTextClose: '',
       resetHtmlState() {
-        session.htmlState = 'outside'
-        session.pendingTagStart = -1
-        session.pendingRawTextClose = ''
+        boundaries.reset()
       },
       safeToInjectFlight() {
-        return session.htmlState === 'outside'
+        return boundaries.safeToInjectFlight()
       },
       trackHtmlBoundaries(text: string) {
-        let i = 0
-        const lower = text.toLowerCase()
-
-        while (i < text.length) {
-          switch (session.htmlState) {
-            case 'outside': {
-              const openAt = lower.indexOf('<', i)
-              if (openAt === -1)
-                return true
-              session.htmlState = 'in_tag'
-              session.pendingTagStart = openAt
-              i = openAt + 1
-              break
-            }
-            case 'in_tag': {
-              const closeAt = text.indexOf('>', i)
-              if (closeAt === -1)
-                return false
-              const openTag = text.slice(session.pendingTagStart, closeAt + 1)
-              const rawTextTag = /^<(style|title|textarea|xmp)\b/i.exec(openTag)
-              if (rawTextTag) {
-                session.htmlState = 'in_raw_text'
-                session.pendingRawTextClose = `</${rawTextTag[1]!.toLowerCase()}>`
-              }
-              else {
-                const isInlineScript = /^<script/i.test(openTag) && !/\bsrc\s*=/.test(openTag)
-                session.htmlState = isInlineScript ? 'in_inline_script' : 'outside'
-              }
-              session.pendingTagStart = -1
-              i = closeAt + 1
-              break
-            }
-            case 'in_raw_text': {
-              const closeTag = session.pendingRawTextClose
-              const closeAt = lower.indexOf(closeTag, i)
-              if (closeAt === -1)
-                return false
-              session.htmlState = 'outside'
-              session.pendingRawTextClose = ''
-              i = closeAt + closeTag.length
-              break
-            }
-            case 'in_inline_script': {
-              const closeAt = lower.indexOf('</script>', i)
-              if (closeAt === -1)
-                return false
-              session.htmlState = 'outside'
-              i = closeAt + 9
-              break
-            }
-          }
-        }
-
-        return session.safeToInjectFlight()
+        return boundaries.trackHtmlBoundaries(text)
       },
       async pumpFizzChunk(text: string) {
         if (!text || session.disconnected)

--- a/crates/rari/src/rendering/layout/js/streaming_fizz.ts
+++ b/crates/rari/src/rendering/layout/js/streaming_fizz.ts
@@ -1,789 +1,875 @@
 /// <reference path="../../types.d.ts" />
 
-const flightStreamPromises = new WeakMap<ReadableStream, Promise<unknown>>()
-
-function rariFlightRenderOptions(onError: (error: unknown) => void) {
-  return {
-    formState: g['~rari']?.actionFormState ?? undefined,
-    onError,
-  }
-}
-
-function rariStreamLog(phase: string, detail?: string) {
-  const message = detail ? `[streaming] ${phase}: ${detail}` : `[streaming] ${phase}`
-  try {
-    Deno.core.ops.op_internal_log(message)
-  }
-  catch {
-    console.error(message)
-  }
-}
-
-function rariAtLeastOneTask(): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, 0))
-}
-
-function rariStripLeadingDoctype(text: string): string {
-  const match = /^\s*<!doctype[^>]*>/i.exec(text)
-  if (!match)
-    return text
-
-  return text.slice(match[0].length)
-}
-
-async function rariReadStream(stream: ReadableStream): Promise<string> {
-  const reader = stream.getReader()
-  const decoder = new TextDecoder()
-  let html = ''
-
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done)
-      break
-    html += decoder.decode(value, { stream: true })
-  }
-
-  html += decoder.decode()
-  return html
-}
-
-let rariStreamDisconnected = false
-
-type RariHtmlStreamState = 'outside' | 'in_tag' | 'in_inline_script' | 'in_raw_text'
-
-let rariHtmlStreamState: RariHtmlStreamState = 'outside'
-let rariPendingTagStart = -1
-let rariPendingRawTextClose = ''
-
-function rariResetHtmlStreamState() {
-  rariHtmlStreamState = 'outside'
-  rariPendingTagStart = -1
-  rariPendingRawTextClose = ''
-}
-
-function rariSafeToInjectFlight(): boolean {
-  return rariHtmlStreamState === 'outside'
-}
-
-function rariTrackHtmlStreamBoundaries(text: string): boolean {
-  let i = 0
-  const lower = text.toLowerCase()
-
-  while (i < text.length) {
-    switch (rariHtmlStreamState) {
-      case 'outside': {
-        const openAt = lower.indexOf('<', i)
-        if (openAt === -1)
-          return true
-        rariHtmlStreamState = 'in_tag'
-        rariPendingTagStart = openAt
-        i = openAt + 1
-        break
-      }
-      case 'in_tag': {
-        const closeAt = text.indexOf('>', i)
-        if (closeAt === -1)
-          return false
-        const openTag = text.slice(rariPendingTagStart, closeAt + 1)
-        const rawTextTag = /^<(style|title|textarea|xmp)\b/i.exec(openTag)
-        if (rawTextTag) {
-          rariHtmlStreamState = 'in_raw_text'
-          rariPendingRawTextClose = `</${rawTextTag[1]!.toLowerCase()}>`
-        }
-        else {
-          const isInlineScript = /^<script/i.test(openTag) && !/\bsrc\s*=/.test(openTag)
-          rariHtmlStreamState = isInlineScript ? 'in_inline_script' : 'outside'
-        }
-        rariPendingTagStart = -1
-        i = closeAt + 1
-        break
-      }
-      case 'in_raw_text': {
-        const closeTag = rariPendingRawTextClose
-        const closeAt = lower.indexOf(closeTag, i)
-        if (closeAt === -1)
-          return false
-        rariHtmlStreamState = 'outside'
-        rariPendingRawTextClose = ''
-        i = closeAt + closeTag.length
-        break
-      }
-      case 'in_inline_script': {
-        const closeAt = lower.indexOf('</script>', i)
-        if (closeAt === -1)
-          return false
-        rariHtmlStreamState = 'outside'
-        i = closeAt + 9
-        break
-      }
-    }
-  }
-
-  return rariSafeToInjectFlight()
-}
-
-async function rariPumpFizzChunk(text: string): Promise<boolean> {
-  if (!text || rariStreamDisconnected)
-    return false
-  try {
-    await Deno.core.ops.op_fizz_chunk(text)
-    return true
-  }
-  catch (e: unknown) {
-    const message = e && typeof e === 'object' && 'message' in e
-      ? String((e as { message: unknown }).message)
-      : String(e)
-    if (message.includes('disconnected')) {
-      rariStreamDisconnected = true
-      return false
-    }
-    throw e
-  }
-}
-
-function rariFormatFlightScriptPush(payload: string | number): string {
-  const escaped = JSON.stringify(payload).split('</').join('<\\/')
-  return `<script>(self.__rari_f=self.__rari_f||[]).push(${escaped})<\/script>`
-}
-
-function rariFormatFlightBinaryPush(b64: string): string {
-  const payload = JSON.stringify([2, b64]).split('</').join('<\\/')
-  return `<script>(self.__rari_f=self.__rari_f||[]).push(${payload})<\/script>`
-}
-
-async function rariPumpFlightScriptPush(payload: string | number): Promise<boolean> {
-  return await rariPumpFizzChunk(rariFormatFlightScriptPush(payload))
-}
-
-async function rariPumpFlightBinaryPush(b64: string): Promise<boolean> {
-  return await rariPumpFizzChunk(rariFormatFlightBinaryPush(b64))
-}
-
-function rariParseFlightRowId(line: string): number {
-  const trimmed = line.trim()
-  const colon = trimmed.indexOf(':')
-  if (colon === -1)
-    return Number.MAX_SAFE_INTEGER
-  const parsed = Number.parseInt(trimmed.slice(0, colon), 16)
-  return Number.isNaN(parsed) ? Number.MAX_SAFE_INTEGER : parsed
-}
-
-function rariFlightBytesToB64(bytes: Uint8Array): string {
-  let b64 = ''
-  for (let i = 0; i < bytes.length; i++)
-    b64 += String.fromCharCode(bytes[i]!)
-
-  return btoa(b64)
-}
-
-function rariFlightEmbedLooksText(lines: string[]): boolean {
-  if (lines.length === 0)
-    return false
-
-  return lines.some(line => /^[0-9a-f]+:/i.test(line.trim()))
-}
-
-function rariEnsureFlightRow0(buffer: Map<number, string>) {
-  if (buffer.has(0))
+;(() => {
+  if (typeof g['~rari']?.renderStreamingDocument === 'function')
     return
-  let maxId = 0
-  for (const id of buffer.keys()) {
-    if (id !== Number.MAX_SAFE_INTEGER && id > maxId)
-      maxId = id
-  }
-  if (maxId > 0)
-    buffer.set(0, `0:"$${maxId.toString(16)}"`)
-}
 
-function rariCreateLiveFlightSource() {
-  const buffer = new Map<number, string>()
-  let nextExpectedId = 0
-  let complete = false
-  let binaryB64: string | null = null
-  const waiters: Array<() => void> = []
-  let pendingText = ''
-  const rawChunks: Uint8Array[] = []
-  const textDecoder = new TextDecoder()
-  let totalBytes = 0
-  let chunksConsumed = 0
+  const flightStreamPromises = new WeakMap<ReadableStream, Promise<unknown>>()
 
-  const notifyWaiters = () => {
-    const pending = waiters.splice(0)
-    for (const resolve of pending)
-      resolve()
-  }
-
-  const insertRow = (line: string) => {
-    const id = rariParseFlightRowId(line)
-    buffer.set(id, line.trim())
-    notifyWaiters()
-  }
-
-  const takeNextReady = () => {
-    if (buffer.has(nextExpectedId)) {
-      const line = buffer.get(nextExpectedId)!
-      buffer.delete(nextExpectedId)
-      nextExpectedId++
-      return { type: 'line' as const, line }
+  function rariFlightRenderOptions(onError: (error: unknown) => void) {
+    return {
+      formState: g['~rari']?.actionFormState ?? undefined,
+      onError,
     }
-    if (binaryB64 && complete && buffer.size === 0) {
-      const b64 = binaryB64
-      binaryB64 = null
-      return { type: 'binary' as const, b64 }
-    }
-    if (complete && buffer.size > 0) {
-      const ids = [...buffer.keys()].sort((a, b) => a - b)
-      nextExpectedId = ids[0]!
-      return takeNextReady()
-    }
-
-    return null
   }
 
-  const flushPendingText = () => {
-    const tailLines = pendingText.split('\n').map(line => line.trim()).filter(Boolean)
-    pendingText = ''
-    if (tailLines.length > 0 && rariFlightEmbedLooksText(tailLines)) {
-      for (const line of tailLines)
-        insertRow(line)
-
+  function rariStreamLog(phase: string, detail?: string) {
+  // Hot-path logging adds Deno-op cost under concurrent streams; keep off by default.
+    if (!(g as { RARI_STREAM_DEBUG?: boolean }).RARI_STREAM_DEBUG)
       return
+    const message = detail ? `[streaming] ${phase}: ${detail}` : `[streaming] ${phase}`
+    try {
+      Deno.core.ops.op_internal_log(message)
     }
-    if (totalBytes > 0) {
-      const out = new Uint8Array(totalBytes)
-      let offset = 0
-      for (const chunk of rawChunks) {
-        out.set(chunk, offset)
-        offset += chunk.byteLength
-      }
-      binaryB64 = rariFlightBytesToB64(out)
+    catch {
+      console.error(message)
     }
   }
 
-  return {
-    consumeChunk(value: Uint8Array) {
-      chunksConsumed++
-      rawChunks.push(value)
-      totalBytes += value.byteLength
-      pendingText += textDecoder.decode(value, { stream: true })
-      let newline = pendingText.indexOf('\n')
-      while (newline !== -1) {
-        const line = pendingText.slice(0, newline)
-        pendingText = pendingText.slice(newline + 1)
-        if (line.trim())
-          insertRow(line)
-        newline = pendingText.indexOf('\n')
-      }
-    },
+  const RARI_STREAMING_COMPLETE_SCRIPT
+    = '<script>if(!window[\'~rari\'])window[\'~rari\']={};window[\'~rari\'].streaming={complete:true}<\/script>'
 
-    markStreamEnd() {
-      if (complete)
-        return
-      pendingText += textDecoder.decode()
-      flushPendingText()
-      // Only synthesize row 0 if it was never received/pumped.
-      if (nextExpectedId === 0)
-        rariEnsureFlightRow0(buffer)
-      complete = true
-      rariStreamLog('liveFlight.end', `chunks=${chunksConsumed} rows=${nextExpectedId} binary=${binaryB64 != null}`)
-      notifyWaiters()
-    },
-
-    tryDrainNext() {
-      return takeNextReady()
-    },
-
-    async drainNext() {
-      while (true) {
-        const item = takeNextReady()
-        if (item)
-          return item
-        if (complete)
-          return null
-        await new Promise<void>(resolve => waiters.push(resolve))
-      }
-    },
-
-    async drainAllRemaining() {
-      while (true) {
-        const item = await this.drainNext()
-        if (!item)
-          break
-        if (item.type === 'line') {
-          if (!(await rariPumpFlightScriptPush(`${item.line}\n`)))
-            return false
-        }
-        else if (item.type === 'binary') {
-          if (!(await rariPumpFlightBinaryPush(item.b64)))
-            return false
-        }
-      }
-
-      return true
-    },
-  }
-}
-
-function rariCreatePullFlightFanout(sourceStream: ReadableStream) {
-  const sourceReader = sourceStream.getReader()
-  const liveFlight = rariCreateLiveFlightSource()
-  let pullCount = 0
-  let sourceDone = false
-
-  const flightReadable = new ReadableStream({
-    async pull(controller) {
-      pullCount++
-      rariStreamLog('fanout.pull', `n=${pullCount}`)
-      const { done, value } = await sourceReader.read()
-      if (done) {
-        sourceDone = true
-        liveFlight.markStreamEnd()
-        controller.close()
-        rariStreamLog('fanout.sourceDone', `pulls=${pullCount}`)
-        return
-      }
-      liveFlight.consumeChunk(value)
-      controller.enqueue(value)
-      rariStreamLog('fanout.chunk', `bytes=${value.byteLength}`)
-    },
-    cancel(reason) {
-      rariStreamLog('fanout.cancel', String(reason))
-      sourceReader.cancel(reason)
-      if (!sourceDone) {
-        sourceDone = true
-        liveFlight.markStreamEnd()
-      }
-    },
-  })
-
-  async function ensureSourceComplete() {
-    if (sourceDone)
-      return
-    while (true) {
-      const { done, value } = await sourceReader.read()
-      if (done) {
-        sourceDone = true
-        liveFlight.markStreamEnd()
-        rariStreamLog('fanout.sourceDone', `pulls=${pullCount} drained=true`)
-        return
-      }
-      pullCount++
-      liveFlight.consumeChunk(value)
-      rariStreamLog('fanout.chunk', `bytes=${value.byteLength} drained=true`)
-    }
-  }
-
-  return {
-    flightReadable,
-    liveFlight,
-    ensureSourceComplete,
-    get sourceDone() {
-      return sourceDone
-    },
-  }
-}
-
-function rariGetFlightStream(stream: ReadableStream): Promise<unknown> {
-  const cached = flightStreamPromises.get(stream)
-  if (cached)
-    return cached
-
-  const FlightClient = g['~flightClient']
-  if (!FlightClient?.createFromReadableStream)
-    throw new Error('[rari] Flight client not loaded for streaming')
-
-  rariStreamLog('flight.createFromReadableStream.start')
-  // createFromReadableStream returns a ReactPromise (custom thenable), not a
-  // native Promise — do not chain .then/.catch directly or .catch throws.
-  const ssrModules = g['~rari']?.ssrModules || {}
-  const flightPromise = FlightClient.createFromReadableStream(stream, {
-    ssrManifest: {
-      moduleMap: ssrModules,
-      moduleLoading: null,
-    },
-  })
-
-  Promise.resolve(flightPromise).then(
-    (result: unknown) => {
-      rariStreamLog('flight.createFromReadableStream.done', String(result == null ? 'null' : typeof result))
-    },
-    (error: unknown) => {
-      rariStreamLog('flight.createFromReadableStream.error', String(error))
-    },
-  )
-
-  flightStreamPromises.set(stream, flightPromise)
-  return flightPromise
-}
-
-function rariCreateStreamingRoot(flightStream: ReadableStream): unknown {
-  const react = g.React
-  if (!react?.createElement || !react.use)
-    throw new Error('[rari] React.use not available for streaming App')
-
-  const { createElement, use } = react
-
-  function RariStreamingApp() {
-    const payload = use(rariGetFlightStream(flightStream))
-    return payload
-  }
-
-  return createElement(RariStreamingApp, null)
-}
-
-async function rariPumpLiveMux(
-  fizzStream: ReadableStream & { allReady?: Promise<void> },
-  liveFlight: ReturnType<typeof rariCreateLiveFlightSource>,
-) {
-  const reader = fizzStream.getReader()
-  const decoder = new TextDecoder()
-  const allReady = fizzStream.allReady
-  let htmlChunkCount = 0
-  let flightPumpCount = 0
-  let htmlStreamFinished = false
-  let flightBootstrapped = false
-  let strippedDoctype = false
-
-  const ensureFlightBootstrap = async (): Promise<boolean> => {
-    if (flightBootstrapped)
-      return true
-    flightBootstrapped = true
-    return await rariPumpFlightScriptPush(0)
-  }
-
-  const prepareFizzChunk = (text: string): string => {
-    let chunk = text
-    if (!strippedDoctype) {
-      strippedDoctype = true
-      chunk = rariStripLeadingDoctype(chunk)
-    }
-
-    return chunk
-  }
-
-  const pumpPendingFlight = async (): Promise<boolean> => {
-    while (rariSafeToInjectFlight()) {
-      await rariAtLeastOneTask()
-      const item = liveFlight.tryDrainNext()
-      if (!item)
-        return true
-      flightPumpCount++
-      rariStreamLog('mux.flightRow', `n=${flightPumpCount}`)
-      if (item.type === 'line') {
-        if (!(await rariPumpFlightScriptPush(`${item.line}\n`)))
-          return false
-      }
-      else if (item.type === 'binary') {
-        if (!(await rariPumpFlightBinaryPush(item.b64)))
-          return false
-      }
-    }
-
-    return true
-  }
-
-  const pumpFizzText = async (text: string) => {
-    if (!text || rariStreamDisconnected)
-      return true
-
-    const chunk = prepareFizzChunk(text)
-    if (!chunk)
-      return true
-
-    const bodyClose = chunk.indexOf('</body>')
-    if (bodyClose === -1) {
-      if (!(await rariPumpFizzChunk(chunk)))
-        return false
-      rariTrackHtmlStreamBoundaries(chunk)
-      return true
-    }
-
-    const before = chunk.slice(0, bodyClose)
-    const after = chunk.slice(bodyClose)
-    if (before) {
-      if (!(await rariPumpFizzChunk(before)))
-        return false
-      rariTrackHtmlStreamBoundaries(before)
-    }
-    if (!(await ensureFlightBootstrap()))
-      return false
-    if (!(await liveFlight.drainAllRemaining()))
-      return false
-
-    return await rariPumpFizzChunk(after)
-  }
-
-  const pumpFizzLoop = async () => {
-    rariStreamLog('mux.fizzLoop.start')
-    while (true) {
-      const { done, value } = await reader.read()
-      if (done) {
-        htmlStreamFinished = true
-        const tail = decoder.decode()
-        if (tail) {
-          if (!(await pumpFizzText(tail)))
-            return
-          if (rariSafeToInjectFlight()) {
-            if (!(await ensureFlightBootstrap()))
-              return
-            if (!(await pumpPendingFlight()))
-              return
-          }
-        }
-        rariStreamLog('mux.fizzLoop.done', `htmlChunks=${htmlChunkCount}`)
-        break
-      }
-      htmlChunkCount++
-      const chunkText = decoder.decode(value, { stream: true })
-      rariStreamLog('mux.htmlChunk', `n=${htmlChunkCount} bytes=${value.byteLength}`)
-      if (!(await pumpFizzText(chunkText)))
-        return
-      if (rariSafeToInjectFlight()) {
-        if (!(await ensureFlightBootstrap()))
-          return
-        if (!(await pumpPendingFlight()))
-          return
-      }
-    }
-    if (htmlStreamFinished) {
-      rariStreamLog('mux.drainRemaining.start')
-      if (!rariSafeToInjectFlight())
-        rariResetHtmlStreamState()
-      if (!(await ensureFlightBootstrap()))
-        return
-      await liveFlight.drainAllRemaining()
-      rariStreamLog('mux.drainRemaining.done')
-    }
-  }
-
-  const allReadyTask = allReady != null
-    ? Promise.resolve(allReady).then(() => {
-        rariStreamLog('mux.allReady.resolved')
-      })
-    : Promise.resolve()
-
-  await Promise.all([
-    pumpFizzLoop(),
-    allReadyTask,
-  ])
-  rariStreamLog('mux.complete', `htmlChunks=${htmlChunkCount} flightRows=${flightPumpCount}`)
-}
-
-async function pumpStreamingCompleteScript() {
-  await rariPumpFizzChunk(
-    '<script>if(!window[\'~rari\'])window[\'~rari\']={};window[\'~rari\'].streaming={complete:true}<\/script>',
-  )
-}
-
-async function injectStreamError(caughtErrors: unknown[]) {
-  if (caughtErrors.length === 0)
-    return
-  const displayError = caughtErrors.find((e) => {
-    if (!e || typeof e !== 'object' || !('message' in e))
-      return false
-    const message = String((e as { message: unknown }).message)
-    return message && !message.includes('omitted in production')
-  }) || caughtErrors[0]
-  const errMsg = String(
-    displayError && typeof displayError === 'object' && 'message' in displayError
-      ? (displayError as { message: unknown }).message
-      : 'Unknown error',
-  ).split('<').join('&lt;')
-  const errorHtml = `<div class=rari-error style=color:red;border:1px_solid_red;padding:10px;border-radius:4px;background-color:#fff5f5><strong>Error loading content: </strong>${errMsg}</div>`
-  await rariPumpFizzChunk(errorHtml)
-}
-
-interface RenderStreamingDocumentOptions {
-  capturedElement: unknown
-  headContent: string
-  caughtErrors: unknown[]
-}
-
-async function renderStreamingDocument(options: RenderStreamingDocumentOptions) {
-  const { capturedElement, headContent, caughtErrors } = options
-
-  const ReactServerRenderer = g['~reactServerRenderer']
-  const ReactDOMServer = g['~reactServer']
-  const R = g.React
-
-  if (!ReactServerRenderer?.renderToReadableStream)
-    throw new Error('[rari] RSC renderer not loaded')
-  if (!ReactDOMServer?.renderToReadableStream)
-    throw new Error('[rari] Fizz renderer not loaded')
-  if (!R?.createElement)
-    throw new Error('[rari] React not loaded')
-
-  rariStreamDisconnected = false
-  rariResetHtmlStreamState()
-  rariStreamLog('render.start')
-
-  const bundlerConfig = g['~rari']?.clientReferenceManifest || {}
-
-  const rscStream = await ReactServerRenderer.renderToReadableStream(
-    capturedElement,
-    bundlerConfig,
-    rariFlightRenderOptions((error: unknown) => {
-      console.error('[rari] RSC error:', error)
-      caughtErrors.push(error)
-    }),
-  )
-  rariStreamLog('rsc.stream.ready')
-
-  const { flightReadable, liveFlight } = rariCreatePullFlightFanout(rscStream)
-
-  const fullDoc = R.createElement(
-    'html',
-    { lang: 'en' },
-    R.createElement('head', { dangerouslySetInnerHTML: { __html: headContent } }),
-    R.createElement(
-      'body',
-      null,
-      R.createElement('div', { id: 'root' }, rariCreateStreamingRoot(flightReadable)),
-    ),
-  )
-
-  rariStreamLog('fizz.render.start')
-  const fizzStream = await ReactDOMServer.renderToReadableStream(fullDoc, {
-    onError(error: unknown) {
-      console.error('[rari] Fizz streaming error:', error)
-      caughtErrors.push(error)
-    },
-  }) as ReadableStream & { allReady?: Promise<void> }
-  rariStreamLog('fizz.stream.ready')
-
-  await rariPumpLiveMux(fizzStream, liveFlight)
-  rariStreamLog('render.done')
-}
-
-async function rariCollectFlightEmbedScripts(
-  liveFlight: ReturnType<typeof rariCreateLiveFlightSource>,
-): Promise<string> {
-  let scripts = rariFormatFlightScriptPush(0)
-  while (true) {
-    const item = await liveFlight.drainNext()
-    if (!item)
-      break
+  function rariFormatFlightItem(
+    item: { type: 'line', line: string } | { type: 'binary', b64: string },
+  ): string {
     if (item.type === 'line')
-      scripts += rariFormatFlightScriptPush(`${item.line}\n`)
-    else if (item.type === 'binary')
-      scripts += rariFormatFlightBinaryPush(item.b64)
+      return rariFormatFlightScriptPush(`${item.line}\n`)
+
+    return rariFormatFlightBinaryPush(item.b64)
   }
 
-  return scripts
-}
+  function rariStripLeadingDoctype(text: string): string {
+    const match = /^\s*<!doctype[^>]*>/i.exec(text)
+    if (!match)
+      return text
 
-function rariInjectBeforeBodyClose(html: string, injection: string): string {
-  const bodyClose = html.lastIndexOf('</body>')
-  if (bodyClose === -1)
-    return `${html}${injection}`
+    return text.slice(match[0].length)
+  }
 
-  return `${html.slice(0, bodyClose)}${injection}\n${html.slice(bodyClose)}`
-}
+  async function rariReadStream(stream: ReadableStream): Promise<string> {
+    const reader = stream.getReader()
+    const decoder = new TextDecoder()
+    let html = ''
 
-async function renderStaticDocument(options: RenderStreamingDocumentOptions): Promise<string> {
-  const { capturedElement, headContent, caughtErrors } = options
-
-  const ReactServerRenderer = g['~reactServerRenderer']
-  const ReactDOMServer = g['~reactServer']
-  const R = g.React
-
-  if (!ReactServerRenderer?.renderToReadableStream)
-    throw new Error('[rari] RSC renderer not loaded')
-  if (!ReactDOMServer?.renderToReadableStream)
-    throw new Error('[rari] Fizz renderer not loaded')
-  if (!R?.createElement)
-    throw new Error('[rari] React not loaded')
-
-  const bundlerConfig = g['~rari']?.clientReferenceManifest || {}
-
-  const rscStream = await ReactServerRenderer.renderToReadableStream(
-    capturedElement,
-    bundlerConfig,
-    rariFlightRenderOptions((error: unknown) => {
-      console.error('[rari] RSC error:', error)
-      caughtErrors.push(error)
-    }),
-  )
-
-  const { flightReadable, liveFlight, ensureSourceComplete } = rariCreatePullFlightFanout(rscStream)
-
-  const fullDoc = R.createElement(
-    'html',
-    { lang: 'en' },
-    R.createElement('head', { dangerouslySetInnerHTML: { __html: headContent } }),
-    R.createElement(
-      'body',
-      null,
-      R.createElement('div', { id: 'root' }, rariCreateStreamingRoot(flightReadable)),
-    ),
-  )
-
-  const fizzStream = await ReactDOMServer.renderToReadableStream(fullDoc, {
-    onError(error: unknown) {
-      console.error('[rari] Fizz static error:', error)
-      caughtErrors.push(error)
-    },
-  }) as ReadableStream & { allReady?: Promise<void> }
-
-  await fizzStream.allReady
-  await ensureSourceComplete()
-
-  let html = await rariReadStream(fizzStream)
-  html = rariStripLeadingDoctype(html)
-  if (!html.trimStart().toLowerCase().startsWith('<!doctype'))
-    html = `<!DOCTYPE html>\n${html}`
-
-  const flightScripts = await rariCollectFlightEmbedScripts(liveFlight)
-  const completionScript = `<script>if(!window['~rari'])window['~rari']={};window['~rari'].streaming={complete:true}<\/script>`
-
-  return rariInjectBeforeBodyClose(html, `${flightScripts}\n${completionScript}`)
-}
-
-async function pumpRscElementStream(
-  element: unknown,
-  pumpChunk: (text: string) => Promise<boolean>,
-): Promise<void> {
-  rariStreamDisconnected = false
-
-  const ReactServerRenderer = g['~reactServerRenderer']
-  if (!ReactServerRenderer?.renderToReadableStream)
-    throw new Error('[rari] RSC renderer not loaded')
-
-  const bundlerConfig = g['~rari']?.clientReferenceManifest || {}
-  const stream = await ReactServerRenderer.renderToReadableStream(
-    element,
-    bundlerConfig,
-    rariFlightRenderOptions((error: unknown) => {
-      console.error('[rari] RSC stream error:', error)
-    }),
-  )
-
-  const reader = stream.getReader()
-  const decoder = new TextDecoder()
-  try {
     while (true) {
       const { done, value } = await reader.read()
       if (done)
         break
-      const text = decoder.decode(value, { stream: true })
-      if (!(await pumpChunk(text)))
-        break
+      html += decoder.decode(value, { stream: true })
     }
-    if (!rariStreamDisconnected) {
-      const tail = decoder.decode()
-      await pumpChunk(tail)
-    }
-  }
-  finally {
-    await reader.cancel().catch(() => {})
-  }
-}
 
-if (!g['~rari'])
-  g['~rari'] = {}
-g['~rari'].renderStreamingDocument = renderStreamingDocument
-g['~rari'].renderStaticDocument = renderStaticDocument
-g['~rari'].pumpStreamingCompleteScript = pumpStreamingCompleteScript
-g['~rari'].injectStreamError = injectStreamError
-g['~rari'].pumpFizzChunk = rariPumpFizzChunk
-g['~rari'].pumpRscElementStream = pumpRscElementStream
+    html += decoder.decode()
+    return html
+  }
+
+  interface RariFizzSession {
+    streamId: string
+    disconnected: boolean
+    htmlState: RariHtmlStreamState
+    pendingTagStart: number
+    pendingRawTextClose: string
+    resetHtmlState: () => void
+    safeToInjectFlight: () => boolean
+    trackHtmlBoundaries: (text: string) => boolean
+    pumpFizzChunk: (text: string) => Promise<boolean>
+  }
+
+  type RariHtmlStreamState = 'outside' | 'in_tag' | 'in_inline_script' | 'in_raw_text'
+
+  function rariCreateFizzSession(streamId: string): RariFizzSession {
+    const session: RariFizzSession = {
+      streamId,
+      disconnected: false,
+      htmlState: 'outside',
+      pendingTagStart: -1,
+      pendingRawTextClose: '',
+      resetHtmlState() {
+        session.htmlState = 'outside'
+        session.pendingTagStart = -1
+        session.pendingRawTextClose = ''
+      },
+      safeToInjectFlight() {
+        return session.htmlState === 'outside'
+      },
+      trackHtmlBoundaries(text: string) {
+        let i = 0
+        const lower = text.toLowerCase()
+
+        while (i < text.length) {
+          switch (session.htmlState) {
+            case 'outside': {
+              const openAt = lower.indexOf('<', i)
+              if (openAt === -1)
+                return true
+              session.htmlState = 'in_tag'
+              session.pendingTagStart = openAt
+              i = openAt + 1
+              break
+            }
+            case 'in_tag': {
+              const closeAt = text.indexOf('>', i)
+              if (closeAt === -1)
+                return false
+              const openTag = text.slice(session.pendingTagStart, closeAt + 1)
+              const rawTextTag = /^<(style|title|textarea|xmp)\b/i.exec(openTag)
+              if (rawTextTag) {
+                session.htmlState = 'in_raw_text'
+                session.pendingRawTextClose = `</${rawTextTag[1]!.toLowerCase()}>`
+              }
+              else {
+                const isInlineScript = /^<script/i.test(openTag) && !/\bsrc\s*=/.test(openTag)
+                session.htmlState = isInlineScript ? 'in_inline_script' : 'outside'
+              }
+              session.pendingTagStart = -1
+              i = closeAt + 1
+              break
+            }
+            case 'in_raw_text': {
+              const closeTag = session.pendingRawTextClose
+              const closeAt = lower.indexOf(closeTag, i)
+              if (closeAt === -1)
+                return false
+              session.htmlState = 'outside'
+              session.pendingRawTextClose = ''
+              i = closeAt + closeTag.length
+              break
+            }
+            case 'in_inline_script': {
+              const closeAt = lower.indexOf('</script>', i)
+              if (closeAt === -1)
+                return false
+              session.htmlState = 'outside'
+              i = closeAt + 9
+              break
+            }
+          }
+        }
+
+        return session.safeToInjectFlight()
+      },
+      async pumpFizzChunk(text: string) {
+        if (!text || session.disconnected)
+          return false
+        try {
+        // Prefer sync try-send; only await the async op under channel backpressure.
+          const status = Deno.core.ops.op_fizz_chunk_try(session.streamId, text)
+          if (status === 0)
+            return true
+          if (status === 2) {
+            session.disconnected = true
+            return false
+          }
+          await Deno.core.ops.op_fizz_chunk(session.streamId, text)
+          return true
+        }
+        catch (e: unknown) {
+          const message = e && typeof e === 'object' && 'message' in e
+            ? String((e as { message: unknown }).message)
+            : String(e)
+          if (message.includes('disconnected')) {
+            session.disconnected = true
+            return false
+          }
+          throw e
+        }
+      },
+    }
+    return session
+  }
+
+  function rariFormatFlightScriptPush(payload: string | number): string {
+    const escaped = JSON.stringify(payload).split('</').join('<\\/')
+    return `<script>(self.__rari_f=self.__rari_f||[]).push(${escaped})<\/script>`
+  }
+
+  function rariFormatFlightBinaryPush(b64: string): string {
+    const payload = JSON.stringify([2, b64]).split('</').join('<\\/')
+    return `<script>(self.__rari_f=self.__rari_f||[]).push(${payload})<\/script>`
+  }
+
+  function rariParseFlightRowId(line: string): number {
+    const trimmed = line.trim()
+    const colon = trimmed.indexOf(':')
+    if (colon === -1)
+      return Number.MAX_SAFE_INTEGER
+    const parsed = Number.parseInt(trimmed.slice(0, colon), 16)
+    return Number.isNaN(parsed) ? Number.MAX_SAFE_INTEGER : parsed
+  }
+
+  function rariFlightBytesToB64(bytes: Uint8Array): string {
+    let b64 = ''
+    for (let i = 0; i < bytes.length; i++)
+      b64 += String.fromCharCode(bytes[i]!)
+
+    return btoa(b64)
+  }
+
+  function rariFlightEmbedLooksText(lines: string[]): boolean {
+    if (lines.length === 0)
+      return false
+
+    return lines.some(line => /^[0-9a-f]+:/i.test(line.trim()))
+  }
+
+  function rariEnsureFlightRow0(buffer: Map<number, string>) {
+    if (buffer.has(0))
+      return
+    let maxId = 0
+    for (const id of buffer.keys()) {
+      if (id !== Number.MAX_SAFE_INTEGER && id > maxId)
+        maxId = id
+    }
+    if (maxId > 0)
+      buffer.set(0, `0:"$${maxId.toString(16)}"`)
+  }
+
+  function rariCreateLiveFlightSource() {
+    const buffer = new Map<number, string>()
+    let nextExpectedId = 0
+    let complete = false
+    let binaryB64: string | null = null
+    const waiters: Array<() => void> = []
+    let pendingText = ''
+    const rawChunks: Uint8Array[] = []
+    const textDecoder = new TextDecoder()
+    let totalBytes = 0
+    let chunksConsumed = 0
+
+    const notifyWaiters = () => {
+      const pending = waiters.splice(0)
+      for (const resolve of pending)
+        resolve()
+    }
+
+    const insertRow = (line: string) => {
+      const id = rariParseFlightRowId(line)
+      buffer.set(id, line.trim())
+      notifyWaiters()
+    }
+
+    const takeNextReady = () => {
+      if (buffer.has(nextExpectedId)) {
+        const line = buffer.get(nextExpectedId)!
+        buffer.delete(nextExpectedId)
+        nextExpectedId++
+        return { type: 'line' as const, line }
+      }
+      if (binaryB64 && complete && buffer.size === 0) {
+        const b64 = binaryB64
+        binaryB64 = null
+        return { type: 'binary' as const, b64 }
+      }
+      if (complete && buffer.size > 0) {
+        const ids = [...buffer.keys()].sort((a, b) => a - b)
+        nextExpectedId = ids[0]!
+        return takeNextReady()
+      }
+
+      return null
+    }
+
+    const flushPendingText = () => {
+      const tailLines = pendingText.split('\n').map(line => line.trim()).filter(Boolean)
+      pendingText = ''
+      if (tailLines.length > 0 && rariFlightEmbedLooksText(tailLines)) {
+        for (const line of tailLines)
+          insertRow(line)
+
+        return
+      }
+      if (totalBytes > 0) {
+        const out = new Uint8Array(totalBytes)
+        let offset = 0
+        for (const chunk of rawChunks) {
+          out.set(chunk, offset)
+          offset += chunk.byteLength
+        }
+        binaryB64 = rariFlightBytesToB64(out)
+      }
+    }
+
+    return {
+      consumeChunk(value: Uint8Array) {
+        chunksConsumed++
+        rawChunks.push(value)
+        totalBytes += value.byteLength
+        pendingText += textDecoder.decode(value, { stream: true })
+        let newline = pendingText.indexOf('\n')
+        while (newline !== -1) {
+          const line = pendingText.slice(0, newline)
+          pendingText = pendingText.slice(newline + 1)
+          if (line.trim())
+            insertRow(line)
+          newline = pendingText.indexOf('\n')
+        }
+      },
+
+      markStreamEnd() {
+        if (complete)
+          return
+        pendingText += textDecoder.decode()
+        flushPendingText()
+        // Only synthesize row 0 if it was never received/pumped.
+        if (nextExpectedId === 0)
+          rariEnsureFlightRow0(buffer)
+        complete = true
+        rariStreamLog('liveFlight.end', `chunks=${chunksConsumed} rows=${nextExpectedId} binary=${binaryB64 != null}`)
+        notifyWaiters()
+      },
+
+      tryDrainNext() {
+        return takeNextReady()
+      },
+
+      async drainNext() {
+        while (true) {
+          const item = takeNextReady()
+          if (item)
+            return item
+          if (complete)
+            return null
+          await new Promise<void>(resolve => waiters.push(resolve))
+        }
+      },
+
+      async collectAllRemainingText(): Promise<string> {
+        let buf = ''
+        while (true) {
+          const item = await this.drainNext()
+          if (!item)
+            break
+          buf += rariFormatFlightItem(item)
+        }
+
+        return buf
+      },
+    }
+  }
+
+  function rariCreatePullFlightFanout(sourceStream: ReadableStream) {
+    const sourceReader = sourceStream.getReader()
+    const liveFlight = rariCreateLiveFlightSource()
+    let pullCount = 0
+    let sourceDone = false
+
+    const flightReadable = new ReadableStream({
+      async pull(controller) {
+        pullCount++
+        rariStreamLog('fanout.pull', `n=${pullCount}`)
+        const { done, value } = await sourceReader.read()
+        if (done) {
+          sourceDone = true
+          liveFlight.markStreamEnd()
+          controller.close()
+          rariStreamLog('fanout.sourceDone', `pulls=${pullCount}`)
+          return
+        }
+        liveFlight.consumeChunk(value)
+        controller.enqueue(value)
+        rariStreamLog('fanout.chunk', `bytes=${value.byteLength}`)
+      },
+      cancel(reason) {
+        rariStreamLog('fanout.cancel', String(reason))
+        sourceReader.cancel(reason)
+        if (!sourceDone) {
+          sourceDone = true
+          liveFlight.markStreamEnd()
+        }
+      },
+    })
+
+    async function ensureSourceComplete() {
+      if (sourceDone)
+        return
+      while (true) {
+        const { done, value } = await sourceReader.read()
+        if (done) {
+          sourceDone = true
+          liveFlight.markStreamEnd()
+          rariStreamLog('fanout.sourceDone', `pulls=${pullCount} drained=true`)
+          return
+        }
+        pullCount++
+        liveFlight.consumeChunk(value)
+        rariStreamLog('fanout.chunk', `bytes=${value.byteLength} drained=true`)
+      }
+    }
+
+    return {
+      flightReadable,
+      liveFlight,
+      ensureSourceComplete,
+      get sourceDone() {
+        return sourceDone
+      },
+    }
+  }
+
+  function rariGetFlightStream(stream: ReadableStream): Promise<unknown> {
+    const cached = flightStreamPromises.get(stream)
+    if (cached)
+      return cached
+
+    const FlightClient = g['~flightClient']
+    if (!FlightClient?.createFromReadableStream)
+      throw new Error('[rari] Flight client not loaded for streaming')
+
+    rariStreamLog('flight.createFromReadableStream.start')
+    // createFromReadableStream returns a ReactPromise (custom thenable), not a
+    // native Promise — do not chain .then/.catch directly or .catch throws.
+    const ssrModules = g['~rari']?.ssrModules || {}
+    const flightPromise = FlightClient.createFromReadableStream(stream, {
+      ssrManifest: {
+        moduleMap: ssrModules,
+        moduleLoading: null,
+      },
+    })
+
+    Promise.resolve(flightPromise).then(
+      (result: unknown) => {
+        rariStreamLog('flight.createFromReadableStream.done', String(result == null ? 'null' : typeof result))
+      },
+      (error: unknown) => {
+        rariStreamLog('flight.createFromReadableStream.error', String(error))
+      },
+    )
+
+    flightStreamPromises.set(stream, flightPromise)
+    return flightPromise
+  }
+
+  function rariCreateStreamingRoot(flightStream: ReadableStream): unknown {
+    const react = g.React
+    if (!react?.createElement || !react.use)
+      throw new Error('[rari] React.use not available for streaming App')
+
+    const { createElement, use } = react
+
+    function RariStreamingApp() {
+      const payload = use(rariGetFlightStream(flightStream))
+      return payload
+    }
+
+    return createElement(RariStreamingApp, null)
+  }
+
+  async function rariPumpLiveMux(
+    session: RariFizzSession,
+    fizzStream: ReadableStream & { allReady?: Promise<void> },
+    liveFlight: ReturnType<typeof rariCreateLiveFlightSource>,
+    ensureSourceComplete?: () => Promise<void>,
+  ) {
+    const reader = fizzStream.getReader()
+    const decoder = new TextDecoder()
+    let htmlChunkCount = 0
+    let flightPumpCount = 0
+    let htmlStreamFinished = false
+    let flightBootstrapped = false
+    let strippedDoctype = false
+    let completeScriptSent = false
+    let finalPackageSent = false
+
+    const takeFlightBootstrap = (): string => {
+      if (flightBootstrapped)
+        return ''
+      flightBootstrapped = true
+      return rariFormatFlightScriptPush(0)
+    }
+
+    const collectPendingFlight = (): string => {
+      let out = ''
+      while (session.safeToInjectFlight()) {
+        const item = liveFlight.tryDrainNext()
+        if (!item)
+          break
+        flightPumpCount++
+        out += rariFormatFlightItem(item)
+      }
+
+      return out
+    }
+
+    const prepareFizzChunk = (text: string): string => {
+      let chunk = text
+      if (!strippedDoctype) {
+        strippedDoctype = true
+        chunk = rariStripLeadingDoctype(chunk)
+      }
+
+      return chunk
+    }
+
+    const pumpPendingFlight = async (): Promise<boolean> => {
+      const bootstrap = takeFlightBootstrap()
+      const pending = collectPendingFlight()
+      const combined = bootstrap + pending
+      if (!combined)
+        return true
+
+      return session.pumpFizzChunk(combined)
+    }
+
+    const takeCompleteScript = (): string => {
+      if (completeScriptSent)
+        return ''
+      completeScriptSent = true
+      return RARI_STREAMING_COMPLETE_SCRIPT
+    }
+
+    const markFinalPackageSent = () => {
+      finalPackageSent = true
+      // Drop the mpsc sender in this turn so HTTP endgame coalesce sees
+      // disconnect instead of spinning the full 500µs wait.
+      if (session.disconnected)
+        return
+      try {
+        Deno.core.ops.op_fizz_done(session.streamId)
+      }
+      catch {
+        // Outer script also calls op_fizz_done; ignore double-close.
+      }
+    }
+
+    const pumpFizzText = async (text: string) => {
+      if (!text || session.disconnected)
+        return true
+
+      const chunk = prepareFizzChunk(text)
+      if (!chunk)
+        return true
+
+      const bodyClose = chunk.indexOf('</body>')
+      if (bodyClose === -1) {
+        if (!(await session.pumpFizzChunk(chunk)))
+          return false
+        session.trackHtmlBoundaries(chunk)
+        return true
+      }
+
+      const before = chunk.slice(0, bodyClose)
+      const after = chunk.slice(bodyClose)
+      // Collect flight before pumping so we don't await between "before" and
+      // "tail" — that yield lets HTTP flush a penultimate chunk alone.
+      if (ensureSourceComplete)
+        await ensureSourceComplete()
+      const flight = takeFlightBootstrap() + await liveFlight.collectAllRemainingText()
+      if (before)
+        session.trackHtmlBoundaries(before)
+      const combined = before + flight + takeCompleteScript() + after
+      if (!combined)
+        return true
+
+      // Sync try-send when possible so we don't microtask-yield before op_fizz_done.
+      const status = Deno.core.ops.op_fizz_chunk_try(session.streamId, combined)
+      if (status === 2) {
+        session.disconnected = true
+        return false
+      }
+      if (status === 1) {
+        if (!(await session.pumpFizzChunk(combined)))
+          return false
+      }
+      markFinalPackageSent()
+      return true
+    }
+
+    const pumpFizzLoop = async () => {
+      rariStreamLog('mux.fizzLoop.start')
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) {
+          htmlStreamFinished = true
+          const tail = decoder.decode()
+          if (tail) {
+            if (!(await pumpFizzText(tail)))
+              return
+            if (!finalPackageSent && session.safeToInjectFlight()) {
+              if (!(await pumpPendingFlight()))
+                return
+            }
+          }
+          rariStreamLog('mux.fizzLoop.done', `htmlChunks=${htmlChunkCount}`)
+          break
+        }
+        htmlChunkCount++
+        const chunkText = decoder.decode(value, { stream: true })
+        rariStreamLog('mux.htmlChunk', `n=${htmlChunkCount} bytes=${value.byteLength}`)
+        if (!(await pumpFizzText(chunkText)))
+          return
+        if (!finalPackageSent && session.safeToInjectFlight()) {
+          if (!(await pumpPendingFlight()))
+            return
+        }
+      }
+      if (htmlStreamFinished && !finalPackageSent) {
+        rariStreamLog('mux.drainRemaining.start')
+        if (!session.safeToInjectFlight())
+          session.resetHtmlState()
+        if (ensureSourceComplete)
+          await ensureSourceComplete()
+        const flight = takeFlightBootstrap() + await liveFlight.collectAllRemainingText()
+        const complete = takeCompleteScript()
+        const tail = flight + complete
+        if (tail) {
+          const status = Deno.core.ops.op_fizz_chunk_try(session.streamId, tail)
+          if (status === 2) {
+            session.disconnected = true
+            return
+          }
+          if (status === 1 && !(await session.pumpFizzChunk(tail)))
+            return
+        }
+        markFinalPackageSent()
+        rariStreamLog('mux.drainRemaining.done')
+      }
+    }
+
+    if (fizzStream.allReady) {
+      void Promise.resolve(fizzStream.allReady).then(() => {
+        rariStreamLog('mux.allReady.resolved')
+      })
+    }
+
+    await pumpFizzLoop()
+    if (finalPackageSent && !session.disconnected) {
+      try {
+        Deno.core.ops.op_fizz_done(session.streamId)
+      }
+      catch {
+        // Already closed after final package, or outer script closes.
+      }
+    }
+    rariStreamLog('mux.complete', `htmlChunks=${htmlChunkCount} flightRows=${flightPumpCount}`)
+  }
+
+  async function injectStreamError(caughtErrors: unknown[], streamId: string) {
+    if (caughtErrors.length === 0)
+      return
+    const displayError = caughtErrors.find((e) => {
+      if (!e || typeof e !== 'object' || !('message' in e))
+        return false
+      const message = String((e as { message: unknown }).message)
+      return message && !message.includes('omitted in production')
+    }) || caughtErrors[0]
+    const errMsg = String(
+      displayError && typeof displayError === 'object' && 'message' in displayError
+        ? (displayError as { message: unknown }).message
+        : 'Unknown error',
+    ).split('<').join('&lt;')
+    const errorHtml = `<div class=rari-error style=color:red;border:1px_solid_red;padding:10px;border-radius:4px;background-color:#fff5f5><strong>Error loading content: </strong>${errMsg}</div>`
+    const session = rariCreateFizzSession(streamId)
+    await session.pumpFizzChunk(errorHtml)
+  }
+
+  interface RenderStreamingDocumentOptions {
+    capturedElement: unknown
+    headContent: string
+    caughtErrors: unknown[]
+    streamId: string
+  }
+
+  interface RenderStaticDocumentOptions {
+    capturedElement: unknown
+    headContent: string
+    caughtErrors: unknown[]
+  }
+
+  async function renderStreamingDocument(options: RenderStreamingDocumentOptions) {
+    const { capturedElement, headContent, caughtErrors, streamId } = options
+    if (!streamId)
+      throw new Error('[rari] renderStreamingDocument requires streamId')
+
+    const session = rariCreateFizzSession(streamId)
+
+    const ReactServerRenderer = g['~reactServerRenderer']
+    const ReactDOMServer = g['~reactServer']
+    const R = g.React
+
+    if (!ReactServerRenderer?.renderToReadableStream)
+      throw new Error('[rari] RSC renderer not loaded')
+    if (!ReactDOMServer?.renderToReadableStream)
+      throw new Error('[rari] Fizz renderer not loaded')
+    if (!R?.createElement)
+      throw new Error('[rari] React not loaded')
+
+    session.resetHtmlState()
+    rariStreamLog('render.start')
+
+    const bundlerConfig = g['~rari']?.clientReferenceManifest || {}
+
+    const rscStream = await ReactServerRenderer.renderToReadableStream(
+      capturedElement,
+      bundlerConfig,
+      rariFlightRenderOptions((error: unknown) => {
+        console.error('[rari] RSC error:', error)
+        caughtErrors.push(error)
+      }),
+    )
+    rariStreamLog('rsc.stream.ready')
+
+    const { flightReadable, liveFlight, ensureSourceComplete } = rariCreatePullFlightFanout(rscStream)
+
+    const fullDoc = R.createElement(
+      'html',
+      { lang: 'en' },
+      R.createElement('head', { dangerouslySetInnerHTML: { __html: headContent } }),
+      R.createElement(
+        'body',
+        null,
+        R.createElement('div', { id: 'root' }, rariCreateStreamingRoot(flightReadable)),
+      ),
+    )
+
+    rariStreamLog('fizz.render.start')
+    const fizzStream = await ReactDOMServer.renderToReadableStream(fullDoc, {
+      onError(error: unknown) {
+        console.error('[rari] Fizz streaming error:', error)
+        caughtErrors.push(error)
+      },
+    }) as ReadableStream & { allReady?: Promise<void> }
+    rariStreamLog('fizz.stream.ready')
+
+    await rariPumpLiveMux(session, fizzStream, liveFlight, ensureSourceComplete)
+    rariStreamLog('render.done')
+  }
+
+  async function rariCollectFlightEmbedScripts(
+    liveFlight: ReturnType<typeof rariCreateLiveFlightSource>,
+  ): Promise<string> {
+    let scripts = rariFormatFlightScriptPush(0)
+    while (true) {
+      const item = await liveFlight.drainNext()
+      if (!item)
+        break
+      if (item.type === 'line')
+        scripts += rariFormatFlightScriptPush(`${item.line}\n`)
+      else if (item.type === 'binary')
+        scripts += rariFormatFlightBinaryPush(item.b64)
+    }
+
+    return scripts
+  }
+
+  function rariInjectBeforeBodyClose(html: string, injection: string): string {
+    const bodyClose = html.lastIndexOf('</body>')
+    if (bodyClose === -1)
+      return `${html}${injection}`
+
+    return `${html.slice(0, bodyClose)}${injection}\n${html.slice(bodyClose)}`
+  }
+
+  async function renderStaticDocument(options: RenderStaticDocumentOptions): Promise<string> {
+    const { capturedElement, headContent, caughtErrors } = options
+
+    const ReactServerRenderer = g['~reactServerRenderer']
+    const ReactDOMServer = g['~reactServer']
+    const R = g.React
+
+    if (!ReactServerRenderer?.renderToReadableStream)
+      throw new Error('[rari] RSC renderer not loaded')
+    if (!ReactDOMServer?.renderToReadableStream)
+      throw new Error('[rari] Fizz renderer not loaded')
+    if (!R?.createElement)
+      throw new Error('[rari] React not loaded')
+
+    const bundlerConfig = g['~rari']?.clientReferenceManifest || {}
+
+    const rscStream = await ReactServerRenderer.renderToReadableStream(
+      capturedElement,
+      bundlerConfig,
+      rariFlightRenderOptions((error: unknown) => {
+        console.error('[rari] RSC error:', error)
+        caughtErrors.push(error)
+      }),
+    )
+
+    const { flightReadable, liveFlight, ensureSourceComplete } = rariCreatePullFlightFanout(rscStream)
+
+    const fullDoc = R.createElement(
+      'html',
+      { lang: 'en' },
+      R.createElement('head', { dangerouslySetInnerHTML: { __html: headContent } }),
+      R.createElement(
+        'body',
+        null,
+        R.createElement('div', { id: 'root' }, rariCreateStreamingRoot(flightReadable)),
+      ),
+    )
+
+    const fizzStream = await ReactDOMServer.renderToReadableStream(fullDoc, {
+      onError(error: unknown) {
+        console.error('[rari] Fizz static error:', error)
+        caughtErrors.push(error)
+      },
+    }) as ReadableStream & { allReady?: Promise<void> }
+
+    await fizzStream.allReady
+    await ensureSourceComplete()
+
+    let html = await rariReadStream(fizzStream)
+    html = rariStripLeadingDoctype(html)
+    if (!html.trimStart().toLowerCase().startsWith('<!doctype'))
+      html = `<!DOCTYPE html>\n${html}`
+
+    const flightScripts = await rariCollectFlightEmbedScripts(liveFlight)
+    const completionScript = RARI_STREAMING_COMPLETE_SCRIPT
+
+    return rariInjectBeforeBodyClose(html, `${flightScripts}\n${completionScript}`)
+  }
+
+  async function pumpRscElementStream(
+    element: unknown,
+    pumpChunk: (text: string) => Promise<boolean>,
+  ): Promise<void> {
+    let disconnected = false
+    const wrappedPump = async (text: string) => {
+      if (disconnected)
+        return false
+      const ok = await pumpChunk(text)
+      if (!ok)
+        disconnected = true
+
+      return ok
+    }
+
+    const ReactServerRenderer = g['~reactServerRenderer']
+    if (!ReactServerRenderer?.renderToReadableStream)
+      throw new Error('[rari] RSC renderer not loaded')
+
+    const bundlerConfig = g['~rari']?.clientReferenceManifest || {}
+    const stream = await ReactServerRenderer.renderToReadableStream(
+      element,
+      bundlerConfig,
+      rariFlightRenderOptions((error: unknown) => {
+        console.error('[rari] RSC stream error:', error)
+      }),
+    )
+
+    const reader = stream.getReader()
+    const decoder = new TextDecoder()
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done)
+          break
+        const text = decoder.decode(value, { stream: true })
+        if (!(await wrappedPump(text)))
+          break
+      }
+      if (!disconnected) {
+        const tail = decoder.decode()
+        await wrappedPump(tail)
+      }
+    }
+    finally {
+      await reader.cancel().catch(() => {})
+    }
+  }
+
+  if (!g['~rari'])
+    g['~rari'] = {}
+  g['~rari'].renderStreamingDocument = renderStreamingDocument
+  g['~rari'].renderStaticDocument = renderStaticDocument
+  g['~rari'].injectStreamError = injectStreamError
+  g['~rari'].pumpRscElementStream = pumpRscElementStream
+})()

--- a/crates/rari/src/rendering/layout/mod.rs
+++ b/crates/rari/src/rendering/layout/mod.rs
@@ -13,19 +13,14 @@ pub use utils::{create_layout_context, sort_flight_protocol};
 #[cfg(test)]
 #[expect(clippy::unwrap_used)]
 mod tests {
-    use std::{path::Path, sync::Arc};
+    use std::path::Path;
 
     use rustc_hash::FxHashMap;
-    use tokio::sync::Mutex;
 
     use super::*;
-    use crate::{
-        rendering::base::RscRenderer,
-        runtime::JsExecutionRuntime,
-        server::routing::{
-            app_router::{AppRouteEntry, AppRouteMatch, LayoutEntry},
-            types::ParamValue,
-        },
+    use crate::server::routing::{
+        app_router::{AppRouteEntry, AppRouteMatch, LayoutEntry},
+        types::ParamValue,
     };
 
     #[test]
@@ -74,6 +69,7 @@ mod tests {
             pathname: "/test".to_string(),
             template_navigation_id: None,
             metadata: None,
+            streaming_head_extra: None,
         };
 
         let route_match = AppRouteMatch {
@@ -103,10 +99,6 @@ mod tests {
 
     #[test]
     fn test_build_composition_script_with_use_suspense_true() {
-        let renderer = LayoutRenderer::new(Arc::new(Mutex::new(RscRenderer::new(Arc::new(
-            JsExecutionRuntime::new(None),
-        )))));
-
         let route_match = AppRouteMatch {
             route: AppRouteEntry {
                 path: "/test".to_string(),
@@ -134,11 +126,17 @@ mod tests {
             pathname: "/test".to_string(),
             template_navigation_id: None,
             metadata: None,
+            streaming_head_extra: None,
         };
 
-        let script = renderer
-            .build_composition_script(&route_match, &context, Some("app/test/loading"), true, false)
-            .unwrap();
+        let script = LayoutRenderer::build_composition_script(
+            &route_match,
+            &context,
+            Some("app/test/loading"),
+            true,
+            false,
+        )
+        .unwrap();
 
         assert!(script.contains("const useSuspense = true"));
         assert!(
@@ -148,10 +146,6 @@ mod tests {
 
     #[test]
     fn test_build_composition_script_with_use_suspense_false() {
-        let renderer = LayoutRenderer::new(Arc::new(Mutex::new(RscRenderer::new(Arc::new(
-            JsExecutionRuntime::new(None),
-        )))));
-
         let route_match = AppRouteMatch {
             route: AppRouteEntry {
                 path: "/test".to_string(),
@@ -179,17 +173,17 @@ mod tests {
             pathname: "/test".to_string(),
             template_navigation_id: None,
             metadata: None,
+            streaming_head_extra: None,
         };
 
-        let script = renderer
-            .build_composition_script(
-                &route_match,
-                &context,
-                Some("app/test/loading"),
-                false,
-                false,
-            )
-            .unwrap();
+        let script = LayoutRenderer::build_composition_script(
+            &route_match,
+            &context,
+            Some("app/test/loading"),
+            false,
+            false,
+        )
+        .unwrap();
 
         assert!(script.contains("const useSuspense = false"));
         assert!(
@@ -199,10 +193,6 @@ mod tests {
 
     #[test]
     fn test_composition_script_includes_layout_structure_markers() {
-        let renderer = LayoutRenderer::new(Arc::new(Mutex::new(RscRenderer::new(Arc::new(
-            JsExecutionRuntime::new(None),
-        )))));
-
         let route_match = AppRouteMatch {
             route: AppRouteEntry {
                 path: "/test".to_string(),
@@ -238,10 +228,12 @@ mod tests {
             pathname: "/test".to_string(),
             template_navigation_id: None,
             metadata: None,
+            streaming_head_extra: None,
         };
 
         let script =
-            renderer.build_composition_script(&route_match, &context, None, true, false).unwrap();
+            LayoutRenderer::build_composition_script(&route_match, &context, None, true, false)
+                .unwrap();
 
         assert!(!script.contains("'data-content-slot': true"));
         assert!(!script.contains("const contentSlot = React.createElement"));
@@ -251,10 +243,6 @@ mod tests {
 
     #[test]
     fn test_mode_consistency_metadata_structure() {
-        let renderer = LayoutRenderer::new(Arc::new(Mutex::new(RscRenderer::new(Arc::new(
-            JsExecutionRuntime::new(None),
-        )))));
-
         let route_match = AppRouteMatch {
             route: AppRouteEntry {
                 path: "/test".to_string(),
@@ -282,12 +270,15 @@ mod tests {
             pathname: "/test".to_string(),
             template_navigation_id: None,
             metadata: None,
+            streaming_head_extra: None,
         };
 
         let script_ssr =
-            renderer.build_composition_script(&route_match, &context, None, true, false).unwrap();
+            LayoutRenderer::build_composition_script(&route_match, &context, None, true, false)
+                .unwrap();
         let script_rsc =
-            renderer.build_composition_script(&route_match, &context, None, false, false).unwrap();
+            LayoutRenderer::build_composition_script(&route_match, &context, None, false, false)
+                .unwrap();
 
         assert!(script_ssr.contains("rsc_data: rscData"));
         assert!(script_rsc.contains("rsc_data: rscData"));
@@ -304,10 +295,6 @@ mod tests {
 
     #[test]
     fn test_mode_consistency_async_component_handling_with_loading() {
-        let renderer = LayoutRenderer::new(Arc::new(Mutex::new(RscRenderer::new(Arc::new(
-            JsExecutionRuntime::new(None),
-        )))));
-
         let route_match = AppRouteMatch {
             route: AppRouteEntry {
                 path: "/test".to_string(),
@@ -335,20 +322,25 @@ mod tests {
             pathname: "/test".to_string(),
             template_navigation_id: None,
             metadata: None,
+            streaming_head_extra: None,
         };
 
-        let script_ssr = renderer
-            .build_composition_script(&route_match, &context, Some("app/test/loading"), true, false)
-            .unwrap();
-        let script_rsc = renderer
-            .build_composition_script(
-                &route_match,
-                &context,
-                Some("app/test/loading"),
-                false,
-                false,
-            )
-            .unwrap();
+        let script_ssr = LayoutRenderer::build_composition_script(
+            &route_match,
+            &context,
+            Some("app/test/loading"),
+            true,
+            false,
+        )
+        .unwrap();
+        let script_rsc = LayoutRenderer::build_composition_script(
+            &route_match,
+            &context,
+            Some("app/test/loading"),
+            false,
+            false,
+        )
+        .unwrap();
 
         assert!(script_ssr.contains("const useSuspense = true"));
         assert!(
@@ -365,10 +357,6 @@ mod tests {
 
     #[test]
     fn test_mode_consistency_wrapper_elements() {
-        let renderer = LayoutRenderer::new(Arc::new(Mutex::new(RscRenderer::new(Arc::new(
-            JsExecutionRuntime::new(None),
-        )))));
-
         let route_match = AppRouteMatch {
             route: AppRouteEntry {
                 path: "/test".to_string(),
@@ -396,12 +384,15 @@ mod tests {
             pathname: "/test".to_string(),
             template_navigation_id: None,
             metadata: None,
+            streaming_head_extra: None,
         };
 
         let script_ssr =
-            renderer.build_composition_script(&route_match, &context, None, true, false).unwrap();
+            LayoutRenderer::build_composition_script(&route_match, &context, None, true, false)
+                .unwrap();
         let script_rsc =
-            renderer.build_composition_script(&route_match, &context, None, false, false).unwrap();
+            LayoutRenderer::build_composition_script(&route_match, &context, None, false, false)
+                .unwrap();
 
         assert!(!script_ssr.contains("const contentSlot = React.createElement"));
         assert!(!script_ssr.contains("'data-content-slot': true"));
@@ -417,10 +408,6 @@ mod tests {
 
     #[test]
     fn test_mode_consistency_error_handling() {
-        let renderer = LayoutRenderer::new(Arc::new(Mutex::new(RscRenderer::new(Arc::new(
-            JsExecutionRuntime::new(None),
-        )))));
-
         let route_match = AppRouteMatch {
             route: AppRouteEntry {
                 path: "/test".to_string(),
@@ -448,12 +435,15 @@ mod tests {
             pathname: "/test".to_string(),
             template_navigation_id: None,
             metadata: None,
+            streaming_head_extra: None,
         };
 
         let script_ssr =
-            renderer.build_composition_script(&route_match, &context, None, true, false).unwrap();
+            LayoutRenderer::build_composition_script(&route_match, &context, None, true, false)
+                .unwrap();
         let script_rsc =
-            renderer.build_composition_script(&route_match, &context, None, false, false).unwrap();
+            LayoutRenderer::build_composition_script(&route_match, &context, None, false, false)
+                .unwrap();
 
         assert!(script_ssr.contains("React.createElement"));
         assert!(script_rsc.contains("React.createElement"));

--- a/crates/rari/src/rendering/layout/route_composer.rs
+++ b/crates/rari/src/rendering/layout/route_composer.rs
@@ -54,6 +54,7 @@ impl RouteComposer {
             metadata_json,
             false,
             pathname_json,
+            None,
         )
     }
 
@@ -71,6 +72,7 @@ impl RouteComposer {
         metadata_json: &str,
         defer_rsc: bool,
         action_post_url_json: &str,
+        capture_stream_id: Option<&str>,
     ) -> String {
         let mut script = format!(
             r"
@@ -128,6 +130,7 @@ impl RouteComposer {
             error_boundary,
             metadata_json,
             defer_rsc,
+            capture_stream_id,
         ));
 
         script
@@ -190,6 +193,7 @@ impl RouteComposer {
         error_boundary: Option<&ErrorBoundaryInfo>,
         metadata_json: &str,
         defer_rsc: bool,
+        capture_stream_id: Option<&str>,
     ) -> String {
         let wrap_with_error_boundary = error_boundary.is_some();
         let error_component_id_json = error_boundary
@@ -197,15 +201,34 @@ impl RouteComposer {
             .unwrap_or_else(|| "\"\"".to_string());
 
         let rsc_render = if defer_rsc {
-            r"
-                if (!globalThis['~rari']) globalThis['~rari'] = {};
-                globalThis['~rari'].capturedElement = elementToRender;
+            if let Some(stream_id) = capture_stream_id {
+                let stream_id_json =
+                    serde_json::to_string(stream_id).unwrap_or_else(|_| "\"\"".to_string());
+                format!(
+                    r"
+                if (!globalThis['~rari']) globalThis['~rari'] = {{}};
+                if (!globalThis['~rari'].capturedByStream) globalThis['~rari'].capturedByStream = Object.create(null);
+                globalThis['~rari'].capturedByStream[{stream_id_json}] = elementToRender;
                 return;
             "
+                )
+            } else {
+                r"
+                if (!globalThis['~rari']) globalThis['~rari'] = {};
+                if (globalThis['~rari'].isActionRefreshCompose) {
+                    globalThis['~rari'].actionRefreshElement = elementToRender;
+                } else {
+                    globalThis['~rari'].capturedElement = elementToRender;
+                }
+                return;
+            "
+                .to_string()
+            }
         } else {
             r"
                 let rscData = await globalThis.renderToRsc(elementToRender);
             "
+            .to_string()
         };
 
         format!(
@@ -371,7 +394,8 @@ mod tests {
 
     #[test]
     fn test_generate_rsc_conversion() {
-        let conversion = RouteComposer::generate_rsc_conversion("finalElement", None, "{}", false);
+        let conversion =
+            RouteComposer::generate_rsc_conversion("finalElement", None, "{}", false, None);
 
         assert!(conversion.contains("elementToRender = finalElement"));
         assert!(conversion.contains("renderToRsc(elementToRender"));
@@ -392,6 +416,7 @@ mod tests {
             Some(&error_boundary),
             "{}",
             false,
+            None,
         );
 
         assert!(conversion.contains("virtual:error-boundary-wrapper.tsx#ErrorBoundaryWrapper"));
@@ -404,15 +429,21 @@ mod tests {
     #[test]
     fn test_generate_rsc_conversion_with_metadata() {
         let metadata_json = r#"{"title":"Test Page","description":"A test"}"#;
-        let conversion =
-            RouteComposer::generate_rsc_conversion("finalElement", None, metadata_json, false);
+        let conversion = RouteComposer::generate_rsc_conversion(
+            "finalElement",
+            None,
+            metadata_json,
+            false,
+            None,
+        );
 
         assert!(conversion.contains(r#"metadata: {"title":"Test Page","description":"A test"}"#));
     }
 
     #[test]
     fn test_generate_rsc_conversion_deferred() {
-        let conversion = RouteComposer::generate_rsc_conversion("finalElement", None, "{}", true);
+        let conversion =
+            RouteComposer::generate_rsc_conversion("finalElement", None, "{}", true, None);
 
         assert!(conversion.contains("capturedElement = elementToRender"));
         assert!(!conversion.contains("renderToRsc(elementToRender"));
@@ -446,6 +477,7 @@ mod tests {
             "{}",
             false,
             "\"/\"",
+            None,
         );
         assert_eq!(empty_tpl, no_tpl);
     }
@@ -462,6 +494,7 @@ mod tests {
             "{}",
             false,
             "\"/about\"",
+            None,
         );
 
         assert!(script.contains("TemplateComponent0"));
@@ -490,6 +523,7 @@ mod tests {
             "{}",
             false,
             "\"/blog/hello\"",
+            None,
         );
 
         let page_idx = script.find("pageElement").expect("pageElement present");
@@ -512,6 +546,7 @@ mod tests {
             "{}",
             false,
             "\"/about\"",
+            None,
         );
 
         assert!(script.contains("TemplateComponent0"));

--- a/crates/rari/src/rendering/layout/types.rs
+++ b/crates/rari/src/rendering/layout/types.rs
@@ -14,6 +14,7 @@ pub struct LayoutRenderContext {
     pub pathname: String,
     pub template_navigation_id: Option<u32>,
     pub metadata: Option<PageMetadata>,
+    pub streaming_head_extra: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/rari/src/rendering/layout/utils.rs
+++ b/crates/rari/src/rendering/layout/utils.rs
@@ -165,6 +165,7 @@ pub fn create_layout_context(
         pathname,
         template_navigation_id: None,
         metadata: None,
+        streaming_head_extra: None,
     }
 }
 

--- a/crates/rari/src/rendering/types.d.ts
+++ b/crates/rari/src/rendering/types.d.ts
@@ -48,8 +48,10 @@ declare global {
     namespace core {
       namespace ops {
         function op_sanitize_html(html: string, componentId: string): string
-        function op_fizz_chunk(text: string): Promise<void>
-        function op_fizz_done(): void
+        function op_fizz_chunk_try(streamId: string, text: string): number
+        function op_fizz_chunk(streamId: string, text: string): Promise<void>
+        function op_fizz_done(streamId: string): void
+        function op_stream_promise_settled(streamId: string, ok: boolean, error: string): void
         function op_internal_log(message: string): void
       }
     }

--- a/crates/rari/src/rsc.rs
+++ b/crates/rari/src/rsc.rs
@@ -192,6 +192,14 @@ impl ComponentRegistry {
         }
     }
 
+    pub fn get_loaded_component_ids(&self) -> Vec<String> {
+        self.components
+            .iter()
+            .filter(|(_, component)| component.is_loaded)
+            .map(|(id, _)| id.clone())
+            .collect()
+    }
+
     pub fn mark_component_not_loaded(&mut self, id: &str) {
         let normalized_id = Self::normalize_id(id);
         if let Some(component) = self.components.get_mut(normalized_id.as_ref()) {

--- a/crates/rari/src/runtime/ext/rari/core/types.d.ts
+++ b/crates/rari/src/runtime/ext/rari/core/types.d.ts
@@ -117,19 +117,24 @@ declare global {
       useCacheDynamicDepth?: number
       markUseCacheDynamic?: () => void
       invalidateUseCache?: (input: { tag?: string, path?: string }) => Promise<void>
+      requestStorage?: {
+        run: <T>(store: { requestId: string, streamId?: string }, fn: () => T) => T
+        getStore: () => { requestId?: string, streamId?: string } | undefined
+      }
+      currentRequestId?: () => string
       renderStreamingDocument?: (options: {
         capturedElement: unknown
         headContent: string
         caughtErrors: unknown[]
+        streamId: string
       }) => Promise<void>
       renderStaticDocument?: (options: {
         capturedElement: unknown
         headContent: string
         caughtErrors: unknown[]
+        streamId?: string
       }) => Promise<string>
-      pumpStreamingCompleteScript?: () => Promise<void>
-      injectStreamError?: (caughtErrors: unknown[]) => Promise<void>
-      pumpFizzChunk?: (text: string) => Promise<boolean>
+      injectStreamError?: (caughtErrors: unknown[], streamId: string) => Promise<void>
       pumpRscElementStream?: (element: unknown, pumpChunk: (text: string) => Promise<boolean>) => Promise<void>
       streaming?: { complete?: boolean }
       loadFullReactVendors?: () => boolean
@@ -140,8 +145,8 @@ declare global {
   namespace Deno {
     namespace core {
       namespace ops {
-        function op_get_cookies(): string
-        function op_get_request_headers(): string
+        function op_get_cookies(requestId?: string): string
+        function op_get_request_headers(requestId?: string): string
         function op_set_cookie(options: {
           name: string
           value: string
@@ -154,10 +159,11 @@ declare global {
           sameSite?: 'strict' | 'lax' | 'none'
           priority?: 'low' | 'medium' | 'high'
           partitioned?: boolean
+          requestId?: string
         }): void
-        function op_delete_cookie(name: string): void
-        function op_cache_get(key: string): any
-        function op_cache_set(key: string, value: any): void
+        function op_delete_cookie(name: string, requestId?: string): void
+        function op_cache_get(key: string, requestId?: string): any
+        function op_cache_set(key: string, value: any, requestId?: string): void
       }
     }
   }

--- a/crates/rari/src/runtime/ext/rari/core/types.d.ts
+++ b/crates/rari/src/runtime/ext/rari/core/types.d.ts
@@ -100,8 +100,11 @@ declare global {
       lastRscBinary?: Uint8Array
       actionPostUrl?: string
       actionRefreshSearch?: string
+      isActionRefreshCompose?: boolean
+      actionRefreshElement?: unknown
       actionFormState?: unknown
       capturedElement?: unknown
+      capturedByStream?: Record<string, unknown>
       pendingActionResult?: unknown
       exportOwners?: Record<string, string>
       metadataCollector?: {
@@ -118,8 +121,8 @@ declare global {
       markUseCacheDynamic?: () => void
       invalidateUseCache?: (input: { tag?: string, path?: string }) => Promise<void>
       requestStorage?: {
-        run: <T>(store: { requestId: string, streamId?: string }, fn: () => T) => T
-        getStore: () => { requestId?: string, streamId?: string } | undefined
+        run: <T>(store: { requestId: string, streamId?: string, capturedElement?: unknown }, fn: () => T) => T
+        getStore: () => { requestId?: string, streamId?: string, capturedElement?: unknown } | undefined
       }
       currentRequestId?: () => string
       renderStreamingDocument?: (options: {

--- a/crates/rari/src/runtime/ext/rari/http/cookies.ts
+++ b/crates/rari/src/runtime/ext/rari/http/cookies.ts
@@ -82,22 +82,27 @@
     return normalized
   }
 
+  function currentRequestId(): string {
+    const id = g['~rari']?.currentRequestId?.()
+    return typeof id === 'string' ? id : ''
+  }
+
   function createCookieStore(): RariCookieStore {
     return {
       get: (name: string): RariCookie | undefined => {
-        const map = parseCookieHeader(Deno.core.ops.op_get_cookies())
+        const map = parseCookieHeader(Deno.core.ops.op_get_cookies(currentRequestId()))
         const value = map.get(name)
         return value !== undefined ? { name, value } : undefined
       },
 
       getAll: (name?: string): RariCookie[] => {
-        const map = parseCookieHeader(Deno.core.ops.op_get_cookies())
+        const map = parseCookieHeader(Deno.core.ops.op_get_cookies(currentRequestId()))
         const all = Array.from(map.entries()).map(([n, v]) => ({ name: n, value: v }))
         return name ? all.filter(c => c.name === name) : all
       },
 
       has: (name: string): boolean => {
-        return parseCookieHeader(Deno.core.ops.op_get_cookies()).has(name)
+        return parseCookieHeader(Deno.core.ops.op_get_cookies(currentRequestId())).has(name)
       },
 
       set: ((nameOrOptions: string | (RariCookieSetOptions & { name: string, value: string }), value?: string, options?: RariCookieSetOptions): void => {
@@ -115,6 +120,7 @@
             sameSite: opts.sameSite as 'strict' | 'lax' | 'none' | undefined,
             priority: opts.priority as 'low' | 'medium' | 'high' | undefined,
             partitioned: opts.partitioned,
+            requestId: currentRequestId() || undefined,
           })
         }
         else {
@@ -131,16 +137,17 @@
             sameSite: opts.sameSite as 'strict' | 'lax' | 'none' | undefined,
             priority: opts.priority as 'low' | 'medium' | 'high' | undefined,
             partitioned: opts.partitioned,
+            requestId: currentRequestId() || undefined,
           })
         }
       }) as RariCookieStore['set'],
 
       delete: (name: string): void => {
-        Deno.core.ops.op_delete_cookie(name)
+        Deno.core.ops.op_delete_cookie(name, currentRequestId())
       },
 
       toString: (): string => {
-        return Deno.core.ops.op_get_cookies()
+        return Deno.core.ops.op_get_cookies(currentRequestId())
       },
     }
   }

--- a/crates/rari/src/runtime/ext/rari/http/headers.ts
+++ b/crates/rari/src/runtime/ext/rari/http/headers.ts
@@ -17,8 +17,13 @@
     return name.toLowerCase()
   }
 
+  function currentRequestId(): string {
+    const id = g['~rari']?.currentRequestId?.()
+    return typeof id === 'string' ? id : ''
+  }
+
   function parseRequestHeaders(): Map<string, string> {
-    const raw = Deno.core.ops.op_get_request_headers()
+    const raw = Deno.core.ops.op_get_request_headers(currentRequestId())
     if (!raw)
       return new Map()
 

--- a/crates/rari/src/runtime/ext/runtime/init_node_bootstrap.ts
+++ b/crates/rari/src/runtime/ext/runtime/init_node_bootstrap.ts
@@ -1,7 +1,7 @@
 /// <reference path="../types.d.ts" />
 /// <reference path="../rari/core/types.d.ts" />
 
-// @ts-expect-error TS2307 — Deno runtime has no ambient types for node:async_hooks
+// @ts-expect-error TS2307 - Deno runtime has no ambient types for node:async_hooks
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { core, internals } from 'ext:core/mod.js'
 

--- a/crates/rari/src/runtime/ext/runtime/init_node_bootstrap.ts
+++ b/crates/rari/src/runtime/ext/runtime/init_node_bootstrap.ts
@@ -1,6 +1,7 @@
 /// <reference path="../types.d.ts" />
+/// <reference path="../rari/core/types.d.ts" />
 
-// @ts-ignore
+// @ts-expect-error TS2307 — Deno runtime has no ambient types for node:async_hooks
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { core, internals } from 'ext:core/mod.js'
 

--- a/crates/rari/src/runtime/ext/runtime/init_node_bootstrap.ts
+++ b/crates/rari/src/runtime/ext/runtime/init_node_bootstrap.ts
@@ -1,6 +1,6 @@
 /// <reference path="../types.d.ts" />
 
-// @ts-expect-error TS2307
+// @ts-ignore
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { core, internals } from 'ext:core/mod.js'
 
@@ -27,6 +27,7 @@ if (!g['~rari'].requestStorage) {
   g['~rari'].requestStorage = new AsyncLocalStorage<{
     requestId: string
     streamId?: string
+    capturedElement?: unknown
   }>()
 }
 g['~rari'].currentRequestId = () => {

--- a/crates/rari/src/runtime/ext/runtime/init_node_bootstrap.ts
+++ b/crates/rari/src/runtime/ext/runtime/init_node_bootstrap.ts
@@ -1,5 +1,7 @@
 /// <reference path="../types.d.ts" />
 
+// @ts-expect-error TS2307
+import { AsyncLocalStorage } from 'node:async_hooks'
 import { core, internals } from 'ext:core/mod.js'
 
 // 99_main.js normally calls core.setBuildInfo during bootstrap. Without it,
@@ -16,4 +18,21 @@ internals.__nodeBootstrapArgs = {
   nodeDebug: '',
   denoArgs: core.ops.op_bootstrap_args(),
   denoVersion: Deno.version,
+}
+
+// Per-request async context for concurrent streams on one isolate.
+if (!g['~rari'])
+  g['~rari'] = {}
+if (!g['~rari'].requestStorage) {
+  g['~rari'].requestStorage = new AsyncLocalStorage<{
+    requestId: string
+    streamId?: string
+  }>()
+}
+g['~rari'].currentRequestId = () => {
+  const store = g['~rari']?.requestStorage?.getStore?.()
+  if (store && typeof store === 'object' && store.requestId != null)
+    return String(store.requestId)
+
+  return ''
 }

--- a/crates/rari/src/runtime/ext/types.d.ts
+++ b/crates/rari/src/runtime/ext/types.d.ts
@@ -516,7 +516,7 @@ declare global {
 
     namespace core {
       namespace ops {
-        function op_fetch_with_cache(url: string, options: string): Promise<{
+        function op_fetch_with_cache(url: string, options: string, requestId?: string): Promise<{
           ok: boolean
           error?: string
           body?: string

--- a/crates/rari/src/runtime/ext/web/init_fetch.ts
+++ b/crates/rari/src/runtime/ext/web/init_fetch.ts
@@ -170,7 +170,12 @@ async function fetchWithRustCache(input: RequestInfo | URL, init: RequestInit & 
   options.timeout = String(typeof timeoutMs === 'number' && timeoutMs > 0 ? timeoutMs : 5000)
 
   try {
-    const result = await Deno.core.ops.op_fetch_with_cache(url, JSON.stringify(options))
+    const rariGlobal = (globalThis as { '~rari'?: { currentRequestId?: () => string } })['~rari']
+    const result = await Deno.core.ops.op_fetch_with_cache(
+      url,
+      JSON.stringify(options),
+      rariGlobal?.currentRequestId?.() || '',
+    )
 
     if (!result.ok)
       throw new Error(result.error || 'Fetch failed')

--- a/crates/rari/src/runtime/factory/executor.rs
+++ b/crates/rari/src/runtime/factory/executor.rs
@@ -85,8 +85,107 @@ fn default_promise_timeout_ms() -> u64 {
     env::var("RARI_PROMISE_RESOLUTION_TIMEOUT_MS").ok().and_then(|s| s.parse().ok()).unwrap_or(5000)
 }
 
-fn streaming_promise_timeout_ms() -> u64 {
+pub fn streaming_promise_timeout_ms() -> u64 {
     env::var("RARI_STREAMING_SCRIPT_TIMEOUT_MS").ok().and_then(|s| s.parse().ok()).unwrap_or(30000)
+}
+
+fn sanitize_stream_id_for_slot(stream_id: &str) -> String {
+    stream_id.chars().map(|c| if c.is_ascii_alphanumeric() { c } else { '_' }).collect()
+}
+
+/// Register a chunk sender and kick off concurrent promise tracking without awaiting.
+/// Returns the `~rari_concurrent` slot key for cooperative polling.
+pub fn start_streaming_script(
+    runtime: &mut JsRuntime,
+    script_name: &str,
+    script_code: &str,
+    stream_id: &str,
+    chunk_sender: mpsc::Sender<Result<Vec<u8>, RariError>>,
+) -> Result<String, RariError> {
+    {
+        let op_state_rc = runtime.op_state();
+        let mut op_state = op_state_rc.borrow_mut();
+        if let Some(stream_state) = op_state.try_borrow_mut::<StreamOpState>() {
+            stream_state.register_sender(stream_id.to_string(), chunk_sender);
+        } else {
+            return Err(RariError::js_runtime(
+                "StreamOpState not available in runtime".to_string(),
+            ));
+        }
+    }
+
+    let slot_key = format!("__rari_s{}__", sanitize_stream_id_for_slot(stream_id));
+
+    let cleanup_sender = |runtime: &mut JsRuntime| {
+        let op_state_rc = runtime.op_state();
+        let mut op_state = op_state_rc.borrow_mut();
+        if let Some(stream_state) = op_state.try_borrow_mut::<StreamOpState>() {
+            let _ = stream_state.take_sender(stream_id);
+        }
+    };
+
+    let v8_val = match runtime.execute_script(script_name.to_string(), script_code.to_string()) {
+        Ok(val) => val,
+        Err(e) => {
+            cleanup_sender(runtime);
+            return Err(RariError::js_execution(format!(
+                "Failed to execute streaming script '{script_name}': {e}"
+            )));
+        }
+    };
+
+    let store_result = with_scope!(runtime, |scope| {
+        let local_val = deno_core::v8::Local::new(scope, &v8_val);
+        let context = scope.get_current_context();
+        let global = context.global(scope);
+        if let Some(key_str) = v8::String::new(scope, &slot_key) {
+            global.set(scope, key_str.into(), local_val);
+            Ok::<(), RariError>(())
+        } else {
+            Err(RariError::internal("Failed to create V8 key string".to_string()))
+        }
+    });
+
+    if let Err(e) = store_result {
+        cleanup_sender(runtime);
+        return Err(e);
+    }
+
+    let setup = format!(
+        r"(function() {{
+            if (!globalThis['~rari_concurrent']) globalThis['~rari_concurrent'] = {{}};
+            const val = globalThis['{slot_key}'];
+            const settle = function(ok, error) {{
+                Deno.core.ops.op_stream_promise_settled('{stream_id}', ok, error);
+            }};
+            if (val && typeof val.then === 'function') {{
+                globalThis['~rari_concurrent']['{slot_key}'] = {{ done: false, result: null, error: null }};
+                val.then(function(r) {{
+                    globalThis['~rari_concurrent']['{slot_key}'] = {{ done: true, result: r, error: null }};
+                    settle(true, '');
+                }}).catch(function(e) {{
+                    globalThis['~rari_concurrent']['{slot_key}'] = {{ done: true, result: null, error: String(e) }};
+                    settle(false, String(e));
+                }});
+            }} else {{
+                globalThis['~rari_concurrent']['{slot_key}'] = {{ done: true, result: val, error: null }};
+                settle(true, '');
+            }}
+        }})()"
+    );
+
+    if let Err(e) = runtime.execute_script(format!("setup_stream_{slot_key}"), setup) {
+        let cleanup = format!(
+            "delete globalThis['{slot_key}']; delete globalThis['~rari_concurrent']['{slot_key}']"
+        );
+        let _ = runtime.execute_script(format!("cleanup_stream_setup_{slot_key}"), cleanup);
+        cleanup_sender(runtime);
+        return Err(RariError::internal(format!(
+            "Failed to setup streaming concurrent tracking: {e}"
+        )));
+    }
+
+    Ok(slot_key)
 }
 
 async fn execute_as_module(
@@ -407,55 +506,4 @@ async fn retry_as_module(
         .await?;
 
     Ok(Value::Null)
-}
-
-pub async fn execute_script_for_streaming(
-    runtime: &mut JsRuntime,
-    module_loader: &Rc<RariModuleLoader>,
-    script_name: &str,
-    script_code: &str,
-    chunk_sender: mpsc::Sender<Result<Vec<u8>, RariError>>,
-) -> Result<(), RariError> {
-    {
-        let op_state_rc = runtime.op_state();
-        let mut op_state = op_state_rc.borrow_mut();
-        if let Some(stream_state) = op_state.try_borrow_mut::<StreamOpState>() {
-            stream_state.chunk_sender = Some(chunk_sender);
-        } else {
-            return Err(RariError::js_runtime(
-                "StreamOpState not available in runtime".to_string(),
-            ));
-        }
-    }
-
-    let result = execute_as_script(
-        runtime,
-        module_loader,
-        script_name,
-        script_code,
-        streaming_promise_timeout_ms(),
-    )
-    .await;
-
-    let leftover_sender = {
-        let op_state_rc = runtime.op_state();
-        let mut op_state = op_state_rc.borrow_mut();
-        op_state
-            .try_borrow_mut::<StreamOpState>()
-            .and_then(|stream_state| stream_state.chunk_sender.take())
-    };
-
-    if let Some(sender) = leftover_sender {
-        let stream_err = match &result {
-            Err(err) => err.clone(),
-            Ok(_) => RariError::js_execution(format!(
-                "Streaming script '{script_name}' ended without completing the stream"
-            )),
-        };
-
-        let _ = sender.send(Err(stream_err)).await;
-    }
-
-    result?;
-    Ok(())
 }

--- a/crates/rari/src/runtime/factory/interface.rs
+++ b/crates/rari/src/runtime/factory/interface.rs
@@ -8,6 +8,9 @@ use crate::server::middleware::request_context::RequestContext;
 
 pub type BatchResultReceiver = mpsc::UnboundedReceiver<(usize, Result<Value, RariError>)>;
 pub type AsyncBatchResult = Pin<Box<dyn Future<Output = BatchResultReceiver> + Send>>;
+pub type StreamingCompletionFuture = Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>>;
+pub type QueueStreamingScriptFuture =
+    Pin<Box<dyn Future<Output = Result<StreamingCompletionFuture, RariError>> + Send>>;
 
 pub trait JsRuntimeInterface: Send + Sync {
     fn execute_script(
@@ -55,24 +58,38 @@ pub trait JsRuntimeInterface: Send + Sync {
         request_context: Arc<RequestContext>,
     ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>>;
 
-    fn clear_request_context(&self) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>>;
-
     fn clear_request_context_if_matches(
         &self,
         expected_context: Arc<RequestContext>,
     ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>>;
 
-    fn execute_script_with_request_context(
-        &self,
-        request_context: Arc<RequestContext>,
-        script_name: String,
-        script_code: String,
-    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send>>;
-
     fn execute_script_for_streaming(
         &self,
+        stream_id: String,
         script_name: String,
         script_code: String,
         chunk_sender: Sender<Result<Vec<u8>, RariError>>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>>;
+
+    /// Queue a streaming script on the isolate without waiting for it to finish.
+    /// The returned future resolves when the stream completes (or errors).
+    /// Optional `request_context` is registered in the same isolate turn.
+    fn queue_script_for_streaming(
+        &self,
+        stream_id: String,
+        script_name: String,
+        script_code: String,
+        chunk_sender: Sender<Result<Vec<u8>, RariError>>,
+        request_context: Option<Arc<RequestContext>>,
+    ) -> QueueStreamingScriptFuture;
+
+    fn register_request_context(
+        &self,
+        request_context: Arc<RequestContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>>;
+
+    fn unregister_request_context(
+        &self,
+        request_id: &str,
     ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>>;
 }

--- a/crates/rari/src/runtime/factory/mod.rs
+++ b/crates/rari/src/runtime/factory/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod utils;
 use std::sync::Arc;
 
 pub use interface::JsRuntimeInterface;
+pub use pool::{JsRuntimePool, PooledRuntime, PostRebuildHook, StreamingSlotGuard};
 pub use runtime::RariRuntime;
 use rustc_hash::FxHashMap;
 

--- a/crates/rari/src/runtime/factory/mod.rs
+++ b/crates/rari/src/runtime/factory/mod.rs
@@ -10,7 +10,9 @@ pub(crate) mod utils;
 use std::sync::Arc;
 
 pub use interface::JsRuntimeInterface;
-pub use pool::{JsRuntimePool, PooledRuntime, PostRebuildHook, StreamingSlotGuard};
+pub use pool::{
+    JsRuntimePool, LeasedRequestRuntime, PooledRuntime, PostRebuildHook, StreamingSlotGuard,
+};
 pub use runtime::RariRuntime;
 use rustc_hash::FxHashMap;
 

--- a/crates/rari/src/runtime/factory/pool/handle.rs
+++ b/crates/rari/src/runtime/factory/pool/handle.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
 
 use deno_core::ModuleId;
 use rari_error::RariError;
@@ -62,11 +62,33 @@ impl PooledRuntime {
     /// (matches [`crate::runtime::JsExecutionRuntime::execute_script_for_streaming`]).
     pub async fn execute_script_for_streaming(
         &self,
+        stream_id: String,
         script_name: String,
         script_code: String,
         chunk_sender: Sender<Result<Vec<u8>, RariError>>,
     ) -> Result<(), RariError> {
-        self.runtime.execute_script_for_streaming(script_name, script_code, chunk_sender).await
+        self.runtime
+            .execute_script_for_streaming(stream_id, script_name, script_code, chunk_sender)
+            .await
+    }
+
+    pub async fn queue_script_for_streaming(
+        &self,
+        stream_id: String,
+        script_name: String,
+        script_code: String,
+        chunk_sender: Sender<Result<Vec<u8>, RariError>>,
+        request_context: Option<Arc<RequestContext>>,
+    ) -> Result<Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>>, RariError> {
+        self.runtime
+            .queue_script_for_streaming(
+                stream_id,
+                script_name,
+                script_code,
+                chunk_sender,
+                request_context,
+            )
+            .await
     }
 
     forward_async_to_runtime_with_timeout! {
@@ -78,8 +100,8 @@ impl PooledRuntime {
         pub async fn evaluate_module(&self, module_id: ModuleId) -> Result<Value, RariError>;
         pub async fn get_module_namespace(&self, module_id: ModuleId) -> Result<Value, RariError>;
         pub async fn set_request_context(&self, request_context: Arc<RequestContext>) -> Result<(), RariError>;
-        pub async fn clear_request_context(&self) -> Result<(), RariError>;
         pub async fn clear_request_context_if_matches(&self, expected_context: Arc<RequestContext>) -> Result<(), RariError>;
-        pub async fn execute_script_with_request_context(&self, request_context: Arc<RequestContext>, script_name: String, script_code: String) -> Result<Value, RariError>;
+        pub async fn register_request_context(&self, request_context: Arc<RequestContext>) -> Result<(), RariError>;
+        pub async fn unregister_request_context(&self, request_id: &str) -> Result<(), RariError>;
     }
 }

--- a/crates/rari/src/runtime/factory/pool/lease.rs
+++ b/crates/rari/src/runtime/factory/pool/lease.rs
@@ -1,0 +1,136 @@
+use std::sync::Arc;
+
+use rari_error::RariError;
+use serde_json::Value;
+use tokio::{
+    sync::OwnedMutexGuard,
+    time::{self, Duration},
+};
+
+use super::{super::interface::JsRuntimeInterface, JsRuntimePool};
+use crate::server::middleware::request_context::RequestContext;
+
+/// Holds a pool slot lease with request context installed for multi-step work.
+///
+/// Call [`Self::release`] when finished. If dropped without release, context cleanup
+/// is best-effort via a spawned task.
+pub struct LeasedRequestRuntime {
+    pool: Arc<JsRuntimePool>,
+    idx: usize,
+    runtime: Arc<dyn JsRuntimeInterface>,
+    ctx: Arc<RequestContext>,
+    _lease: OwnedMutexGuard<()>,
+    timeout_ms: u64,
+    released: bool,
+}
+
+impl LeasedRequestRuntime {
+    pub fn runtime(&self) -> &Arc<dyn JsRuntimeInterface> {
+        &self.runtime
+    }
+
+    pub fn request_context(&self) -> &Arc<RequestContext> {
+        &self.ctx
+    }
+
+    pub async fn execute_script(
+        &self,
+        script_name: String,
+        script_code: String,
+    ) -> Result<Value, RariError> {
+        match time::timeout(
+            Duration::from_millis(self.timeout_ms),
+            self.runtime.execute_script(script_name, script_code),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => {
+                self.pool.mark_unhealthy_if_runtime_matches(self.idx, &self.runtime);
+                Err(RariError::timeout(format!(
+                    "execute_script timed out after {} ms",
+                    self.timeout_ms
+                )))
+            }
+        }
+    }
+
+    pub async fn release(mut self) -> Result<(), RariError> {
+        self.released = true;
+        let cleanup = time::timeout(
+            Duration::from_millis(self.timeout_ms),
+            self.runtime.clear_request_context_if_matches(Arc::clone(&self.ctx)),
+        )
+        .await;
+        match cleanup {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => {
+                self.pool.mark_unhealthy_if_runtime_matches(self.idx, &self.runtime);
+                self.pool.mark_needs_rebuild(self.idx);
+                Err(e)
+            }
+            Err(_) => {
+                self.pool.mark_unhealthy_if_runtime_matches(self.idx, &self.runtime);
+                self.pool.mark_needs_rebuild(self.idx);
+                Err(RariError::timeout(format!(
+                    "clear_request_context timed out after {} ms",
+                    self.timeout_ms
+                )))
+            }
+        }
+    }
+}
+
+impl Drop for LeasedRequestRuntime {
+    fn drop(&mut self) {
+        if self.released {
+            return;
+        }
+        let runtime = Arc::clone(&self.runtime);
+        let ctx = Arc::clone(&self.ctx);
+        tokio::spawn(async move {
+            let _ = runtime.clear_request_context_if_matches(ctx).await;
+        });
+    }
+}
+
+impl JsRuntimePool {
+    pub async fn acquire_request_runtime(
+        self: &Arc<Self>,
+        ctx: Arc<RequestContext>,
+    ) -> Result<LeasedRequestRuntime, RariError> {
+        self.probe_and_heal().await;
+        let handle = self.pick_runtime().await?;
+        let idx = handle.idx();
+        let runtime = Arc::clone(handle.runtime());
+        let lease = self.acquire_owned_slot_lease_for_execute(idx, &runtime).await?;
+
+        match time::timeout(
+            Duration::from_millis(self.timeout_ms),
+            runtime.set_request_context(Arc::clone(&ctx)),
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => return Err(e),
+            Err(_) => {
+                self.mark_unhealthy_if_runtime_matches(idx, &runtime);
+                self.mark_needs_rebuild(idx);
+                return Err(RariError::timeout(format!(
+                    "set_request_context timed out after {} ms",
+                    self.timeout_ms
+                )));
+            }
+        }
+
+        Ok(LeasedRequestRuntime {
+            pool: Arc::clone(self),
+            idx,
+            runtime,
+            ctx,
+            _lease: lease,
+            timeout_ms: self.timeout_ms,
+            released: false,
+        })
+    }
+}

--- a/crates/rari/src/runtime/factory/pool/mod.rs
+++ b/crates/rari/src/runtime/factory/pool/mod.rs
@@ -27,11 +27,13 @@ use super::runtime::RariRuntime;
 mod broadcast;
 mod handle;
 mod interface;
+mod lease;
 mod strategy;
 #[cfg(test)]
 mod tests;
 
 pub use handle::PooledRuntime;
+pub use lease::LeasedRequestRuntime;
 pub use strategy::{PickStrategy, RoundRobinStrategy};
 
 use super::interface::JsRuntimeInterface;
@@ -78,6 +80,9 @@ pub struct JsRuntimePool {
     healthy: Vec<AtomicBool>,
     /// Unix millis when the slot was marked unhealthy; `0` if healthy / unknown.
     unhealthy_since_ms: Vec<AtomicU64>,
+    /// True after an immediate zero-healthy heal attempt until the slot recovers
+    /// or is freshly marked unhealthy. Prevents heal storms while quarantine runs.
+    heal_attempted: Vec<AtomicBool>,
     /// Per-slot lease so `with_request_context` cannot interleave on one runtime.
     slot_leases: Vec<Arc<AsyncMutex<()>>>,
     /// Soft in-flight stream counts for least-busy streaming admission.
@@ -163,6 +168,7 @@ impl JsRuntimePool {
 
         let healthy = runtimes.iter().map(|_| AtomicBool::new(true)).collect();
         let unhealthy_since_ms = runtimes.iter().map(|_| AtomicU64::new(0)).collect();
+        let heal_attempted = runtimes.iter().map(|_| AtomicBool::new(false)).collect();
         let slot_leases = (0..pool_size).map(|_| Arc::new(AsyncMutex::new(()))).collect();
         let stream_load = (0..pool_size).map(|_| Arc::new(AtomicUsize::new(0))).collect();
         let needs_rebuild = (0..pool_size).map(|_| AtomicBool::new(false)).collect();
@@ -174,6 +180,7 @@ impl JsRuntimePool {
             next_index: AtomicUsize::new(0),
             healthy,
             unhealthy_since_ms,
+            heal_attempted,
             slot_leases,
             stream_load,
             needs_rebuild,
@@ -250,13 +257,18 @@ impl JsRuntimePool {
         if since == 0 {
             return false;
         }
-        // Never leave the pool with zero healthy slots waiting on the heal delay —
-        // especially critical for pool size 1.
-        if self.healthy_count() == 0 {
+        let now = unix_now_ms();
+        let quarantine_elapsed = now.saturating_sub(since) >= self.heal_after_ms;
+        if quarantine_elapsed {
             return true;
         }
-        let now = unix_now_ms();
-        now.saturating_sub(since) >= self.heal_after_ms
+        // Never leave the pool with zero healthy slots waiting on the heal delay —
+        // allow one immediate attempt per outage, then enforce quarantine.
+        if self.healthy_count() == 0 {
+            let attempted = self.heal_attempted.get(idx).is_some_and(|f| f.load(Ordering::Acquire));
+            return !attempted;
+        }
+        false
     }
 
     fn slot_admissible_for_execute(
@@ -434,6 +446,9 @@ impl JsRuntimePool {
             if let Some(since) = self.unhealthy_since_ms.get(idx) {
                 since.store(unix_now_ms(), Ordering::Release);
             }
+            if let Some(attempted) = self.heal_attempted.get(idx) {
+                attempted.store(false, Ordering::Release);
+            }
             tracing::warn!("Marked JS runtime pool slot {} as unhealthy", idx);
         }
     }
@@ -443,6 +458,9 @@ impl JsRuntimePool {
             h.store(true, Ordering::Release);
             if let Some(since) = self.unhealthy_since_ms.get(idx) {
                 since.store(0, Ordering::Release);
+            }
+            if let Some(attempted) = self.heal_attempted.get(idx) {
+                attempted.store(false, Ordering::Release);
             }
             tracing::info!("Marked JS runtime pool slot {} as healthy", idx);
         }
@@ -476,6 +494,10 @@ impl JsRuntimePool {
                 return;
             }
 
+            if let Some(attempted) = self.heal_attempted.get(idx) {
+                attempted.store(true, Ordering::Release);
+            }
+
             let force_rebuild = self.needs_rebuild(idx);
             if !force_rebuild {
                 let Some(runtime) = self.runtime_at(idx) else {
@@ -504,13 +526,26 @@ impl JsRuntimePool {
             {
                 let hook = self.post_rebuild_hook.read().clone();
                 let resync_ok = if let Some(hook) = hook {
-                    match hook(idx, Arc::clone(&replacement)).await {
-                        Ok(()) => true,
-                        Err(e) => {
+                    match time::timeout(
+                        Duration::from_millis(self.timeout_ms),
+                        hook(idx, Arc::clone(&replacement)),
+                    )
+                    .await
+                    {
+                        Ok(Ok(())) => true,
+                        Ok(Err(e)) => {
                             tracing::error!(
                                 idx,
                                 error = %e,
                                 "Post-rebuild resync failed; keeping slot unhealthy"
+                            );
+                            false
+                        }
+                        Err(_) => {
+                            tracing::error!(
+                                idx,
+                                timeout_ms = self.timeout_ms,
+                                "Post-rebuild resync timed out; keeping slot unhealthy"
                             );
                             false
                         }

--- a/crates/rari/src/runtime/factory/pool/mod.rs
+++ b/crates/rari/src/runtime/factory/pool/mod.rs
@@ -3,6 +3,7 @@
 use std::{
     fmt::{self, Formatter, Result as FmtResult},
     future::Future,
+    pin::Pin,
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
@@ -48,6 +49,27 @@ pub const HEAL_DISABLED: u64 = u64::MAX;
 /// Creates a fresh isolate when heal rebuilds a quarantined slot.
 pub type RuntimeFactory = Arc<dyn Fn() -> Arc<dyn JsRuntimeInterface> + Send + Sync>;
 
+/// Decrements a slot's soft stream load when dropped.
+pub struct StreamingSlotGuard {
+    load: Arc<AtomicUsize>,
+}
+
+impl Drop for StreamingSlotGuard {
+    fn drop(&mut self) {
+        self.load.fetch_sub(1, Ordering::Release);
+    }
+}
+
+/// Called after a slot isolate is rebuilt and passes the basic probe.
+pub type PostRebuildHook = Arc<
+    dyn Fn(
+            usize,
+            Arc<dyn JsRuntimeInterface>,
+        ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>>
+        + Send
+        + Sync,
+>;
+
 pub struct JsRuntimePool {
     runtimes: Vec<RwLock<Arc<dyn JsRuntimeInterface>>>,
     runtime_factory: RuntimeFactory,
@@ -58,11 +80,15 @@ pub struct JsRuntimePool {
     unhealthy_since_ms: Vec<AtomicU64>,
     /// Per-slot lease so `with_request_context` cannot interleave on one runtime.
     slot_leases: Vec<Arc<AsyncMutex<()>>>,
+    /// Soft in-flight stream counts for least-busy streaming admission.
+    stream_load: Vec<Arc<AtomicUsize>>,
     /// Set when request-context cleanup fails or times out; blocks probe-only heal.
     needs_rebuild: Vec<AtomicBool>,
     setup_mode: AtomicBool,
     timeout_ms: u64,
     heal_after_ms: u64,
+    /// Optional app-level resync after isolate rebuild (pipelines + components).
+    post_rebuild_hook: parking_lot::RwLock<Option<PostRebuildHook>>,
 }
 
 #[expect(
@@ -138,6 +164,7 @@ impl JsRuntimePool {
         let healthy = runtimes.iter().map(|_| AtomicBool::new(true)).collect();
         let unhealthy_since_ms = runtimes.iter().map(|_| AtomicU64::new(0)).collect();
         let slot_leases = (0..pool_size).map(|_| Arc::new(AsyncMutex::new(()))).collect();
+        let stream_load = (0..pool_size).map(|_| Arc::new(AtomicUsize::new(0))).collect();
         let needs_rebuild = (0..pool_size).map(|_| AtomicBool::new(false)).collect();
 
         Ok(Arc::new(Self {
@@ -148,11 +175,17 @@ impl JsRuntimePool {
             healthy,
             unhealthy_since_ms,
             slot_leases,
+            stream_load,
             needs_rebuild,
             setup_mode: AtomicBool::new(false),
             timeout_ms,
             heal_after_ms,
+            post_rebuild_hook: parking_lot::RwLock::new(None),
         }))
+    }
+
+    pub fn set_post_rebuild_hook(&self, hook: PostRebuildHook) {
+        *self.post_rebuild_hook.write() = Some(hook);
     }
 
     pub fn size(&self) -> usize {
@@ -216,6 +249,11 @@ impl JsRuntimePool {
             self.unhealthy_since_ms.get(idx).map(|s| s.load(Ordering::Acquire)).unwrap_or(0);
         if since == 0 {
             return false;
+        }
+        // Never leave the pool with zero healthy slots waiting on the heal delay —
+        // especially critical for pool size 1.
+        if self.healthy_count() == 0 {
+            return true;
         }
         let now = unix_now_ms();
         now.saturating_sub(since) >= self.heal_after_ms
@@ -464,8 +502,35 @@ impl JsRuntimePool {
             if self.probe_runtime(idx, &replacement, probe_timeout_ms).await
                 && self.runtime_still_installed(idx, &replacement)
             {
-                self.clear_needs_rebuild(idx);
-                self.mark_healthy(idx);
+                let hook = self.post_rebuild_hook.read().clone();
+                let resync_ok = if let Some(hook) = hook {
+                    match hook(idx, Arc::clone(&replacement)).await {
+                        Ok(()) => true,
+                        Err(e) => {
+                            tracing::error!(
+                                idx,
+                                error = %e,
+                                "Post-rebuild resync failed; keeping slot unhealthy"
+                            );
+                            false
+                        }
+                    }
+                } else if self.runtimes.len() > 1 {
+                    tracing::error!(
+                        idx,
+                        "Rebuilt JS runtime pool slot left unhealthy: post-rebuild resync required for pool_size > 1"
+                    );
+                    false
+                } else {
+                    true
+                };
+
+                if resync_ok {
+                    self.clear_needs_rebuild(idx);
+                    self.mark_healthy(idx);
+                } else {
+                    self.refresh_unhealthy_timestamp(idx);
+                }
             } else {
                 tracing::warn!(
                     idx,
@@ -533,6 +598,55 @@ impl JsRuntimePool {
         Ok(PooledRuntime::new(idx, runtime, self.timeout_ms))
     }
 
+    /// Prefer healthy slots with the fewest in-flight streams (soft lease).
+    pub fn pick_least_busy(&self) -> Option<usize> {
+        let healthy_indices: Vec<usize> = self
+            .healthy
+            .iter()
+            .enumerate()
+            .filter_map(|(i, h)| if h.load(Ordering::Acquire) { Some(i) } else { None })
+            .collect();
+        if healthy_indices.is_empty() {
+            return None;
+        }
+
+        let min_load = healthy_indices
+            .iter()
+            .filter_map(|&i| self.stream_load.get(i).map(|c| c.load(Ordering::Acquire)))
+            .min()?;
+        let candidates: Vec<usize> = healthy_indices
+            .into_iter()
+            .filter(|&i| {
+                self.stream_load.get(i).is_some_and(|c| c.load(Ordering::Acquire) == min_load)
+            })
+            .collect();
+        self.pick_strategy
+            .pick(&candidates, &self.next_index)
+            .filter(|&idx| idx < self.runtimes.len() && self.is_healthy(idx))
+    }
+
+    /// Sticky streaming pick that increments soft load until the guard drops.
+    pub async fn pick_runtime_for_streaming(
+        &self,
+    ) -> Result<(PooledRuntime, StreamingSlotGuard), RariError> {
+        self.probe_and_heal().await;
+        let idx = self.pick_least_busy().ok_or_else(|| {
+            RariError::js_runtime("No healthy JS runtime available in pool".to_string())
+        })?;
+        let runtime = self.runtime_at(idx).ok_or_else(|| {
+            RariError::js_runtime("No healthy JS runtime available in pool".to_string())
+        })?;
+        let load = self.stream_load.get(idx).cloned().ok_or_else(|| {
+            RariError::js_runtime("No healthy JS runtime available in pool".to_string())
+        })?;
+        load.fetch_add(1, Ordering::AcqRel);
+        Ok((PooledRuntime::new(idx, runtime, self.timeout_ms), StreamingSlotGuard { load }))
+    }
+
+    pub fn stream_load_at(&self, idx: usize) -> usize {
+        self.stream_load.get(idx).map(|c| c.load(Ordering::Acquire)).unwrap_or(0)
+    }
+
     /// Load+evaluate on a single picked isolate.
     ///
     /// `ModuleId` values are isolate-local. For bootstrap / HMR that must reach every
@@ -593,12 +707,13 @@ impl JsRuntimePool {
             let Ok(op_result) =
                 time::timeout(Duration::from_millis(timeout_ms), op(Arc::clone(&runtime))).await
             else {
+                // A hung operation is not proof the isolate is dead. Only quarantine when
+                // cleanup fails or times out (isolate unresponsive).
                 let cleanup = time::timeout(
                     Duration::from_millis(timeout_ms),
                     runtime.clear_request_context_if_matches(Arc::clone(&ctx)),
                 )
                 .await;
-                pool.mark_unhealthy_if_runtime_matches(idx, &runtime);
                 match cleanup {
                     Ok(Ok(())) => {}
                     Ok(Err(cleanup_err)) => {
@@ -606,12 +721,14 @@ impl JsRuntimePool {
                             "Failed to clear request context after timeout: {}",
                             cleanup_err
                         );
+                        pool.mark_unhealthy_if_runtime_matches(idx, &runtime);
                         pool.mark_needs_rebuild(idx);
                     }
                     Err(_) => {
                         tracing::error!(
                             "Clearing request context timed out after {timeout_ms} ms; slot needs rebuild"
                         );
+                        pool.mark_unhealthy_if_runtime_matches(idx, &runtime);
                         pool.mark_needs_rebuild(idx);
                     }
                 }

--- a/crates/rari/src/runtime/factory/pool/tests.rs
+++ b/crates/rari/src/runtime/factory/pool/tests.rs
@@ -18,7 +18,10 @@ use tokio::{
 };
 
 use super::*;
-use crate::server::middleware::request_context::RequestContext;
+use crate::{
+    runtime::factory::interface::QueueStreamingScriptFuture,
+    server::middleware::request_context::RequestContext,
+};
 
 struct CountingRuntime {
     calls: Arc<AtomicUsize>,
@@ -126,10 +129,6 @@ impl JsRuntimeInterface for CountingRuntime {
         Box::pin(async move { Ok(()) })
     }
 
-    fn clear_request_context(&self) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
-        Box::pin(async move { Ok(()) })
-    }
-
     fn clear_request_context_if_matches(
         &self,
         _expected_context: Arc<RequestContext>,
@@ -137,20 +136,41 @@ impl JsRuntimeInterface for CountingRuntime {
         Box::pin(async move { Ok(()) })
     }
 
-    fn execute_script_with_request_context(
-        &self,
-        _request_context: Arc<RequestContext>,
-        script_name: String,
-        script_code: String,
-    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send>> {
-        self.execute_script(script_name, script_code)
-    }
-
     fn execute_script_for_streaming(
         &self,
+        _stream_id: String,
         _script_name: String,
         _script_code: String,
         _chunk_sender: mpsc::Sender<Result<Vec<u8>, RariError>>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn queue_script_for_streaming(
+        &self,
+        _stream_id: String,
+        _script_name: String,
+        _script_code: String,
+        _chunk_sender: mpsc::Sender<Result<Vec<u8>, RariError>>,
+        _request_context: Option<Arc<RequestContext>>,
+    ) -> QueueStreamingScriptFuture {
+        Box::pin(async move {
+            let completion: Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> =
+                Box::pin(async move { Ok(()) });
+            Ok(completion)
+        })
+    }
+
+    fn register_request_context(
+        &self,
+        _request_context: Arc<RequestContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn unregister_request_context(
+        &self,
+        _request_id: &str,
     ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
         Box::pin(async move { Ok(()) })
     }
@@ -182,10 +202,12 @@ fn pool_from_runtimes(
         healthy: (0..size).map(|_| AtomicBool::new(true)).collect(),
         unhealthy_since_ms: (0..size).map(|_| AtomicU64::new(0)).collect(),
         slot_leases: (0..size).map(|_| Arc::new(AsyncMutex::new(()))).collect(),
+        stream_load: (0..size).map(|_| Arc::new(AtomicUsize::new(0))).collect(),
         needs_rebuild: (0..size).map(|_| AtomicBool::new(false)).collect(),
         setup_mode: AtomicBool::new(false),
         timeout_ms,
         heal_after_ms,
+        post_rebuild_hook: parking_lot::RwLock::new(None),
     })
 }
 
@@ -319,10 +341,12 @@ async fn probe_and_heal_rebuilds_and_re_admits_when_probe_fails() -> Result<(), 
         healthy: vec![AtomicBool::new(true)],
         unhealthy_since_ms: vec![AtomicU64::new(0)],
         slot_leases: vec![Arc::new(AsyncMutex::new(()))],
+        stream_load: vec![Arc::new(AtomicUsize::new(0))],
         needs_rebuild: vec![AtomicBool::new(false)],
         setup_mode: AtomicBool::new(false),
         timeout_ms: DEFAULT_TIMEOUT_MS,
         heal_after_ms: 1,
+        post_rebuild_hook: parking_lot::RwLock::new(None),
     });
 
     pool.mark_unhealthy(0);
@@ -354,10 +378,12 @@ async fn probe_and_heal_keeps_unhealthy_when_rebuild_still_fails() -> Result<(),
         healthy: vec![AtomicBool::new(true)],
         unhealthy_since_ms: vec![AtomicU64::new(0)],
         slot_leases: vec![Arc::new(AsyncMutex::new(()))],
+        stream_load: vec![Arc::new(AtomicUsize::new(0))],
         needs_rebuild: vec![AtomicBool::new(false)],
         setup_mode: AtomicBool::new(false),
         timeout_ms: DEFAULT_TIMEOUT_MS,
         heal_after_ms: 1,
+        post_rebuild_hook: parking_lot::RwLock::new(None),
     });
 
     pool.mark_unhealthy(0);
@@ -495,10 +521,6 @@ impl JsRuntimeInterface for BroadcastingRuntime {
         Box::pin(async move { Ok(()) })
     }
 
-    fn clear_request_context(&self) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
-        Box::pin(async move { Ok(()) })
-    }
-
     fn clear_request_context_if_matches(
         &self,
         _expected_context: Arc<RequestContext>,
@@ -506,20 +528,41 @@ impl JsRuntimeInterface for BroadcastingRuntime {
         Box::pin(async move { Ok(()) })
     }
 
-    fn execute_script_with_request_context(
-        &self,
-        _request_context: Arc<RequestContext>,
-        script_name: String,
-        script_code: String,
-    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send>> {
-        self.execute_script(script_name, script_code)
-    }
-
     fn execute_script_for_streaming(
         &self,
+        _stream_id: String,
         _script_name: String,
         _script_code: String,
         _chunk_sender: mpsc::Sender<Result<Vec<u8>, RariError>>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn queue_script_for_streaming(
+        &self,
+        _stream_id: String,
+        _script_name: String,
+        _script_code: String,
+        _chunk_sender: mpsc::Sender<Result<Vec<u8>, RariError>>,
+        _request_context: Option<Arc<RequestContext>>,
+    ) -> QueueStreamingScriptFuture {
+        Box::pin(async move {
+            let completion: Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> =
+                Box::pin(async move { Ok(()) });
+            Ok(completion)
+        })
+    }
+
+    fn register_request_context(
+        &self,
+        _request_context: Arc<RequestContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn unregister_request_context(
+        &self,
+        _request_id: &str,
     ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
         Box::pin(async move { Ok(()) })
     }
@@ -862,10 +905,6 @@ impl JsRuntimeInterface for RequestContextRuntime {
         })
     }
 
-    fn clear_request_context(&self) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
-        Box::pin(async move { Ok(()) })
-    }
-
     fn clear_request_context_if_matches(
         &self,
         expected_context: Arc<RequestContext>,
@@ -890,20 +929,41 @@ impl JsRuntimeInterface for RequestContextRuntime {
         })
     }
 
-    fn execute_script_with_request_context(
-        &self,
-        _request_context: Arc<RequestContext>,
-        script_name: String,
-        script_code: String,
-    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send>> {
-        self.execute_script(script_name, script_code)
-    }
-
     fn execute_script_for_streaming(
         &self,
+        _stream_id: String,
         _script_name: String,
         _script_code: String,
         _chunk_sender: mpsc::Sender<Result<Vec<u8>, RariError>>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn queue_script_for_streaming(
+        &self,
+        _stream_id: String,
+        _script_name: String,
+        _script_code: String,
+        _chunk_sender: mpsc::Sender<Result<Vec<u8>, RariError>>,
+        _request_context: Option<Arc<RequestContext>>,
+    ) -> QueueStreamingScriptFuture {
+        Box::pin(async move {
+            let completion: Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> =
+                Box::pin(async move { Ok(()) });
+            Ok(completion)
+        })
+    }
+
+    fn register_request_context(
+        &self,
+        _request_context: Arc<RequestContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn unregister_request_context(
+        &self,
+        _request_id: &str,
     ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
         Box::pin(async move { Ok(()) })
     }
@@ -1160,10 +1220,12 @@ async fn with_request_context_returns_cleanup_error_and_quarantines() {
         healthy: vec![AtomicBool::new(true)],
         unhealthy_since_ms: vec![AtomicU64::new(0)],
         slot_leases: vec![Arc::new(AsyncMutex::new(()))],
+        stream_load: vec![Arc::new(AtomicUsize::new(0))],
         needs_rebuild: vec![AtomicBool::new(false)],
         setup_mode: AtomicBool::new(false),
         timeout_ms: DEFAULT_TIMEOUT_MS,
         heal_after_ms: 1,
+        post_rebuild_hook: parking_lot::RwLock::new(None),
     });
 
     let ctx = Arc::new(RequestContext::new("/cleanup_fails".to_string()));
@@ -1248,6 +1310,78 @@ async fn setup_mode_error_message_uses_executed_not_total() {
         "error must report failed/attempted (1 of 2), got: {msg}"
     );
     assert!(!msg.contains("1 of 4 runtimes"), "error must not use total pool size, got: {msg}");
+}
+
+#[tokio::test]
+async fn with_request_context_op_timeout_keeps_slot_healthy_when_cleanup_ok() {
+    let last_seen = Arc::new(Mutex::new(None));
+    let runtime: Arc<dyn JsRuntimeInterface> = Arc::new(RequestContextRuntime {
+        last_seen: Arc::clone(&last_seen),
+        fail_cleanup: Arc::new(AtomicBool::new(false)),
+    });
+    let pool = pool_from_runtimes(vec![runtime], 30, HEAL_DISABLED);
+    let ctx = Arc::new(RequestContext::new("/timeout_ok_cleanup".to_string()));
+
+    let result = pool
+        .with_request_context(Arc::clone(&ctx), |_runtime| async {
+            sleep(Duration::from_millis(80)).await;
+            Ok(1_i32)
+        })
+        .await;
+
+    assert!(result.is_err(), "expected timeout error");
+    let msg = match result {
+        Ok(_) => String::new(),
+        Err(e) => e.to_string(),
+    };
+    assert!(msg.contains("timed out"), "got: {msg}");
+    assert!(
+        pool.is_healthy(0),
+        "successful cleanup after op timeout must not quarantine the only slot"
+    );
+    assert!(
+        last_seen.lock().map(|guard| guard.is_none()).unwrap_or(false),
+        "request context must be cleared after timed-out op"
+    );
+}
+
+#[tokio::test]
+async fn probe_and_heal_immediately_when_no_healthy_slots() -> Result<(), RariError> {
+    let runtime = CountingRuntime::new(Arc::new(AtomicUsize::new(0)));
+    let pool = pool_from_runtimes(vec![Arc::new(runtime)], DEFAULT_TIMEOUT_MS, 60_000);
+    pool.mark_unhealthy(0);
+    assert_eq!(pool.healthy_count(), 0);
+
+    pool.probe_and_heal().await;
+    assert!(pool.is_healthy(0), "empty pool must heal immediately without waiting heal_after_ms");
+    Ok(())
+}
+
+#[tokio::test]
+async fn pick_runtime_for_streaming_prefers_least_busy_slot() -> Result<(), RariError> {
+    let (pool, _counters) = build_pool_with_counters(3);
+
+    let (first, guard0) = pool.pick_runtime_for_streaming().await?;
+    assert_eq!(pool.stream_load_at(first.idx()), 1);
+
+    let (second, guard1) = pool.pick_runtime_for_streaming().await?;
+    assert_ne!(second.idx(), first.idx());
+    assert_eq!(pool.stream_load_at(second.idx()), 1);
+
+    let (third, guard2) = pool.pick_runtime_for_streaming().await?;
+    assert_ne!(third.idx(), first.idx());
+    assert_ne!(third.idx(), second.idx());
+
+    let busy_idx = first.idx();
+    drop(guard0);
+    assert_eq!(pool.stream_load_at(busy_idx), 0);
+
+    let (again, _guard) = pool.pick_runtime_for_streaming().await?;
+    assert_eq!(again.idx(), busy_idx, "freed slot should be preferred over busier ones");
+
+    drop(guard1);
+    drop(guard2);
+    Ok(())
 }
 
 #[tokio::test]

--- a/crates/rari/src/runtime/factory/pool/tests.rs
+++ b/crates/rari/src/runtime/factory/pool/tests.rs
@@ -201,6 +201,7 @@ fn pool_from_runtimes(
         next_index: AtomicUsize::new(0),
         healthy: (0..size).map(|_| AtomicBool::new(true)).collect(),
         unhealthy_since_ms: (0..size).map(|_| AtomicU64::new(0)).collect(),
+        heal_attempted: (0..size).map(|_| AtomicBool::new(false)).collect(),
         slot_leases: (0..size).map(|_| Arc::new(AsyncMutex::new(()))).collect(),
         stream_load: (0..size).map(|_| Arc::new(AtomicUsize::new(0))).collect(),
         needs_rebuild: (0..size).map(|_| AtomicBool::new(false)).collect(),
@@ -340,6 +341,7 @@ async fn probe_and_heal_rebuilds_and_re_admits_when_probe_fails() -> Result<(), 
         next_index: AtomicUsize::new(0),
         healthy: vec![AtomicBool::new(true)],
         unhealthy_since_ms: vec![AtomicU64::new(0)],
+        heal_attempted: vec![AtomicBool::new(false)],
         slot_leases: vec![Arc::new(AsyncMutex::new(()))],
         stream_load: vec![Arc::new(AtomicUsize::new(0))],
         needs_rebuild: vec![AtomicBool::new(false)],
@@ -377,6 +379,7 @@ async fn probe_and_heal_keeps_unhealthy_when_rebuild_still_fails() -> Result<(),
         next_index: AtomicUsize::new(0),
         healthy: vec![AtomicBool::new(true)],
         unhealthy_since_ms: vec![AtomicU64::new(0)],
+        heal_attempted: vec![AtomicBool::new(false)],
         slot_leases: vec![Arc::new(AsyncMutex::new(()))],
         stream_load: vec![Arc::new(AtomicUsize::new(0))],
         needs_rebuild: vec![AtomicBool::new(false)],
@@ -1044,6 +1047,21 @@ async fn load_and_evaluate_on_picked_returns_pool_unavailable_when_all_unhealthy
 }
 
 #[tokio::test]
+#[expect(clippy::expect_used)]
+async fn acquire_request_runtime_is_sticky_across_scripts() {
+    let (pool, _) = build_pool_with_distinct_request_context_runtimes(2);
+    let ctx = Arc::new(RequestContext::new("/sticky_lease".to_string()));
+
+    let leased = pool.acquire_request_runtime(Arc::clone(&ctx)).await.expect("acquire lease");
+    let first = Arc::clone(leased.runtime());
+    assert!(leased.execute_script("a".into(), "1".into()).await.is_ok(), "first script");
+    let second = Arc::clone(leased.runtime());
+    assert!(leased.execute_script("b".into(), "2".into()).await.is_ok(), "second script");
+    assert!(Arc::ptr_eq(&first, &second), "sticky lease must keep the same isolate across scripts");
+    assert!(leased.release().await.is_ok(), "release");
+}
+
+#[tokio::test]
 async fn with_request_context_runs_op_and_cleans_up() {
     let (pool, last_seens) = build_pool_with_distinct_request_context_runtimes(2);
 
@@ -1219,6 +1237,7 @@ async fn with_request_context_returns_cleanup_error_and_quarantines() {
         next_index: AtomicUsize::new(0),
         healthy: vec![AtomicBool::new(true)],
         unhealthy_since_ms: vec![AtomicU64::new(0)],
+        heal_attempted: vec![AtomicBool::new(false)],
         slot_leases: vec![Arc::new(AsyncMutex::new(()))],
         stream_load: vec![Arc::new(AtomicUsize::new(0))],
         needs_rebuild: vec![AtomicBool::new(false)],

--- a/crates/rari/src/runtime/factory/runtime.rs
+++ b/crates/rari/src/runtime/factory/runtime.rs
@@ -11,7 +11,7 @@ use std::{
 use base64::engine::general_purpose::STANDARD;
 use deno_core::{ModuleSpecifier, v8};
 use rari_error::RariError;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde_json::Value;
 use tokio::{
     runtime::Builder,
@@ -99,6 +99,7 @@ struct PendingBatch {
 struct PendingStream {
     stream_id: String,
     slot_key: String,
+    request_id: Option<String>,
     result_tx: Option<oneshot::Sender<Result<(), RariError>>>,
     start: Instant,
     timeout: Duration,
@@ -307,6 +308,7 @@ impl RariRuntime {
                             pending_batches.retain(|b| b.remaining > 0 && b.start.elapsed() < b.timeout);
                             check_pending_streams(&mut js_runtime, &mut pending_streams);
                             pending_streams.retain(|s| !s.done);
+                            prune_orphaned_settled(&js_runtime, &pending_streams);
                         } else {
                             priority_streak = 0;
                             match recv_js_request(&mut priority_receiver, &mut request_receiver).await {
@@ -344,6 +346,7 @@ impl RariRuntime {
                                     break;
                                 }
                             }
+                            prune_orphaned_settled(&js_runtime, &pending_streams);
                         }
                     }
 
@@ -640,6 +643,7 @@ async fn handle_js_request(
             result_tx,
         } => {
             if let Some(request_context) = request_context {
+                let request_id = request_context.request_id().to_string();
                 let op_state = js_runtime.op_state();
                 let mut borrowed = op_state.borrow_mut();
                 if let Some(store) = borrowed.try_borrow_mut::<RequestContextStore>() {
@@ -649,30 +653,60 @@ async fn handle_js_request(
                     store.insert(request_context);
                     borrowed.put(store);
                 }
-            }
-            match executor::start_streaming_script(
-                js_runtime,
-                &script_name,
-                &script_code,
-                &stream_id,
-                chunk_sender,
-            ) {
-                Ok(slot_key) => {
-                    pending_streams.push(PendingStream {
-                        stream_id,
-                        slot_key,
-                        result_tx: Some(result_tx),
-                        start: Instant::now(),
-                        timeout: Duration::from_millis(executor::streaming_promise_timeout_ms()),
-                        done: false,
-                    });
-                }
-                Err(e) => {
-                    if is_runtime_restart_needed(&e) {
-                        let _ = result_tx.send(Err(create_graceful_error()));
-                        return Err(RariError::internal("Runtime restart needed".to_string()));
+                drop(borrowed);
+                match executor::start_streaming_script(
+                    js_runtime,
+                    &script_name,
+                    &script_code,
+                    &stream_id,
+                    chunk_sender,
+                ) {
+                    Ok(slot_key) => {
+                        pending_streams.push(PendingStream {
+                            stream_id,
+                            slot_key,
+                            request_id: Some(request_id),
+                            result_tx: Some(result_tx),
+                            start: Instant::now(),
+                            timeout: Duration::from_millis(executor::streaming_promise_timeout_ms()),
+                            done: false,
+                        });
                     }
-                    let _ = result_tx.send(Err(e));
+                    Err(e) => {
+                        clear_stream_request_context(js_runtime, Some(&request_id));
+                        if is_runtime_restart_needed(&e) {
+                            let _ = result_tx.send(Err(create_graceful_error()));
+                            return Err(RariError::internal("Runtime restart needed".to_string()));
+                        }
+                        let _ = result_tx.send(Err(e));
+                    }
+                }
+            } else {
+                match executor::start_streaming_script(
+                    js_runtime,
+                    &script_name,
+                    &script_code,
+                    &stream_id,
+                    chunk_sender,
+                ) {
+                    Ok(slot_key) => {
+                        pending_streams.push(PendingStream {
+                            stream_id,
+                            slot_key,
+                            request_id: None,
+                            result_tx: Some(result_tx),
+                            start: Instant::now(),
+                            timeout: Duration::from_millis(executor::streaming_promise_timeout_ms()),
+                            done: false,
+                        });
+                    }
+                    Err(e) => {
+                        if is_runtime_restart_needed(&e) {
+                            let _ = result_tx.send(Err(create_graceful_error()));
+                            return Err(RariError::internal("Runtime restart needed".to_string()));
+                        }
+                        let _ = result_tx.send(Err(e));
+                    }
                 }
             }
         }
@@ -992,6 +1026,26 @@ fn take_stream_sender(
     borrowed.try_borrow_mut::<StreamOpState>().and_then(|state| state.take_sender(stream_id))
 }
 
+fn clear_stream_request_context(js_runtime: &deno_core::JsRuntime, request_id: Option<&str>) {
+    let Some(request_id) = request_id.filter(|id| !id.is_empty()) else {
+        return;
+    };
+    let op_state = js_runtime.op_state();
+    let mut borrowed = op_state.borrow_mut();
+    if let Some(store) = borrowed.try_borrow_mut::<RequestContextStore>() {
+        store.remove(request_id);
+    }
+}
+
+fn prune_orphaned_settled(js_runtime: &deno_core::JsRuntime, pending_streams: &[PendingStream]) {
+    let active: FxHashSet<&str> = pending_streams.iter().map(|s| s.stream_id.as_str()).collect();
+    let op_state = js_runtime.op_state();
+    let mut borrowed = op_state.borrow_mut();
+    if let Some(state) = borrowed.try_borrow_mut::<StreamOpState>() {
+        state.settled.retain(|id, _| active.contains(id.as_str()));
+    }
+}
+
 fn fail_pending_stream(
     js_runtime: &mut deno_core::JsRuntime,
     stream: &mut PendingStream,
@@ -1020,6 +1074,7 @@ fn fail_pending_stream(
             let _ = state.take_settled(&stream.stream_id);
         }
     }
+    clear_stream_request_context(js_runtime, stream.request_id.as_deref());
     if let Some(tx) = stream.result_tx.take() {
         let _ = tx.send(Err(err));
     }
@@ -1080,6 +1135,7 @@ fn check_pending_streams(
             };
             let _ = sender.try_send(Err(stream_err.clone()));
             if result.is_ok() {
+                clear_stream_request_context(js_runtime, stream.request_id.as_deref());
                 if let Some(tx) = stream.result_tx.take() {
                     let _ = tx.send(Err(stream_err));
                 }
@@ -1088,6 +1144,7 @@ fn check_pending_streams(
             }
         }
 
+        clear_stream_request_context(js_runtime, stream.request_id.as_deref());
         if let Some(tx) = stream.result_tx.take() {
             let _ = tx.send(result);
         }

--- a/crates/rari/src/runtime/factory/runtime.rs
+++ b/crates/rari/src/runtime/factory/runtime.rs
@@ -253,18 +253,6 @@ impl RariRuntime {
                                 if let Ok(Err(e)) = event_loop_result {
                                     eprintln!("[rari] Event loop error: {e}");
                                     if is_runtime_restart_needed(&e) {
-                                        for batch in pending_batches.drain(..) {
-                                            for sender in batch.senders.into_iter().flatten() {
-                                                let _ = sender.send(Err(create_graceful_error()));
-                                            }
-                                        }
-                                        for mut stream in pending_streams.drain(..) {
-                                            fail_pending_stream(
-                                                &mut js_runtime,
-                                                &mut stream,
-                                                create_graceful_error(),
-                                            );
-                                        }
                                         break;
                                     }
                                 }
@@ -308,18 +296,6 @@ impl RariRuntime {
                                         if let Ok(Err(e)) = event_loop_result {
                                             eprintln!("[rari] Event loop error: {e}");
                                             if is_runtime_restart_needed(&e) {
-                                                for batch in pending_batches.drain(..) {
-                                                    for sender in batch.senders.into_iter().flatten() {
-                                                        let _ = sender.send(Err(create_graceful_error()));
-                                                    }
-                                                }
-                                                for mut stream in pending_streams.drain(..) {
-                                                    fail_pending_stream(
-                                                        &mut js_runtime,
-                                                        &mut stream,
-                                                        create_graceful_error(),
-                                                    );
-                                                }
                                                 break;
                                             }
                                         }
@@ -369,6 +345,19 @@ impl RariRuntime {
                                 }
                             }
                         }
+                    }
+
+                    for batch in pending_batches.drain(..) {
+                        for sender in batch.senders.into_iter().flatten() {
+                            let _ = sender.send(Err(create_graceful_error()));
+                        }
+                    }
+                    for mut stream in pending_streams.drain(..) {
+                        fail_pending_stream(
+                            &mut js_runtime,
+                            &mut stream,
+                            create_graceful_error(),
+                        );
                     }
 
                     if !continue_processing {

--- a/crates/rari/src/runtime/factory/runtime.rs
+++ b/crates/rari/src/runtime/factory/runtime.rs
@@ -24,7 +24,7 @@ use crate::{
         factory::{
             component_ops::pending_component_id,
             executor::{self, execute_script},
-            interface::{AsyncBatchResult, JsRuntimeInterface},
+            interface::{AsyncBatchResult, JsRuntimeInterface, QueueStreamingScriptFuture},
             runtime_builder::build_js_runtime,
             utils::{
                 self,
@@ -38,6 +38,7 @@ use crate::{
             },
         },
         module_loader::RariModuleLoader,
+        ops::{RequestContextStore, StreamOpState},
     },
     server::{actions::action_form_state_sync_script, middleware::request_context::RequestContext},
     with_scope,
@@ -95,6 +96,15 @@ struct PendingBatch {
     batch_id: u64,
 }
 
+struct PendingStream {
+    stream_id: String,
+    slot_key: String,
+    result_tx: Option<oneshot::Sender<Result<(), RariError>>>,
+    start: Instant,
+    timeout: Duration,
+    done: bool,
+}
+
 enum JsRequest {
     ExecuteScript {
         script_name: String,
@@ -130,23 +140,24 @@ enum JsRequest {
         request_context: Arc<RequestContext>,
         result_tx: oneshot::Sender<Result<(), RariError>>,
     },
-    ClearRequestContext {
-        result_tx: oneshot::Sender<Result<(), RariError>>,
-    },
     ClearRequestContextIfMatches {
         expected_context: Arc<RequestContext>,
         result_tx: oneshot::Sender<Result<(), RariError>>,
     },
-    ExecuteScriptWithRequestContext {
-        request_context: Arc<RequestContext>,
-        script_name: String,
-        script_code: String,
-        result_tx: oneshot::Sender<Result<Value, RariError>>,
-    },
     ExecuteScriptForStreaming {
+        stream_id: String,
         script_name: String,
         script_code: String,
         chunk_sender: mpsc::Sender<Result<Vec<u8>, RariError>>,
+        request_context: Option<Arc<RequestContext>>,
+        result_tx: oneshot::Sender<Result<(), RariError>>,
+    },
+    RegisterRequestContext {
+        request_context: Arc<RequestContext>,
+        result_tx: oneshot::Sender<Result<(), RariError>>,
+    },
+    UnregisterRequestContext {
+        request_id: String,
         result_tx: oneshot::Sender<Result<(), RariError>>,
     },
 }
@@ -159,7 +170,9 @@ pub struct RariRuntime {
 
 fn is_priority_js_request(req: &JsRequest) -> bool {
     match req {
-        JsRequest::ExecuteScriptWithRequestContext { .. } => true,
+        JsRequest::ExecuteScriptForStreaming { .. } | JsRequest::RegisterRequestContext { .. } => {
+            true
+        }
         JsRequest::ExecuteScript { script_name, .. } => script_name.starts_with("execute_action_"),
         _ => false,
     }
@@ -212,30 +225,16 @@ impl RariRuntime {
 
                     let mut continue_processing = true;
                     let mut pending_batches: Vec<PendingBatch> = Vec::new();
+                    let mut pending_streams: Vec<PendingStream> = Vec::new();
                     let mut batch_id_counter: u64 = 0;
 
                     while continue_processing {
-                        if pending_batches.is_empty() {
-                            match recv_js_request(&mut priority_receiver, &mut request_receiver).await {
-                                Some(req) => {
-                                    let result = handle_js_request(
-                                        req,
-                                        &mut js_runtime,
-                                        &module_loader,
-                                        &mut continue_processing,
-                                        &mut pending_batches,
-                                        &mut batch_id_counter,
-                                    ).await;
-                                    if let Err(e) = result {
-                                        eprintln!("[rari] Error processing request: {e}");
-                                        break;
-                                    }
-                                }
-                                None => {
-                                    continue_processing = false;
-                                }
-                            }
-                        } else {
+                        let has_pending =
+                            !pending_batches.is_empty() || !pending_streams.is_empty();
+                        if has_pending {
+                            // Short polls keep Suspense timers and chunk ops progressing under load.
+                            // Longer polls delay timer wakeups and stretch stream latency.
+                            let pump_budget_ms = if pending_streams.is_empty() { 50 } else { 2 };
                             tokio::select! {
                                 biased;
                                 request = recv_js_request(&mut priority_receiver, &mut request_receiver) => {
@@ -247,6 +246,7 @@ impl RariRuntime {
                                                 &module_loader,
                                                 &mut continue_processing,
                                                 &mut pending_batches,
+                                                &mut pending_streams,
                                                 &mut batch_id_counter,
                                             ).await;
                                             if let Err(e) = result {
@@ -260,9 +260,9 @@ impl RariRuntime {
                                     }
                                 }
                                 event_loop_result = time::timeout(
-                                    Duration::from_millis(50),
+                                    Duration::from_millis(pump_budget_ms),
                                     utils::v8::run_event_loop_with_error_handling(
-                                        &mut js_runtime, "concurrent batch"
+                                        &mut js_runtime, "concurrent pending"
                                     ),
                                 ) => {
                                     if let Ok(Err(e)) = event_loop_result {
@@ -273,6 +273,13 @@ impl RariRuntime {
                                                     let _ = sender.send(Err(create_graceful_error()));
                                                 }
                                             }
+                                            for mut stream in pending_streams.drain(..) {
+                                                fail_pending_stream(
+                                                    &mut js_runtime,
+                                                    &mut stream,
+                                                    create_graceful_error(),
+                                                );
+                                            }
                                             break;
                                         }
                                     }
@@ -281,12 +288,35 @@ impl RariRuntime {
 
                             check_pending_batches(&mut js_runtime, &mut pending_batches);
                             pending_batches.retain(|b| b.remaining > 0 && b.start.elapsed() < b.timeout);
-                        }
+                            check_pending_streams(&mut js_runtime, &mut pending_streams);
+                            pending_streams.retain(|s| !s.done);
+                        } else {
+                            match recv_js_request(&mut priority_receiver, &mut request_receiver).await {
+                                Some(req) => {
+                                    let result = handle_js_request(
+                                        req,
+                                        &mut js_runtime,
+                                        &module_loader,
+                                        &mut continue_processing,
+                                        &mut pending_batches,
+                                        &mut pending_streams,
+                                        &mut batch_id_counter,
+                                    ).await;
+                                    if let Err(e) = result {
+                                        eprintln!("[rari] Error processing request: {e}");
+                                        break;
+                                    }
+                                }
+                                None => {
+                                    continue_processing = false;
+                                }
+                            }
 
-                        let _ = time::timeout(
-                            Duration::from_millis(10),
-                            js_runtime.run_event_loop(PollEventLoopOptions::default()),
-                        ).await;
+                            let _ = time::timeout(
+                                Duration::from_millis(10),
+                                js_runtime.run_event_loop(PollEventLoopOptions::default()),
+                            ).await;
+                        }
                     }
 
                     if !continue_processing {
@@ -458,6 +488,7 @@ async fn handle_js_request(
     module_loader: &Rc<RariModuleLoader>,
     continue_processing: &mut bool,
     pending_batches: &mut Vec<PendingBatch>,
+    pending_streams: &mut Vec<PendingStream>,
     batch_id_counter: &mut u64,
 ) -> Result<(), RariError> {
     match request {
@@ -542,11 +573,6 @@ async fn handle_js_request(
             js_runtime.op_state().borrow_mut().put(request_context);
             let _ = result_tx.send(Ok(()));
         }
-        JsRequest::ClearRequestContext { result_tx } => {
-            js_runtime.op_state().borrow_mut().try_take::<Arc<RequestContext>>();
-            clear_action_form_state(js_runtime);
-            let _ = result_tx.send(Ok(()));
-        }
         JsRequest::ClearRequestContextIfMatches { expected_context, result_tx } => {
             let should_clear = {
                 let op_state = js_runtime.op_state();
@@ -564,56 +590,70 @@ async fn handle_js_request(
             }
             let _ = result_tx.send(Ok(()));
         }
-        JsRequest::ExecuteScriptWithRequestContext {
-            request_context,
-            script_name,
-            script_code,
-            result_tx,
-        } => {
-            let previous_context =
-                js_runtime.op_state().borrow_mut().try_take::<Arc<RequestContext>>();
-            clear_page_cache_tags(js_runtime);
-            reset_use_cache_dynamic_context(js_runtime);
-            sync_action_form_state_for_context(js_runtime, &request_context);
-            js_runtime.op_state().borrow_mut().put(request_context);
-            let result =
-                execute_script(js_runtime, module_loader, &script_name, &script_code).await;
-            js_runtime.op_state().borrow_mut().try_take::<Arc<RequestContext>>();
-            if let Some(previous_context) = previous_context {
-                sync_action_form_state_for_context(js_runtime, &previous_context);
-                js_runtime.op_state().borrow_mut().put(previous_context);
-            } else {
-                clear_action_form_state(js_runtime);
-            }
-            if let Err(e) = &result
-                && is_runtime_restart_needed(e)
-            {
-                let _ = result_tx.send(Err(create_graceful_error()));
-                return Err(RariError::internal("Runtime restart needed".to_string()));
-            }
-            let _ = result_tx.send(result);
-        }
         JsRequest::ExecuteScriptForStreaming {
+            stream_id,
             script_name,
             script_code,
             chunk_sender,
+            request_context,
             result_tx,
         } => {
-            let result = executor::execute_script_for_streaming(
+            if let Some(request_context) = request_context {
+                let op_state = js_runtime.op_state();
+                let mut borrowed = op_state.borrow_mut();
+                if let Some(store) = borrowed.try_borrow_mut::<RequestContextStore>() {
+                    store.insert(request_context);
+                } else {
+                    let mut store = RequestContextStore::default();
+                    store.insert(request_context);
+                    borrowed.put(store);
+                }
+            }
+            match executor::start_streaming_script(
                 js_runtime,
-                module_loader,
                 &script_name,
                 &script_code,
+                &stream_id,
                 chunk_sender,
-            )
-            .await;
-            if let Err(e) = &result
-                && is_runtime_restart_needed(e)
-            {
-                let _ = result_tx.send(Err(create_graceful_error()));
-                return Err(RariError::internal("Runtime restart needed".to_string()));
+            ) {
+                Ok(slot_key) => {
+                    pending_streams.push(PendingStream {
+                        stream_id,
+                        slot_key,
+                        result_tx: Some(result_tx),
+                        start: Instant::now(),
+                        timeout: Duration::from_millis(executor::streaming_promise_timeout_ms()),
+                        done: false,
+                    });
+                }
+                Err(e) => {
+                    if is_runtime_restart_needed(&e) {
+                        let _ = result_tx.send(Err(create_graceful_error()));
+                        return Err(RariError::internal("Runtime restart needed".to_string()));
+                    }
+                    let _ = result_tx.send(Err(e));
+                }
             }
-            let _ = result_tx.send(result);
+        }
+        JsRequest::RegisterRequestContext { request_context, result_tx } => {
+            let op_state = js_runtime.op_state();
+            let mut borrowed = op_state.borrow_mut();
+            if let Some(store) = borrowed.try_borrow_mut::<RequestContextStore>() {
+                store.insert(request_context);
+            } else {
+                let mut store = RequestContextStore::default();
+                store.insert(request_context);
+                borrowed.put(store);
+            }
+            let _ = result_tx.send(Ok(()));
+        }
+        JsRequest::UnregisterRequestContext { request_id, result_tx } => {
+            let op_state = js_runtime.op_state();
+            let mut borrowed = op_state.borrow_mut();
+            if let Some(store) = borrowed.try_borrow_mut::<RequestContextStore>() {
+                store.remove(&request_id);
+            }
+            let _ = result_tx.send(Ok(()));
         }
     }
     Ok(())
@@ -902,6 +942,118 @@ fn check_pending_batches(
     }
 }
 
+fn take_stream_sender(
+    js_runtime: &deno_core::JsRuntime,
+    stream_id: &str,
+) -> Option<mpsc::Sender<Result<Vec<u8>, RariError>>> {
+    let op_state = js_runtime.op_state();
+    let mut borrowed = op_state.borrow_mut();
+    borrowed.try_borrow_mut::<StreamOpState>().and_then(|state| state.take_sender(stream_id))
+}
+
+fn fail_pending_stream(
+    js_runtime: &mut deno_core::JsRuntime,
+    stream: &mut PendingStream,
+    err: RariError,
+) {
+    let slot_key = &stream.slot_key;
+    let cleanup = format!(
+        r"(function() {{
+            if (globalThis['~rari_concurrent'] && globalThis['~rari_concurrent']['{slot_key}']) {{
+                delete globalThis['~rari_concurrent']['{slot_key}'];
+            }}
+            if (globalThis['{slot_key}']) {{
+                delete globalThis['{slot_key}'];
+            }}
+        }})()"
+    );
+    let _ = js_runtime.execute_script(format!("cleanup_stream_fail_{slot_key}"), cleanup);
+
+    if let Some(sender) = take_stream_sender(js_runtime, &stream.stream_id) {
+        let _ = sender.try_send(Err(err.clone()));
+    }
+    {
+        let op_state = js_runtime.op_state();
+        let mut borrowed = op_state.borrow_mut();
+        if let Some(state) = borrowed.try_borrow_mut::<StreamOpState>() {
+            let _ = state.take_settled(&stream.stream_id);
+        }
+    }
+    if let Some(tx) = stream.result_tx.take() {
+        let _ = tx.send(Err(err));
+    }
+    stream.done = true;
+}
+
+fn check_pending_streams(
+    js_runtime: &mut deno_core::JsRuntime,
+    pending_streams: &mut [PendingStream],
+) {
+    for stream in pending_streams.iter_mut() {
+        if stream.done {
+            continue;
+        }
+
+        let settled = {
+            let op_state = js_runtime.op_state();
+            let mut borrowed = op_state.borrow_mut();
+            borrowed
+                .try_borrow_mut::<StreamOpState>()
+                .and_then(|state| state.take_settled(&stream.stream_id))
+        };
+
+        let Some(settled) = settled else {
+            if stream.start.elapsed() >= stream.timeout {
+                let err = RariError::timeout(format!(
+                    "Streaming script timed out for '{}'",
+                    stream.stream_id
+                ));
+                fail_pending_stream(js_runtime, stream, err);
+            }
+            continue;
+        };
+
+        let slot_key = &stream.slot_key;
+        let cleanup = format!(
+            r"(function() {{
+                if (globalThis['~rari_concurrent'] && globalThis['~rari_concurrent']['{slot_key}']) {{
+                    delete globalThis['~rari_concurrent']['{slot_key}'];
+                }}
+                if (globalThis['{slot_key}']) {{
+                    delete globalThis['{slot_key}'];
+                }}
+            }})()"
+        );
+        let _ = js_runtime.execute_script(format!("cleanup_stream_{slot_key}"), cleanup);
+
+        let result = settled.map_err(RariError::js_execution);
+
+        let leftover = take_stream_sender(js_runtime, &stream.stream_id);
+        if let Some(sender) = leftover {
+            let stream_err = match &result {
+                Err(err) => err.clone(),
+                Ok(()) => RariError::js_execution(format!(
+                    "Streaming script for '{}' ended without completing the stream",
+                    stream.stream_id
+                )),
+            };
+            let _ = sender.try_send(Err(stream_err.clone()));
+            if result.is_ok() {
+                if let Some(tx) = stream.result_tx.take() {
+                    let _ = tx.send(Err(stream_err));
+                }
+                stream.done = true;
+                continue;
+            }
+        }
+
+        if let Some(tx) = stream.result_tx.take() {
+            let _ = tx.send(result);
+        }
+        stream.done = true;
+    }
+}
+
 fn extract_component_id_from_specifier(specifier: &str) -> String {
     if let Some(server_idx) = specifier.rfind("/server/") {
         let after_server = &specifier[server_idx + 8..];
@@ -1178,27 +1330,6 @@ impl JsRuntimeInterface for RariRuntime {
         })
     }
 
-    fn clear_request_context(&self) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
-        let request_sender = self.request_sender.clone();
-
-        Box::pin(async move {
-            let (response_sender, response_receiver) = oneshot::channel();
-            request_sender
-                .send(JsRequest::ClearRequestContext { result_tx: response_sender })
-                .await
-                .map_err(|_| {
-                    RariError::js_runtime(
-                        "JS executor channel closed (clear_request_context)".to_string(),
-                    )
-                })?;
-            response_receiver.await.map_err(|_| {
-                RariError::js_runtime(
-                    "JS executor failed to respond (clear_request_context)".to_string(),
-                )
-            })?
-        })
-    }
-
     fn clear_request_context_if_matches(
         &self,
         expected_context: Arc<RequestContext>,
@@ -1226,61 +1357,112 @@ impl JsRuntimeInterface for RariRuntime {
         })
     }
 
-    fn execute_script_with_request_context(
+    fn execute_script_for_streaming(
         &self,
-        request_context: Arc<RequestContext>,
+        stream_id: String,
         script_name: String,
         script_code: String,
-    ) -> Pin<Box<dyn Future<Output = Result<Value, RariError>> + Send>> {
-        let runtime = self.clone();
+        chunk_sender: mpsc::Sender<Result<Vec<u8>, RariError>>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        let runtime = Self {
+            request_sender: self.request_sender.clone(),
+            priority_sender: self.priority_sender.clone(),
+        };
+
+        Box::pin(async move {
+            let completion = runtime
+                .queue_script_for_streaming(stream_id, script_name, script_code, chunk_sender, None)
+                .await?;
+            completion.await
+        })
+    }
+
+    fn queue_script_for_streaming(
+        &self,
+        stream_id: String,
+        script_name: String,
+        script_code: String,
+        chunk_sender: mpsc::Sender<Result<Vec<u8>, RariError>>,
+        request_context: Option<Arc<RequestContext>>,
+    ) -> QueueStreamingScriptFuture {
+        let runtime = Self {
+            request_sender: self.request_sender.clone(),
+            priority_sender: self.priority_sender.clone(),
+        };
+
+        Box::pin(async move {
+            let (response_sender, response_receiver) = oneshot::channel();
+
+            runtime
+                .send_js_request(JsRequest::ExecuteScriptForStreaming {
+                    stream_id,
+                    script_name,
+                    script_code,
+                    chunk_sender,
+                    request_context,
+                    result_tx: response_sender,
+                })
+                .await?;
+
+            let completion: Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> =
+                Box::pin(async move {
+                    response_receiver.await.map_err(|_| {
+                        RariError::js_runtime(
+                            "JS executor failed to respond (execute_script_for_streaming)"
+                                .to_string(),
+                        )
+                    })?
+                });
+            Ok(completion)
+        })
+    }
+
+    fn register_request_context(
+        &self,
+        request_context: Arc<RequestContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
+        let runtime = Self {
+            request_sender: self.request_sender.clone(),
+            priority_sender: self.priority_sender.clone(),
+        };
 
         Box::pin(async move {
             let (response_sender, response_receiver) = oneshot::channel();
             runtime
-                .send_js_request(JsRequest::ExecuteScriptWithRequestContext {
+                .send_js_request(JsRequest::RegisterRequestContext {
                     request_context,
-                    script_name,
-                    script_code,
                     result_tx: response_sender,
                 })
                 .await?;
             response_receiver.await.map_err(|_| {
                 RariError::js_runtime(
-                    "JS executor failed to respond (execute_script_with_request_context)"
-                        .to_string(),
+                    "JS executor failed to respond (register_request_context)".to_string(),
                 )
             })?
         })
     }
 
-    fn execute_script_for_streaming(
+    fn unregister_request_context(
         &self,
-        script_name: String,
-        script_code: String,
-        chunk_sender: mpsc::Sender<Result<Vec<u8>, RariError>>,
+        request_id: &str,
     ) -> Pin<Box<dyn Future<Output = Result<(), RariError>> + Send>> {
-        let request_sender = self.request_sender.clone();
+        let runtime = Self {
+            request_sender: self.request_sender.clone(),
+            priority_sender: self.priority_sender.clone(),
+        };
+        let request_id = request_id.to_string();
 
         Box::pin(async move {
             let (response_sender, response_receiver) = oneshot::channel();
-
-            request_sender
-                .send(JsRequest::ExecuteScriptForStreaming {
-                    script_name,
-                    script_code,
-                    chunk_sender,
+            runtime
+                .send_js_request(JsRequest::UnregisterRequestContext {
+                    request_id,
                     result_tx: response_sender,
                 })
-                .await
-                .map_err(|_| {
-                    RariError::js_runtime(
-                        "JS executor channel closed (execute_script_for_streaming)".to_string(),
-                    )
-                })?;
-
+                .await?;
             response_receiver.await.map_err(|_| {
                 RariError::js_runtime(
-                    "JS executor failed to respond (execute_script_for_streaming)".to_string(),
+                    "JS executor failed to respond (unregister_request_context)".to_string(),
                 )
             })?
         })

--- a/crates/rari/src/runtime/factory/runtime.rs
+++ b/crates/rari/src/runtime/factory/runtime.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use base64::engine::general_purpose::STANDARD;
-use deno_core::{ModuleSpecifier, PollEventLoopOptions, v8};
+use deno_core::{ModuleSpecifier, v8};
 use rari_error::RariError;
 use rustc_hash::FxHashMap;
 use serde_json::Value;
@@ -354,10 +354,20 @@ impl RariRuntime {
                                 }
                             }
 
-                            let _ = time::timeout(
+                            let event_loop_result = time::timeout(
                                 Duration::from_millis(10),
-                                js_runtime.run_event_loop(PollEventLoopOptions::default()),
-                            ).await;
+                                utils::v8::run_event_loop_with_error_handling(
+                                    &mut js_runtime,
+                                    "idle pump",
+                                ),
+                            )
+                            .await;
+                            if let Ok(Err(e)) = event_loop_result {
+                                eprintln!("[rari] Event loop error: {e}");
+                                if is_runtime_restart_needed(&e) {
+                                    break;
+                                }
+                            }
                         }
                     }
 

--- a/crates/rari/src/runtime/factory/runtime.rs
+++ b/crates/rari/src/runtime/factory/runtime.rs
@@ -170,13 +170,17 @@ pub struct RariRuntime {
 
 fn is_priority_js_request(req: &JsRequest) -> bool {
     match req {
-        JsRequest::ExecuteScriptForStreaming { .. } | JsRequest::RegisterRequestContext { .. } => {
-            true
-        }
+        JsRequest::ExecuteScriptForStreaming { .. }
+        | JsRequest::RegisterRequestContext { .. }
+        | JsRequest::UnregisterRequestContext { .. } => true,
         JsRequest::ExecuteScript { script_name, .. } => script_name.starts_with("execute_action_"),
         _ => false,
     }
 }
+
+/// After this many consecutive priority receives while streams/batches are pending,
+/// force an event-loop pump so timers/chunk ops are not starved.
+const PRIORITY_FAIRNESS_QUOTA: u32 = 8;
 
 async fn recv_js_request(
     priority_receiver: &mut mpsc::Receiver<JsRequest>,
@@ -227,6 +231,7 @@ impl RariRuntime {
                     let mut pending_batches: Vec<PendingBatch> = Vec::new();
                     let mut pending_streams: Vec<PendingStream> = Vec::new();
                     let mut batch_id_counter: u64 = 0;
+                    let mut priority_streak: u32 = 0;
 
                     while continue_processing {
                         let has_pending =
@@ -235,52 +240,88 @@ impl RariRuntime {
                             // Short polls keep Suspense timers and chunk ops progressing under load.
                             // Longer polls delay timer wakeups and stretch stream latency.
                             let pump_budget_ms = if pending_streams.is_empty() { 50 } else { 2 };
-                            tokio::select! {
-                                biased;
-                                request = recv_js_request(&mut priority_receiver, &mut request_receiver) => {
-                                    match request {
-                                        Some(req) => {
-                                            let result = handle_js_request(
-                                                req,
-                                                &mut js_runtime,
-                                                &module_loader,
-                                                &mut continue_processing,
-                                                &mut pending_batches,
-                                                &mut pending_streams,
-                                                &mut batch_id_counter,
-                                            ).await;
-                                            if let Err(e) = result {
-                                                eprintln!("[rari] Error processing request: {e}");
-                                                break;
-                                            }
-                                        }
-                                        None => {
-                                            continue_processing = false;
-                                        }
-                                    }
-                                }
-                                event_loop_result = time::timeout(
+                            if priority_streak >= PRIORITY_FAIRNESS_QUOTA {
+                                priority_streak = 0;
+                                let event_loop_result = time::timeout(
                                     Duration::from_millis(pump_budget_ms),
                                     utils::v8::run_event_loop_with_error_handling(
-                                        &mut js_runtime, "concurrent pending"
+                                        &mut js_runtime,
+                                        "priority fairness pump",
                                     ),
-                                ) => {
-                                    if let Ok(Err(e)) = event_loop_result {
-                                        eprintln!("[rari] Event loop error: {e}");
-                                        if is_runtime_restart_needed(&e) {
-                                            for batch in pending_batches.drain(..) {
-                                                for sender in batch.senders.into_iter().flatten() {
-                                                    let _ = sender.send(Err(create_graceful_error()));
+                                )
+                                .await;
+                                if let Ok(Err(e)) = event_loop_result {
+                                    eprintln!("[rari] Event loop error: {e}");
+                                    if is_runtime_restart_needed(&e) {
+                                        for batch in pending_batches.drain(..) {
+                                            for sender in batch.senders.into_iter().flatten() {
+                                                let _ = sender.send(Err(create_graceful_error()));
+                                            }
+                                        }
+                                        for mut stream in pending_streams.drain(..) {
+                                            fail_pending_stream(
+                                                &mut js_runtime,
+                                                &mut stream,
+                                                create_graceful_error(),
+                                            );
+                                        }
+                                        break;
+                                    }
+                                }
+                            } else {
+                                tokio::select! {
+                                    biased;
+                                    request = recv_js_request(&mut priority_receiver, &mut request_receiver) => {
+                                        match request {
+                                            Some(req) => {
+                                                if is_priority_js_request(&req) {
+                                                    priority_streak =
+                                                        priority_streak.saturating_add(1);
+                                                } else {
+                                                    priority_streak = 0;
+                                                }
+                                                let result = handle_js_request(
+                                                    req,
+                                                    &mut js_runtime,
+                                                    &module_loader,
+                                                    &mut continue_processing,
+                                                    &mut pending_batches,
+                                                    &mut pending_streams,
+                                                    &mut batch_id_counter,
+                                                ).await;
+                                                if let Err(e) = result {
+                                                    eprintln!("[rari] Error processing request: {e}");
+                                                    break;
                                                 }
                                             }
-                                            for mut stream in pending_streams.drain(..) {
-                                                fail_pending_stream(
-                                                    &mut js_runtime,
-                                                    &mut stream,
-                                                    create_graceful_error(),
-                                                );
+                                            None => {
+                                                continue_processing = false;
                                             }
-                                            break;
+                                        }
+                                    }
+                                    event_loop_result = time::timeout(
+                                        Duration::from_millis(pump_budget_ms),
+                                        utils::v8::run_event_loop_with_error_handling(
+                                            &mut js_runtime, "concurrent pending"
+                                        ),
+                                    ) => {
+                                        if let Ok(Err(e)) = event_loop_result {
+                                            eprintln!("[rari] Event loop error: {e}");
+                                            if is_runtime_restart_needed(&e) {
+                                                for batch in pending_batches.drain(..) {
+                                                    for sender in batch.senders.into_iter().flatten() {
+                                                        let _ = sender.send(Err(create_graceful_error()));
+                                                    }
+                                                }
+                                                for mut stream in pending_streams.drain(..) {
+                                                    fail_pending_stream(
+                                                        &mut js_runtime,
+                                                        &mut stream,
+                                                        create_graceful_error(),
+                                                    );
+                                                }
+                                                break;
+                                            }
                                         }
                                     }
                                 }
@@ -291,6 +332,7 @@ impl RariRuntime {
                             check_pending_streams(&mut js_runtime, &mut pending_streams);
                             pending_streams.retain(|s| !s.done);
                         } else {
+                            priority_streak = 0;
                             match recv_js_request(&mut priority_receiver, &mut request_receiver).await {
                                 Some(req) => {
                                     let result = handle_js_request(

--- a/crates/rari/src/runtime/factory/runtime_builder.rs
+++ b/crates/rari/src/runtime/factory/runtime_builder.rs
@@ -64,6 +64,7 @@ pub fn build_js_runtime(
         ops: Cow::Owned(streaming_ops),
         op_state_fn: Some(Box::new(|state| {
             state.put(StreamOpState::default());
+            state.put(ops::RequestContextStore::default());
             state.put(ops::rari_main_module());
             let feature_checker = deno_features::FeatureChecker::default();
             state.put(Arc::new(feature_checker));

--- a/crates/rari/src/runtime/mod.rs
+++ b/crates/rari/src/runtime/mod.rs
@@ -271,6 +271,13 @@ impl JsExecutionRuntime {
     {
         self.pool.with_request_context(request_context, operation).await
     }
+
+    pub async fn acquire_request_runtime(
+        self: &Arc<Self>,
+        request_context: Arc<RequestContext>,
+    ) -> Result<factory::LeasedRequestRuntime, RariError> {
+        self.pool.acquire_request_runtime(request_context).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/rari/src/runtime/mod.rs
+++ b/crates/rari/src/runtime/mod.rs
@@ -1,13 +1,9 @@
-use std::{future::Future, sync::Arc, time::Duration};
+use std::{env, future::Future, sync::Arc};
 
-use deno_core::ModuleId;
 use rari_error::RariError;
 use rustc_hash::FxHashMap;
 use serde_json::Value;
-use tokio::{
-    sync::mpsc::{Sender, UnboundedReceiver},
-    time,
-};
+use tokio::sync::mpsc::{Sender, UnboundedReceiver};
 
 pub mod ext;
 pub mod factory;
@@ -15,24 +11,16 @@ pub mod module_loader;
 pub mod ops;
 pub mod transpile;
 
-use factory::JsRuntimeInterface;
+use factory::{JsRuntimePool, PooledRuntime};
 
-use crate::{
-    runtime::factory::{
-        RariRuntime,
-        component_ops::{
-            build_invalidate_script, invalidate_script_name, load_component_code as load_component,
-        },
-    },
-    server::{
-        middleware::request_context::RequestContext, rendering::metadata,
-        routing::types::ParamValue,
-    },
+use crate::server::{
+    middleware::request_context::RequestContext, rendering::metadata, routing::types::ParamValue,
 };
 
+pub const DEFAULT_JS_POOL_SIZE: usize = 1;
+
 pub struct JsExecutionRuntime {
-    runtime: Arc<RariRuntime>,
-    timeout_ms: u64,
+    pool: Arc<JsRuntimePool>,
 }
 
 impl Default for JsExecutionRuntime {
@@ -53,16 +41,60 @@ fn parse_string_array_value(value: &Value) -> Vec<String> {
     Vec::new()
 }
 
+fn pool_size_from_env() -> usize {
+    env::var("RARI_JS_POOL_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .filter(|&n| n >= 1)
+        .unwrap_or(DEFAULT_JS_POOL_SIZE)
+}
+
 #[expect(clippy::missing_errors_doc)]
 impl JsExecutionRuntime {
     pub fn new(env_vars: Option<FxHashMap<String, String>>) -> Self {
-        let runtime = if let Some(env_vars) = env_vars {
-            factory::create_runtime_with_env(env_vars)
-        } else {
-            factory::create_runtime()
-        };
+        Self::with_pool_size(env_vars, pool_size_from_env())
+    }
 
-        Self { runtime, timeout_ms: 30000 }
+    pub fn with_pool_size(env_vars: Option<FxHashMap<String, String>>, pool_size: usize) -> Self {
+        let pool_size = pool_size.max(1);
+        #[expect(
+            clippy::expect_used,
+            reason = "JsRuntimePool::new only fails when size is 0, which is prevented above"
+        )]
+        let pool = JsRuntimePool::new(pool_size, env_vars)
+            .expect("JS runtime pool construction cannot fail for size >= 1");
+
+        Self { pool }
+    }
+
+    pub fn pool(&self) -> &Arc<JsRuntimePool> {
+        &self.pool
+    }
+
+    pub fn pool_size(&self) -> usize {
+        self.pool.size()
+    }
+
+    pub fn set_setup_mode(&self, on: bool) {
+        self.pool.set_setup_mode(on);
+    }
+
+    pub fn set_post_rebuild_hook(&self, hook: factory::PostRebuildHook) {
+        self.pool.set_post_rebuild_hook(hook);
+    }
+
+    pub async fn pick_runtime(&self) -> Result<PooledRuntime, RariError> {
+        self.pool.pick_runtime().await
+    }
+
+    pub async fn pick_runtime_for_streaming(
+        &self,
+    ) -> Result<(PooledRuntime, factory::StreamingSlotGuard), RariError> {
+        self.pool.pick_runtime_for_streaming().await
+    }
+
+    pub fn stream_load_at(&self, idx: usize) -> usize {
+        self.pool.stream_load_at(idx)
     }
 
     pub async fn execute_script(
@@ -70,39 +102,25 @@ impl JsExecutionRuntime {
         script_name: String,
         script_code: String,
     ) -> Result<Value, RariError> {
-        let runtime = Arc::clone(&self.runtime);
-        let script_name_clone = script_name.clone();
-        let script_code_clone = script_code.clone();
-
-        match time::timeout(
-            Duration::from_millis(self.timeout_ms),
-            runtime.execute_script(script_name_clone, script_code_clone),
-        )
-        .await
-        {
-            Ok(result) => result,
-            Err(_) => Err(RariError::timeout(format!(
-                "Script execution timed out after {} ms",
-                self.timeout_ms
-            ))),
-        }
+        self.pool.execute_script(script_name, script_code).await
     }
 
     pub async fn execute_script_batch(
-        &self,
+        self: &Arc<Self>,
         scripts: Vec<(String, String)>,
     ) -> UnboundedReceiver<(usize, Result<Value, RariError>)> {
-        self.runtime.execute_script_batch(scripts).await
+        self.pool.execute_script_batch(scripts).await
     }
 
     pub async fn execute_script_for_streaming(
         &self,
+        stream_id: String,
         script_name: String,
         script_code: String,
         chunk_sender: Sender<Result<Vec<u8>, RariError>>,
     ) -> Result<(), RariError> {
-        let runtime = Arc::clone(&self.runtime);
-        runtime.execute_script_for_streaming(script_name, script_code, chunk_sender).await
+        let (handle, _stream_lease) = self.pool.pick_runtime_for_streaming().await?;
+        handle.execute_script_for_streaming(stream_id, script_name, script_code, chunk_sender).await
     }
 
     pub async fn collect_metadata(
@@ -181,56 +199,19 @@ impl JsExecutionRuntime {
         function_name: &str,
         args: Vec<Value>,
     ) -> Result<Value, RariError> {
-        let runtime = Arc::clone(&self.runtime);
-        let function_name = function_name.to_string();
-
-        match time::timeout(
-            Duration::from_millis(self.timeout_ms),
-            runtime.execute_function(&function_name, args),
-        )
-        .await
-        {
-            Ok(result) => result,
-            Err(_) => Err(RariError::timeout(format!(
-                "Function execution timed out after {} ms",
-                self.timeout_ms
-            ))),
-        }
+        self.pool.execute_function(function_name, args).await
     }
 
-    pub async fn load_es_module(&self, specifier: &str) -> Result<ModuleId, RariError> {
-        let runtime = Arc::clone(&self.runtime);
-        let specifier = specifier.to_string();
-
-        match time::timeout(
-            Duration::from_millis(self.timeout_ms),
-            runtime.load_es_module(&specifier),
-        )
-        .await
-        {
-            Ok(result) => result,
-            Err(_) => Err(RariError::timeout(format!(
-                "Module loading timed out after {} ms for {}",
-                self.timeout_ms, specifier
-            ))),
-        }
+    pub async fn load_and_evaluate_module(&self, specifier: &str) -> Result<(), RariError> {
+        self.pool.broadcast_load_and_evaluate_module(specifier).await
     }
 
-    pub async fn evaluate_module(&self, module_id: ModuleId) -> Result<Value, RariError> {
-        let runtime = Arc::clone(&self.runtime);
-
-        match time::timeout(
-            Duration::from_millis(self.timeout_ms),
-            runtime.evaluate_module(module_id),
-        )
-        .await
-        {
-            Ok(result) => result,
-            Err(_) => Err(RariError::timeout(format!(
-                "Module evaluation timed out after {} ms",
-                self.timeout_ms
-            ))),
-        }
+    pub async fn broadcast_script(
+        &self,
+        script_name: &str,
+        script_code: &str,
+    ) -> Result<(), RariError> {
+        self.pool.broadcast_script(script_name, script_code).await
     }
 
     pub async fn add_module_to_loader(
@@ -238,63 +219,16 @@ impl JsExecutionRuntime {
         specifier: &str,
         code: String,
     ) -> Result<(), RariError> {
-        let runtime = Arc::clone(&self.runtime);
-        let specifier = specifier.to_string();
-
-        match time::timeout(
-            Duration::from_millis(self.timeout_ms),
-            runtime.add_module_to_loader(&specifier, code),
-        )
-        .await
-        {
-            Ok(result) => result,
-            Err(_) => Err(RariError::timeout(format!(
-                "Adding module to loader timed out after {} ms for {}",
-                self.timeout_ms, specifier
-            ))),
-        }
+        self.pool.broadcast_add_module_to_loader(specifier, &code).await
     }
 
     pub async fn clear_module_loader_caches(&self, component_id: &str) -> Result<(), RariError> {
-        let runtime = Arc::clone(&self.runtime);
-        let component_id = component_id.to_string();
-
-        match time::timeout(
-            Duration::from_millis(self.timeout_ms),
-            runtime.clear_module_loader_caches(&component_id),
-        )
-        .await
-        {
-            Ok(result) => result,
-            Err(_) => Err(RariError::timeout(format!(
-                "Clearing module loader caches timed out after {} ms for {}",
-                self.timeout_ms, component_id
-            ))),
-        }
-    }
-
-    pub async fn get_module_namespace(&self, module_id: ModuleId) -> Result<Value, RariError> {
-        let runtime = Arc::clone(&self.runtime);
-
-        match time::timeout(
-            Duration::from_millis(self.timeout_ms),
-            runtime.get_module_namespace(module_id),
-        )
-        .await
-        {
-            Ok(result) => result,
-            Err(_) => Err(RariError::timeout(format!(
-                "Getting module namespace timed out after {} ms",
-                self.timeout_ms
-            ))),
-        }
+        self.pool.broadcast_clear_module_loader_caches(component_id).await
     }
 
     pub async fn invalidate_component(&self, component_id: &str) -> Result<(), RariError> {
-        let script = build_invalidate_script(component_id);
-
-        match self.execute_script(invalidate_script_name(component_id), script).await {
-            Ok(_) => Ok(()),
+        match self.pool.invalidate_component_all(component_id).await {
+            Ok(()) => Ok(()),
             Err(e) => {
                 tracing::error!("Failed to invalidate component {}: {}", component_id, e);
                 Err(RariError::js_runtime(format!(
@@ -309,143 +243,144 @@ impl JsExecutionRuntime {
         component_id: &str,
         component_code: &str,
     ) -> Result<(), RariError> {
-        let runtime = Arc::clone(&self.runtime);
-        let component_id = component_id.to_string();
-        let component_code = component_code.to_string();
-
-        match time::timeout(
-            Duration::from_millis(self.timeout_ms),
-            load_component(runtime.as_ref(), &component_id, &component_code),
-        )
-        .await
-        {
-            Ok(result) => result,
-            Err(_) => Err(RariError::timeout(format!(
-                "Loading component {component_id} timed out after {} ms",
-                self.timeout_ms
-            ))),
-        }
+        self.pool.load_component_code_all(component_id, component_code).await
     }
 
     pub async fn execute_script_with_request_context(
-        &self,
+        self: &Arc<Self>,
         request_context: Arc<RequestContext>,
         script_name: String,
         script_code: String,
     ) -> Result<Value, RariError> {
-        let runtime = Arc::clone(&self.runtime);
-
-        match time::timeout(
-            Duration::from_millis(self.timeout_ms),
-            runtime.execute_script_with_request_context(request_context, script_name, script_code),
-        )
-        .await
-        {
-            Ok(result) => result,
-            Err(_) => Err(RariError::timeout(format!(
-                "Script execution with request context timed out after {} ms",
-                self.timeout_ms
-            ))),
-        }
-    }
-
-    pub async fn set_request_context(
-        &self,
-        request_context: Arc<RequestContext>,
-    ) -> Result<(), RariError> {
-        let runtime = Arc::clone(&self.runtime);
-
-        match time::timeout(
-            Duration::from_millis(self.timeout_ms),
-            runtime.set_request_context(request_context),
-        )
-        .await
-        {
-            Ok(result) => result,
-            Err(_) => Err(RariError::timeout(format!(
-                "Setting request context timed out after {} ms",
-                self.timeout_ms
-            ))),
-        }
-    }
-
-    pub async fn clear_request_context(&self) -> Result<(), RariError> {
-        let runtime = Arc::clone(&self.runtime);
-
-        match time::timeout(Duration::from_millis(self.timeout_ms), runtime.clear_request_context())
+        self.pool
+            .with_request_context(request_context, move |runtime| async move {
+                runtime.execute_script(script_name, script_code).await
+            })
             .await
-        {
-            Ok(result) => result,
-            Err(_) => Err(RariError::timeout(format!(
-                "Clearing request context timed out after {} ms",
-                self.timeout_ms
-            ))),
-        }
     }
 
-    pub async fn clear_request_context_if_matches(
-        &self,
-        expected_context: Arc<RequestContext>,
-    ) -> Result<(), RariError> {
-        let runtime = Arc::clone(&self.runtime);
-
-        match time::timeout(
-            Duration::from_millis(self.timeout_ms),
-            runtime.clear_request_context_if_matches(expected_context),
-        )
-        .await
-        {
-            Ok(result) => result,
-            Err(_) => Err(RariError::timeout(format!(
-                "Clearing request context (if matches) timed out after {} ms",
-                self.timeout_ms
-            ))),
-        }
-    }
-
-    pub async fn execute_with_request_context<F, T>(
-        &self,
+    pub async fn with_request_context<F, Fut, T>(
+        self: &Arc<Self>,
         request_context: Arc<RequestContext>,
         operation: F,
     ) -> Result<T, RariError>
     where
-        F: Future<Output = Result<T, RariError>>,
+        T: Send + 'static,
+        F: FnOnce(Arc<dyn factory::JsRuntimeInterface>) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<T, RariError>> + Send + 'static,
     {
-        self.set_request_context(request_context).await?;
+        self.pool.with_request_context(request_context, operation).await
+    }
+}
 
-        let result = operation.await;
+#[cfg(test)]
+#[expect(clippy::expect_used)]
+mod overlapping_stream_tests {
+    use std::{
+        sync::Arc,
+        time::{Duration, Instant},
+    };
 
-        let clear_result = self.clear_request_context().await;
+    use rari_error::RariError;
+    use tokio::sync::mpsc;
 
-        match (result, clear_result) {
-            (Ok(value), Ok(())) => Ok(value),
-            (Ok(value), Err(clear_err)) => {
-                tracing::error!(
-                    "Failed to clear request context after successful operation: {}",
-                    clear_err
+    use super::JsExecutionRuntime;
+
+    #[tokio::test]
+    async fn overlapping_streams_on_one_isolate_finish_near_max_delay() {
+        let runtime = Arc::new(JsExecutionRuntime::with_pool_size(None, 1));
+        let delay_ms = 200u64;
+        let stream_count = 4usize;
+
+        let start = Instant::now();
+        let mut join_handles = Vec::with_capacity(stream_count);
+
+        for i in 0..stream_count {
+            let runtime = Arc::clone(&runtime);
+            let stream_id = format!("overlap-{i}");
+            let (tx, mut rx) = mpsc::channel::<Result<Vec<u8>, RariError>>(8);
+            let script = format!(
+                r#"(async function() {{
+                    await new Promise((resolve) => setTimeout(resolve, {delay_ms}));
+                    await Deno.core.ops.op_fizz_chunk("{stream_id}", "chunk-{i}");
+                    Deno.core.ops.op_fizz_done("{stream_id}");
+                }})()"#
+            );
+
+            join_handles.push(tokio::spawn(async move {
+                let exec = runtime.execute_script_for_streaming(
+                    stream_id.clone(),
+                    format!("overlap_stream_{i}"),
+                    script,
+                    tx,
                 );
-                Ok(value)
-            }
-            (Err(op_err), Err(clear_err)) => {
-                tracing::error!(
-                    "Failed to clear request context after operation error: {}",
-                    clear_err
-                );
-                Err(op_err)
-            }
-            (Err(op_err), Ok(())) => Err(op_err),
+                let drain = async {
+                    let mut got = Vec::new();
+                    while let Some(chunk) = rx.recv().await {
+                        got.push(chunk);
+                    }
+                    got
+                };
+                let (exec_result, chunks) = tokio::join!(exec, drain);
+                (exec_result, chunks)
+            }));
         }
+
+        let mut successes = 0usize;
+        for handle in join_handles {
+            let (exec_result, chunks) = handle.await.expect("join");
+            exec_result.expect("stream execute");
+            assert!(
+                chunks.iter().any(|c| c.as_ref().is_ok_and(|b| !b.is_empty())),
+                "expected at least one chunk"
+            );
+            successes += 1;
+        }
+
+        let elapsed = start.elapsed();
+        assert_eq!(successes, stream_count);
+        // Serial would be ~800ms; overlapped should be near 200ms (+ runtime overhead).
+        assert!(
+            elapsed < Duration::from_millis(delay_ms * stream_count as u64 / 2 + 400),
+            "expected overlapped streams, elapsed={elapsed:?}"
+        );
+        assert!(
+            elapsed >= Duration::from_millis(delay_ms.saturating_sub(50)),
+            "elapsed unexpectedly fast: {elapsed:?}"
+        );
     }
 
-    pub async fn execute_with_persistent_request_context<F, T>(
-        &self,
-        request_context: Arc<RequestContext>,
-        operation: F,
-    ) -> Result<T, RariError>
-    where
-        F: Future<Output = Result<T, RariError>>,
-    {
-        self.set_request_context(request_context).await?;
-        operation.await
+    #[tokio::test]
+    async fn pool_size_two_broadcast_reaches_every_slot() {
+        let runtime = Arc::new(JsExecutionRuntime::with_pool_size(None, 2));
+        assert_eq!(runtime.pool_size(), 2);
+
+        runtime
+            .broadcast_script("pool_init_marker", "globalThis.__rariPoolMarker = 0")
+            .await
+            .expect("broadcast init");
+        runtime
+            .broadcast_script(
+                "pool_inc_marker",
+                "globalThis.__rariPoolMarker = (globalThis.__rariPoolMarker || 0) + 1",
+            )
+            .await
+            .expect("broadcast increment");
+
+        let first = runtime.pick_runtime().await.expect("pick 0");
+        let second = runtime.pick_runtime().await.expect("pick 1");
+        assert_ne!(first.idx(), second.idx(), "round-robin should yield distinct slots");
+
+        let v0 = first
+            .execute_script("read_marker".into(), "globalThis.__rariPoolMarker".into())
+            .await
+            .expect("read slot 0");
+        let v1 = second
+            .execute_script("read_marker".into(), "globalThis.__rariPoolMarker".into())
+            .await
+            .expect("read slot 1");
+
+        assert_eq!(v0.as_i64(), Some(1));
+        assert_eq!(v1.as_i64(), Some(1));
     }
 }

--- a/crates/rari/src/runtime/ops.rs
+++ b/crates/rari/src/runtime/ops.rs
@@ -134,11 +134,8 @@ fn resolve_request_context(
     op_state: &OpState,
     request_id: Option<&str>,
 ) -> Option<Arc<RequestContext>> {
-    if let Some(id) = request_id.filter(|id| !id.is_empty())
-        && let Some(store) = op_state.try_borrow::<RequestContextStore>()
-        && let Some(ctx) = store.get(id)
-    {
-        return Some(ctx);
+    if let Some(id) = request_id.filter(|id| !id.is_empty()) {
+        return op_state.try_borrow::<RequestContextStore>().and_then(|store| store.get(id));
     }
     op_state.try_borrow::<Arc<RequestContext>>().cloned()
 }

--- a/crates/rari/src/runtime/ops.rs
+++ b/crates/rari/src/runtime/ops.rs
@@ -12,6 +12,7 @@ use deno_core::{ModuleSpecifier, OpDecl, OpState, op2};
 use deno_error::JsErrorBox;
 use deno_runtime::BootstrapOptions;
 use rari_error::RariError;
+use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use tokio::sync::mpsc;
 
@@ -62,17 +63,84 @@ enum RscStreamOperation {
 #[derive(Default)]
 #[non_exhaustive]
 pub struct StreamOpState {
-    pub chunk_sender: Option<mpsc::Sender<Result<Vec<u8>, RariError>>>,
-    pub current_stream_id: Option<String>,
-    pub row_counter: u32,
+    /// Per-stream chunk senders so concurrent streams on one isolate don't clobber each other.
+    pub chunk_senders: FxHashMap<String, mpsc::Sender<Result<Vec<u8>, RariError>>>,
+    pub row_counters: FxHashMap<String, u32>,
+    /// Filled by `op_stream_promise_settled` so the isolate worker can complete
+    /// pending streams without polling V8 via `execute_script` every pump tick.
+    pub settled: FxHashMap<String, Result<(), String>>,
 }
 
 impl StreamOpState {
-    pub fn get_next_row_id(&mut self) -> String {
-        let id = format!("{:x}", self.row_counter);
-        self.row_counter += 1;
+    pub fn register_sender(
+        &mut self,
+        stream_id: String,
+        sender: mpsc::Sender<Result<Vec<u8>, RariError>>,
+    ) {
+        self.chunk_senders.insert(stream_id.clone(), sender);
+        self.row_counters.entry(stream_id).or_insert(0);
+    }
+
+    pub fn take_sender(
+        &mut self,
+        stream_id: &str,
+    ) -> Option<mpsc::Sender<Result<Vec<u8>, RariError>>> {
+        self.row_counters.remove(stream_id);
+        self.chunk_senders.remove(stream_id)
+    }
+
+    pub fn get_sender(&self, stream_id: &str) -> Option<mpsc::Sender<Result<Vec<u8>, RariError>>> {
+        self.chunk_senders.get(stream_id).cloned()
+    }
+
+    pub fn take_settled(&mut self, stream_id: &str) -> Option<Result<(), String>> {
+        self.settled.remove(stream_id)
+    }
+
+    pub fn mark_settled(&mut self, stream_id: String, result: Result<(), String>) {
+        self.settled.insert(stream_id, result);
+    }
+
+    pub fn get_next_row_id(&mut self, stream_id: &str) -> String {
+        let counter = self.row_counters.entry(stream_id.to_string()).or_insert(0);
+        let id = format!("{:x}", *counter);
+        *counter += 1;
         id
     }
+}
+
+/// Multiplexed request contexts keyed by `RequestContext::request_id`.
+#[derive(Default)]
+#[non_exhaustive]
+pub struct RequestContextStore {
+    pub by_id: FxHashMap<String, Arc<RequestContext>>,
+}
+
+impl RequestContextStore {
+    pub fn insert(&mut self, ctx: Arc<RequestContext>) {
+        self.by_id.insert(ctx.request_id().to_string(), ctx);
+    }
+
+    pub fn remove(&mut self, request_id: &str) -> Option<Arc<RequestContext>> {
+        self.by_id.remove(request_id)
+    }
+
+    pub fn get(&self, request_id: &str) -> Option<Arc<RequestContext>> {
+        self.by_id.get(request_id).cloned()
+    }
+}
+
+fn resolve_request_context(
+    op_state: &OpState,
+    request_id: Option<&str>,
+) -> Option<Arc<RequestContext>> {
+    if let Some(id) = request_id.filter(|id| !id.is_empty())
+        && let Some(store) = op_state.try_borrow::<RequestContextStore>()
+        && let Some(ctx) = store.get(id)
+    {
+        return Some(ctx);
+    }
+    op_state.try_borrow::<Arc<RequestContext>>().cloned()
 }
 
 fn parse_hex_row_id(row_id: &str, context: &str) -> Result<u32, JsErrorBox> {
@@ -95,6 +163,7 @@ fn parse_hex_row_id(row_id: &str, context: &str) -> Result<u32, JsErrorBox> {
 #[op2]
 pub async fn op_send_chunk_to_rust(
     state: Rc<RefCell<OpState>>,
+    #[string] stream_id: String,
     #[string] operation_json: String,
 ) -> Result<(), JsErrorBox> {
     let operation: RscStreamOperation = match serde_json::from_str(&operation_json) {
@@ -117,9 +186,9 @@ pub async fn op_send_chunk_to_rust(
 
         match &operation {
             RscStreamOperation::Complete { .. } | RscStreamOperation::Error { .. } => {
-                stream_op_state.chunk_sender.take()
+                stream_op_state.take_sender(&stream_id)
             }
-            _ => stream_op_state.chunk_sender.clone(),
+            _ => stream_op_state.get_sender(&stream_id),
         }
     };
 
@@ -324,8 +393,10 @@ pub fn get_streaming_ops() -> Vec<OpDecl> {
         op_main_module(),
         op_ppid(),
         op_send_chunk_to_rust(),
+        op_fizz_chunk_try(),
         op_fizz_chunk(),
         op_fizz_done(),
+        op_stream_promise_settled(),
         op_internal_log(),
         op_sanitize_html(),
         op_get_cookies(),
@@ -335,39 +406,79 @@ pub fn get_streaming_ops() -> Vec<OpDecl> {
     ]
 }
 
+/// Sync try-send for Fizz chunks. Returns: `0` sent, `1` full (use async op), `2` disconnected.
+#[op2(fast)]
+pub fn op_fizz_chunk_try(state: &OpState, #[string] stream_id: &str, #[string] html: &str) -> u8 {
+    let Some(stream_op_state) = state.try_borrow::<StreamOpState>() else {
+        return 2;
+    };
+    let Some(sender) = stream_op_state.get_sender(stream_id) else {
+        return 2;
+    };
+    match sender.try_send(Ok(html.as_bytes().to_vec())) {
+        Ok(()) => 0,
+        Err(mpsc::error::TrySendError::Full(_)) => 1,
+        Err(mpsc::error::TrySendError::Closed(_)) => 2,
+    }
+}
+
 #[op2]
 pub async fn op_fizz_chunk(
     state: Rc<RefCell<OpState>>,
+    #[string] stream_id: String,
     #[string] html: String,
 ) -> Result<(), JsErrorBox> {
     let sender = {
-        let mut op_state_ref = state.borrow_mut();
-        let Some(stream_op_state) = op_state_ref.try_borrow_mut::<StreamOpState>() else {
+        let op_state_ref = state.borrow();
+        let Some(stream_op_state) = op_state_ref.try_borrow::<StreamOpState>() else {
             return Err(JsErrorBox::generic("StreamOpState not found."));
         };
-        stream_op_state.chunk_sender.clone()
+        stream_op_state.get_sender(&stream_id)
     };
 
     match sender {
         Some(sender) => {
-            if sender.send(Ok(html.into_bytes())).await.is_err() {
-                let mut op_state_ref = state.borrow_mut();
-                if let Some(stream_op_state) = op_state_ref.try_borrow_mut::<StreamOpState>() {
-                    stream_op_state.chunk_sender.take();
+            let bytes = html.into_bytes();
+            // Prefer try_send so the common path doesn't await the channel. Fall back to
+            // async send only under backpressure — never blocking_send (panics in Tokio).
+            match sender.try_send(Ok(bytes)) {
+                Ok(()) => Ok(()),
+                Err(mpsc::error::TrySendError::Full(msg)) => {
+                    if sender.send(msg).await.is_err() {
+                        tracing::debug!("Fizz stream client disconnected before chunk was sent");
+                        return Err(JsErrorBox::generic("Fizz stream receiver disconnected"));
+                    }
+                    Ok(())
                 }
-                tracing::debug!("Fizz stream client disconnected before chunk was sent");
-                return Err(JsErrorBox::generic("Fizz stream receiver disconnected"));
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    // Leave the map entry for op_fizz_done / settle cleanup; just
+                    // signal disconnect so JS stops pumping this stream.
+                    tracing::debug!("Fizz stream client disconnected before chunk was sent");
+                    Err(JsErrorBox::generic("Fizz stream receiver disconnected"))
+                }
             }
-            Ok(())
         }
         None => Err(JsErrorBox::generic("No chunk sender available for Fizz chunk")),
     }
 }
 
 #[op2(fast)]
-pub fn op_fizz_done(state: &mut OpState) {
+pub fn op_fizz_done(state: &mut OpState, #[string] stream_id: &str) {
     if let Some(stream_op_state) = state.try_borrow_mut::<StreamOpState>() {
-        stream_op_state.chunk_sender.take();
+        stream_op_state.take_sender(stream_id);
+    }
+}
+
+#[op2(fast)]
+pub fn op_stream_promise_settled(
+    state: &mut OpState,
+    #[string] stream_id: &str,
+    ok: bool,
+    #[string] error: &str,
+) {
+    if let Some(stream_op_state) = state.try_borrow_mut::<StreamOpState>() {
+        let result = if ok { Ok(()) } else { Err(error.to_string()) };
+        stream_op_state.mark_settled(stream_id.to_string(), result);
     }
 }
 
@@ -424,13 +535,14 @@ pub async fn op_fetch_with_cache(
     state: Rc<RefCell<OpState>>,
     #[string] url: String,
     #[string] options_json: String,
+    #[string] request_id: String,
 ) -> Result<serde_json::Value, JsErrorBox> {
     let options: rustc_hash::FxHashMap<String, String> = serde_json::from_str(&options_json)
         .map_err(|e| JsErrorBox::generic(format!("Invalid options JSON: {e}")))?;
 
     let request_context = {
         let op_state_ref = state.borrow();
-        op_state_ref.try_borrow::<Arc<RequestContext>>().cloned()
+        resolve_request_context(&op_state_ref, Some(request_id.as_str()))
     };
 
     if let Some(ctx) = request_context {
@@ -524,9 +636,9 @@ async fn perform_simple_fetch(
 #[allow(clippy::allow_attributes, clippy::needless_pass_by_value)]
 #[op2]
 #[string]
-pub fn op_get_cookies(state: Rc<RefCell<OpState>>) -> String {
+pub fn op_get_cookies(state: Rc<RefCell<OpState>>, #[string] request_id: String) -> String {
     let op_state_ref = state.borrow();
-    let Some(ctx) = op_state_ref.try_borrow::<Arc<RequestContext>>() else {
+    let Some(ctx) = resolve_request_context(&op_state_ref, Some(request_id.as_str())) else {
         return String::new();
     };
 
@@ -576,9 +688,9 @@ pub fn op_get_cookies(state: Rc<RefCell<OpState>>) -> String {
 #[allow(clippy::allow_attributes, clippy::needless_pass_by_value)]
 #[op2]
 #[string]
-pub fn op_get_request_headers(state: Rc<RefCell<OpState>>) -> String {
+pub fn op_get_request_headers(state: Rc<RefCell<OpState>>, #[string] request_id: String) -> String {
     let op_state_ref = state.borrow();
-    let Some(ctx) = op_state_ref.try_borrow::<Arc<RequestContext>>() else {
+    let Some(ctx) = resolve_request_context(&op_state_ref, Some(request_id.as_str())) else {
         return "{}".to_string();
     };
 
@@ -603,6 +715,8 @@ pub struct SetCookieArgs {
     priority: Option<String>,
     #[serde(default)]
     partitioned: bool,
+    #[serde(rename = "requestId", default)]
+    request_id: Option<String>,
 }
 
 #[allow(clippy::allow_attributes, clippy::needless_pass_by_value)]
@@ -642,7 +756,7 @@ pub fn op_set_cookie(
     }
 
     let op_state_ref = state.borrow();
-    if let Some(ctx) = op_state_ref.try_borrow::<Arc<RequestContext>>() {
+    if let Some(ctx) = resolve_request_context(&op_state_ref, args.request_id.as_deref()) {
         let path = args.path.or_else(|| Some("/".to_string()));
         ctx.pending_cookies.insert(
             PendingCookieKey::new(&args.name, path.as_deref(), args.domain.as_deref()),
@@ -667,9 +781,13 @@ pub fn op_set_cookie(
 
 #[allow(clippy::allow_attributes, clippy::needless_pass_by_value)]
 #[op2(fast)]
-pub fn op_delete_cookie(state: Rc<RefCell<OpState>>, #[string] name: String) {
+pub fn op_delete_cookie(
+    state: Rc<RefCell<OpState>>,
+    #[string] name: String,
+    #[string] request_id: String,
+) {
     let op_state_ref = state.borrow();
-    if let Some(ctx) = op_state_ref.try_borrow::<Arc<RequestContext>>() {
+    if let Some(ctx) = resolve_request_context(&op_state_ref, Some(request_id.as_str())) {
         let cookies_to_delete: Vec<(Option<String>, Option<String>)> = ctx
             .pending_cookies
             .iter()
@@ -726,9 +844,10 @@ pub fn op_delete_cookie(state: Rc<RefCell<OpState>>, #[string] name: String) {
 pub fn op_cache_get(
     state: Rc<RefCell<OpState>>,
     #[string] cache_key: &str,
+    #[string] request_id: &str,
 ) -> Option<serde_json::Value> {
     let op_state_ref = state.borrow();
-    if let Some(ctx) = op_state_ref.try_borrow::<Arc<RequestContext>>() {
+    if let Some(ctx) = resolve_request_context(&op_state_ref, Some(request_id)) {
         ctx.function_cache.get(cache_key).map(|entry| entry.value().clone())
     } else {
         None
@@ -741,9 +860,10 @@ pub fn op_cache_set(
     state: Rc<RefCell<OpState>>,
     #[string] cache_key: String,
     #[serde] value: serde_json::Value,
+    #[string] request_id: &str,
 ) {
     let op_state_ref = state.borrow();
-    if let Some(ctx) = op_state_ref.try_borrow::<Arc<RequestContext>>() {
+    if let Some(ctx) = resolve_request_context(&op_state_ref, Some(request_id)) {
         ctx.function_cache.insert(cache_key, value);
     }
 }
@@ -757,18 +877,21 @@ mod tests {
     #[test]
     fn test_stream_op_state_operations() {
         let mut stream_state = StreamOpState::default();
+        let stream_id = "s1";
 
-        let row_id_1 = stream_state.get_next_row_id();
-        let row_id_2 = stream_state.get_next_row_id();
+        let row_id_1 = stream_state.get_next_row_id(stream_id);
+        let row_id_2 = stream_state.get_next_row_id(stream_id);
 
         assert_eq!(row_id_1, "0");
         assert_eq!(row_id_2, "1");
-        assert_eq!(stream_state.row_counter, 2);
+        assert_eq!(stream_state.row_counters.get(stream_id), Some(&2));
 
         let (sender, _receiver) = mpsc::channel::<Result<Vec<u8>, RariError>>(32);
-        stream_state.chunk_sender = Some(sender);
+        stream_state.register_sender(stream_id.to_string(), sender);
 
-        assert!(stream_state.chunk_sender.is_some());
+        assert!(stream_state.get_sender(stream_id).is_some());
+        assert!(stream_state.take_sender(stream_id).is_some());
+        assert!(stream_state.get_sender(stream_id).is_none());
     }
 
     #[test]

--- a/crates/rari/src/server/actions.rs
+++ b/crates/rari/src/server/actions.rs
@@ -579,7 +579,8 @@ async fn compose_action_refresh_route(
             Arc::clone(&state.renderer),
             Arc::clone(&state.layout_html_cache),
         );
-        match layout_renderer.check_page_not_found(&route_match, &context).await {
+        match layout_renderer.check_page_not_found_on(&route_match, &context, sticky_runtime).await
+        {
             Ok(true) => {
                 if let Some(not_found_entry) = app_router.find_not_found(&route_match.route.path) {
                     route_match.not_found = Some(not_found_entry);

--- a/crates/rari/src/server/actions.rs
+++ b/crates/rari/src/server/actions.rs
@@ -25,13 +25,16 @@ use serde_json::Value;
 
 use crate::{
     rendering::{
-        base::constants::{ACTION_FLIGHT_ENCODE_SCRIPT, ACTION_HANDLER_SCRIPT, GET_RSC_BINARY_B64},
+        base::{
+            constants::{ACTION_FLIGHT_ENCODE_SCRIPT, ACTION_HANDLER_SCRIPT, GET_RSC_BINARY_B64},
+            run_with_renderer_result,
+        },
         layout::{LayoutRenderer, create_layout_context},
     },
     runtime::factory::JsRuntimeInterface,
     server::{
         ServerState,
-        cache::revalidate::invalidate_route_caches,
+        cache::revalidate::{invalidate_route_caches, invalidate_route_caches_on},
         config::RedirectConfig,
         core::utils::http::{extract_headers, extract_search_params, is_origin_allowed},
         error_response,
@@ -260,9 +263,18 @@ fn redirect_target_path(redirect_url: &str) -> String {
     }
 }
 
-async fn invalidate_redirect_target_caches(state: &ServerState, redirect_url: &str) {
+async fn invalidate_redirect_target_caches(
+    state: &ServerState,
+    redirect_url: &str,
+    sticky_runtime: Option<&Arc<dyn crate::runtime::factory::JsRuntimeInterface>>,
+) {
     let redirect_path = redirect_target_path(redirect_url);
-    if let Err(e) = invalidate_route_caches(state, &redirect_path).await {
+    let result = if let Some(runtime) = sticky_runtime {
+        invalidate_route_caches_on(state, &redirect_path, runtime).await
+    } else {
+        invalidate_route_caches(state, &redirect_path).await
+    };
+    if let Err(e) = result {
         tracing::warn!(
             error = %e,
             path = %redirect_path,
@@ -580,7 +592,11 @@ async fn compose_action_refresh_route(
         }
     }
 
-    if let Err(error) = invalidate_route_caches(state, &pathname).await {
+    if let Err(error) = if let Some(runtime) = sticky_runtime {
+        invalidate_route_caches_on(state, &pathname, runtime).await
+    } else {
+        invalidate_route_caches(state, &pathname).await
+    } {
         tracing::warn!(
             error = %error,
             path = %pathname,
@@ -693,6 +709,19 @@ async fn handle_server_action_at_path(
 
     let script_name = action_script_name(action_id);
 
+    if let Err(e) = run_with_renderer_result(Arc::clone(&state.renderer), |renderer| async move {
+        renderer.ensure_rsc_pipeline().await
+    })
+    .await
+    {
+        tracing::error!("Failed to ensure RSC pipeline for server action: {}", e);
+        return Ok(rpc_action_error_response(
+            &e,
+            state.config.is_development(),
+            Some(&request_context.pending_cookies),
+        ));
+    }
+
     let leased = match runtime.acquire_request_runtime(Arc::clone(&request_context)).await {
         Ok(leased) => leased,
         Err(e) => {
@@ -755,7 +784,7 @@ async fn handle_server_action_at_path(
     let redirect = extract_redirect_from_result(&value, &redirect_config);
 
     if let Some(ref redirect_url) = redirect {
-        invalidate_redirect_target_caches(&state, redirect_url).await;
+        invalidate_redirect_target_caches(&state, redirect_url, Some(leased.runtime())).await;
     }
 
     if is_document_form_post {
@@ -794,7 +823,7 @@ async fn handle_server_action_at_path(
             .or(page_form_redirect_path);
 
         if let Some(document_redirect_target) = document_redirect_target {
-            invalidate_redirect_target_caches(&state, &document_redirect_target).await;
+            invalidate_redirect_target_caches(&state, &document_redirect_target, None).await;
             return Ok(document_form_redirect_response(
                 &document_redirect_target,
                 &request_context.pending_cookies,

--- a/crates/rari/src/server/actions.rs
+++ b/crates/rari/src/server/actions.rs
@@ -28,7 +28,7 @@ use crate::{
         base::constants::{ACTION_FLIGHT_ENCODE_SCRIPT, ACTION_HANDLER_SCRIPT, GET_RSC_BINARY_B64},
         layout::{LayoutRenderer, create_layout_context},
     },
-    runtime::JsExecutionRuntime,
+    runtime::factory::JsRuntimeInterface,
     server::{
         ServerState,
         cache::revalidate::invalidate_route_caches,
@@ -458,7 +458,7 @@ fn rpc_action_flight_response(
 }
 
 async fn capture_last_action_flight_binary(
-    runtime: &JsExecutionRuntime,
+    runtime: &Arc<dyn JsRuntimeInterface>,
 ) -> Result<Option<Vec<u8>>, RariError> {
     let result = runtime
         .execute_script("get_action_flight_binary_b64".to_string(), GET_RSC_BINARY_B64.to_string())
@@ -592,19 +592,8 @@ async fn compose_action_refresh_route(
         Arc::clone(&state.layout_html_cache),
     );
     layout_renderer
-        .compose_route_for_action_refresh(&route_match, &context, request_context)
+        .compose_route_for_action_refresh(&route_match, &context, request_context, search)
         .await?;
-
-    let runtime = {
-        let renderer = state.renderer.lock().await;
-        Arc::clone(&renderer.runtime)
-    };
-
-    let set_search_script = format!(
-        "globalThis['~rari'] = globalThis['~rari'] || {{}}; globalThis['~rari'].actionRefreshSearch = {};",
-        serde_json::to_string(&search).map_err(|e| RariError::serialization(e.to_string()))?
-    );
-    runtime.execute_script("set_action_refresh_search".to_string(), set_search_script).await?;
 
     Ok(Some(pathname))
 }
@@ -815,28 +804,18 @@ async fn handle_server_action_at_path(
         format!("action_flight_encode_req{nonce}.ts")
     };
 
-    if let Err(error) = runtime
-        .execute_script_with_request_context(
-            Arc::clone(&request_context),
-            encode_script_name,
-            ACTION_FLIGHT_ENCODE_SCRIPT.to_string(),
-        )
+    let flight_body = match runtime
+        .with_request_context(Arc::clone(&request_context), move |rt| async move {
+            rt.execute_script(encode_script_name, ACTION_FLIGHT_ENCODE_SCRIPT.to_string()).await?;
+            capture_last_action_flight_binary(&rt).await
+        })
         .await
     {
-        tracing::error!("Failed to encode action flight response: {}", error);
-        return Ok(rpc_action_error_response(
-            &error,
-            state.config.is_development(),
-            Some(&request_context.pending_cookies),
-        ));
-    }
-
-    let flight_body = match capture_last_action_flight_binary(&runtime).await {
         Ok(body) => body,
-        Err(e) => {
-            tracing::error!("Failed to read action flight response: {}", e);
+        Err(error) => {
+            tracing::error!("Failed to encode action flight response: {}", error);
             return Ok(rpc_action_error_response(
-                &e,
+                &error,
                 state.config.is_development(),
                 Some(&request_context.pending_cookies),
             ));

--- a/crates/rari/src/server/actions.rs
+++ b/crates/rari/src/server/actions.rs
@@ -534,6 +534,7 @@ async fn compose_action_refresh_route(
     state: &ServerState,
     headers: &HeaderMap,
     request_context: Arc<RequestContext>,
+    sticky_runtime: Option<&Arc<dyn JsRuntimeInterface>>,
 ) -> Result<Option<String>, RariError> {
     let Some((pathname, search, query_params)) = parse_action_refresh_target(headers) else {
         return Ok(None);
@@ -591,9 +592,15 @@ async fn compose_action_refresh_route(
         Arc::clone(&state.renderer),
         Arc::clone(&state.layout_html_cache),
     );
-    layout_renderer
-        .compose_route_for_action_refresh(&route_match, &context, request_context, search)
-        .await?;
+    if let Some(runtime) = sticky_runtime {
+        layout_renderer
+            .compose_route_for_action_refresh_on(runtime, &route_match, &context, search)
+            .await?;
+    } else {
+        layout_renderer
+            .compose_route_for_action_refresh(&route_match, &context, request_context, search)
+            .await?;
+    }
 
     Ok(Some(pathname))
 }
@@ -686,13 +693,36 @@ async fn handle_server_action_at_path(
 
     let script_name = action_script_name(action_id);
 
-    let mut value = match runtime
-        .execute_script_with_request_context(Arc::clone(&request_context), script_name, script)
-        .await
-    {
+    let leased = match runtime.acquire_request_runtime(Arc::clone(&request_context)).await {
+        Ok(leased) => leased,
+        Err(e) => {
+            tracing::error!("Failed to acquire JS runtime for server action: {}", e);
+            if is_document_form_post {
+                #[expect(
+                    clippy::expect_used,
+                    reason = "Response::builder() with valid components never fails"
+                )]
+                let mut response = Response::builder()
+                    .status(error_response::status(&e))
+                    .header(header::CACHE_CONTROL, "no-store, no-cache, must-revalidate, private")
+                    .body(Body::from(e.safe_message(state.config.is_development())))
+                    .expect("Valid error response");
+                append_pending_cookies(response.headers_mut(), &request_context.pending_cookies);
+                return Ok(response);
+            }
+            return Ok(rpc_action_error_response(
+                &e,
+                state.config.is_development(),
+                Some(&request_context.pending_cookies),
+            ));
+        }
+    };
+
+    let mut value = match leased.execute_script(script_name, script).await {
         Ok(value) => value,
         Err(e) => {
             tracing::error!("Server action execution failed: {}", e);
+            let _ = leased.release().await;
             if is_document_form_post {
                 #[expect(
                     clippy::expect_used,
@@ -729,6 +759,7 @@ async fn handle_server_action_at_path(
     }
 
     if is_document_form_post {
+        let _ = leased.release().await;
         if is_failed_action_result(&value) {
             let error_message = value
                 .get("error")
@@ -785,8 +816,13 @@ async fn handle_server_action_at_path(
 
     let mut revalidated_path = None;
     if redirect.is_none() {
-        let refresh_result =
-            compose_action_refresh_route(&state, &headers, Arc::clone(&request_context)).await;
+        let refresh_result = compose_action_refresh_route(
+            &state,
+            &headers,
+            Arc::clone(&request_context),
+            Some(leased.runtime()),
+        )
+        .await;
         revalidated_path = match refresh_result {
             Ok(path) => path,
             Err(error) => {
@@ -804,16 +840,16 @@ async fn handle_server_action_at_path(
         format!("action_flight_encode_req{nonce}.ts")
     };
 
-    let flight_body = match runtime
-        .with_request_context(Arc::clone(&request_context), move |rt| async move {
-            rt.execute_script(encode_script_name, ACTION_FLIGHT_ENCODE_SCRIPT.to_string()).await?;
-            capture_last_action_flight_binary(&rt).await
-        })
-        .await
+    let flight_body = match async {
+        leased.execute_script(encode_script_name, ACTION_FLIGHT_ENCODE_SCRIPT.to_string()).await?;
+        capture_last_action_flight_binary(leased.runtime()).await
+    }
+    .await
     {
         Ok(body) => body,
         Err(error) => {
             tracing::error!("Failed to encode action flight response: {}", error);
+            let _ = leased.release().await;
             return Ok(rpc_action_error_response(
                 &error,
                 state.config.is_development(),
@@ -821,6 +857,10 @@ async fn handle_server_action_at_path(
             ));
         }
     };
+
+    if let Err(e) = leased.release().await {
+        tracing::error!("Failed to release action runtime lease: {}", e);
+    }
 
     let Some(flight_body) = flight_body else {
         tracing::error!("RPC server action did not produce a Flight response payload");

--- a/crates/rari/src/server/actions.rs
+++ b/crates/rari/src/server/actions.rs
@@ -266,7 +266,7 @@ fn redirect_target_path(redirect_url: &str) -> String {
 async fn invalidate_redirect_target_caches(
     state: &ServerState,
     redirect_url: &str,
-    sticky_runtime: Option<&Arc<dyn crate::runtime::factory::JsRuntimeInterface>>,
+    sticky_runtime: Option<&Arc<dyn JsRuntimeInterface>>,
 ) {
     let redirect_path = redirect_target_path(redirect_url);
     let result = if let Some(runtime) = sticky_runtime {

--- a/crates/rari/src/server/cache/revalidate.rs
+++ b/crates/rari/src/server/cache/revalidate.rs
@@ -9,6 +9,7 @@ use tokio::sync::Mutex;
 
 use crate::{
     rendering::base::RscRenderer,
+    runtime::factory::JsRuntimeInterface,
     server::{ServerState, cache::response},
 };
 
@@ -41,6 +42,24 @@ pub(crate) async fn invalidate_use_cache_entries(
     tag: Option<&str>,
     path: Option<&str>,
 ) -> Result<(), RariError> {
+    let script = use_cache_invalidate_script(tag, path);
+    let runtime = {
+        let renderer = renderer.lock().await;
+        Arc::clone(&renderer.runtime)
+    };
+    runtime.broadcast_script("use_cache_invalidate", &script).await
+}
+
+pub(crate) async fn invalidate_use_cache_entries_on(
+    sticky_runtime: &Arc<dyn JsRuntimeInterface>,
+    tag: Option<&str>,
+    path: Option<&str>,
+) -> Result<(), RariError> {
+    let script = use_cache_invalidate_script(tag, path);
+    sticky_runtime.execute_script("use_cache_invalidate".to_string(), script).await.map(|_| ())
+}
+
+fn use_cache_invalidate_script(tag: Option<&str>, path: Option<&str>) -> String {
     let tag_literal = tag
         .and_then(|value| serde_json::to_string(value).ok())
         .unwrap_or_else(|| "undefined".to_string());
@@ -48,7 +67,7 @@ pub(crate) async fn invalidate_use_cache_entries(
         .and_then(|value| serde_json::to_string(value).ok())
         .unwrap_or_else(|| "undefined".to_string());
 
-    let script = format!(
+    format!(
         "(async () => {{
             const invalidateDirect = globalThis.__rariInvalidateUseCache;
             const invalidateBridge = globalThis['~rari']?.invalidateUseCache;
@@ -63,26 +82,42 @@ pub(crate) async fn invalidate_use_cache_entries(
                 await invalidateBridge({{ tag: {tag_literal}, path: {path_literal} }});
             }}
         }})()"
-    );
-
-    let runtime = {
-        let renderer = renderer.lock().await;
-        Arc::clone(&renderer.runtime)
-    };
-
-    runtime.broadcast_script("use_cache_invalidate", &script).await
+    )
 }
 
 pub(crate) async fn invalidate_route_caches(
     state: &ServerState,
     path: &str,
 ) -> Result<(), RariError> {
+    invalidate_route_caches_inner(state, path, None).await
+}
+
+/// Like [`invalidate_route_caches`], but runs use-cache invalidation on `sticky_runtime`
+/// instead of broadcasting (avoids re-entering a held pool slot lease).
+pub(crate) async fn invalidate_route_caches_on(
+    state: &ServerState,
+    path: &str,
+    sticky_runtime: &Arc<dyn JsRuntimeInterface>,
+) -> Result<(), RariError> {
+    invalidate_route_caches_inner(state, path, Some(sticky_runtime)).await
+}
+
+async fn invalidate_route_caches_inner(
+    state: &ServerState,
+    path: &str,
+    sticky_runtime: Option<&Arc<dyn JsRuntimeInterface>>,
+) -> Result<(), RariError> {
     state.response_cache.invalidate(path).await;
     state.response_cache.invalidate_by_tag(path).await;
     response::invalidate_static_fast_cache_for_path(&state.static_fast_cache, path);
     state.html_cache.remove(path);
 
-    if let Err(e) = invalidate_use_cache_entries(&state.renderer, None, Some(path)).await {
+    let use_cache_result = if let Some(runtime) = sticky_runtime {
+        invalidate_use_cache_entries_on(runtime, None, Some(path)).await
+    } else {
+        invalidate_use_cache_entries(&state.renderer, None, Some(path)).await
+    };
+    if let Err(e) = use_cache_result {
         tracing::warn!(error = %e, path = %path, "use cache invalidate failed during route cache invalidation");
         return Err(e);
     }

--- a/crates/rari/src/server/cache/revalidate.rs
+++ b/crates/rari/src/server/cache/revalidate.rs
@@ -70,7 +70,7 @@ pub(crate) async fn invalidate_use_cache_entries(
         Arc::clone(&renderer.runtime)
     };
 
-    runtime.execute_script("use_cache_invalidate".to_string(), script).await.map(|_| ())
+    runtime.broadcast_script("use_cache_invalidate", &script).await
 }
 
 pub(crate) async fn invalidate_route_caches(

--- a/crates/rari/src/server/cache/warmup.rs
+++ b/crates/rari/src/server/cache/warmup.rs
@@ -125,17 +125,18 @@ async fn warm_route(
 
     let _render_guard = warmup_render_lock().await.lock_owned().await;
 
+    context.metadata = collect_page_metadata(state, &route_match, &context).await;
+
     let render_result = layout_renderer
         .render_route_with_streaming(
             &route_match,
             &context,
             Some(Arc::clone(&request_context)),
             false,
+            None,
         )
         .await
         .map_err(|e| RariError::internal(format!("Render failed: {e}")))?;
-
-    context.metadata = collect_page_metadata(state, &route_match, &context).await;
 
     let html = match render_result {
         RenderResult::Static(html) => html,
@@ -273,5 +274,6 @@ fn create_warmup_context(route_match: &AppRouteMatch) -> LayoutRenderContext {
         pathname: route_match.pathname.clone(),
         template_navigation_id: None,
         metadata: None,
+        streaming_head_extra: None,
     }
 }

--- a/crates/rari/src/server/config.rs
+++ b/crates/rari/src/server/config.rs
@@ -14,7 +14,7 @@ use http::HeaderValue;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
-use crate::server::{image::ImageConfig, rendering::html_bots::validate_html_limited_bots_pattern};
+use crate::server::{image::ImageConfig, rendering::html_bots::compile_html_limited_bots_pattern};
 
 pub static GLOBAL_CONFIG: OnceLock<Config> = OnceLock::new();
 
@@ -381,6 +381,9 @@ pub struct Config {
     pub use_cache: UseCacheConfig,
     #[serde(default, rename = "htmlLimitedBots")]
     pub html_limited_bots: Option<String>,
+    /// Precompiled override from `html_limited_bots`; `None` uses the default list.
+    #[serde(skip)]
+    pub html_limited_bots_regex: Option<regex::Regex>,
 }
 
 impl Config {
@@ -629,9 +632,10 @@ impl Config {
                 if let Some(pattern) =
                     config_data.get("htmlLimitedBots").and_then(serde_json::Value::as_str)
                 {
-                    match validate_html_limited_bots_pattern(pattern) {
-                        Ok(()) => {
+                    match compile_html_limited_bots_pattern(pattern) {
+                        Ok(re) => {
                             config.html_limited_bots = Some(pattern.to_string());
+                            config.html_limited_bots_regex = Some(re);
                         }
                         Err(err) => {
                             tracing::warn!(
@@ -753,6 +757,20 @@ impl Config {
                 return Err(ConfigError::Config("RARI_JS_POOL_SIZE must be >= 1".to_string()));
             }
             config.server.js_pool_size = pool_size;
+        }
+
+        if let Ok(pattern) = env::var("RARI_HTML_LIMITED_BOTS") {
+            match compile_html_limited_bots_pattern(&pattern) {
+                Ok(re) => {
+                    config.html_limited_bots = Some(pattern);
+                    config.html_limited_bots_regex = Some(re);
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        "Invalid RARI_HTML_LIMITED_BOTS regex ({pattern:?}): {err}. Ignoring override."
+                    );
+                }
+            }
         }
 
         if config.mode == Mode::Development {
@@ -1176,6 +1194,7 @@ mod tests {
             .unwrap();
         let valid = Config::from_env_with_base(Some(&temp_dir)).unwrap();
         assert_eq!(valid.html_limited_bots.as_deref(), Some("OnlyMyBot"));
+        assert!(valid.html_limited_bots_regex.is_some());
 
         fs::write(dist_server_dir.join("config.json"), r#"{"htmlLimitedBots":"(OnlyMyBot"}"#)
             .unwrap();
@@ -1184,6 +1203,7 @@ mod tests {
             invalid.html_limited_bots.is_none(),
             "invalid regex must fall back to default (None override)"
         );
+        assert!(invalid.html_limited_bots_regex.is_none());
 
         let _ = fs::remove_dir_all(&temp_dir);
     }

--- a/crates/rari/src/server/config.rs
+++ b/crates/rari/src/server/config.rs
@@ -14,7 +14,7 @@ use http::HeaderValue;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
-use crate::server::image::ImageConfig;
+use crate::server::{image::ImageConfig, rendering::html_bots::validate_html_limited_bots_pattern};
 
 pub static GLOBAL_CONFIG: OnceLock<Config> = OnceLock::new();
 
@@ -43,6 +43,12 @@ pub struct ServerConfig {
     pub origin: Option<String>,
     pub enable_logging: bool,
     pub timeout_seconds: u64,
+    #[serde(default = "default_js_pool_size")]
+    pub js_pool_size: usize,
+}
+
+fn default_js_pool_size() -> usize {
+    1
 }
 
 impl Default for ServerConfig {
@@ -53,6 +59,7 @@ impl Default for ServerConfig {
             origin: None,
             enable_logging: true,
             timeout_seconds: 30,
+            js_pool_size: default_js_pool_size(),
         }
     }
 }
@@ -370,8 +377,10 @@ pub struct Config {
     pub images: ImageConfig,
     #[serde(default)]
     pub cache: CacheConfig,
-    #[serde(default, rename = "useCache")]
+    #[serde(default)]
     pub use_cache: UseCacheConfig,
+    #[serde(default, rename = "htmlLimitedBots")]
+    pub html_limited_bots: Option<String>,
 }
 
 impl Config {
@@ -535,169 +544,215 @@ impl Config {
 
         if let Ok(server_config_json) = fs::read_to_string(&config_path) {
             let config_data = match serde_json::from_str::<serde_json::Value>(&server_config_json) {
-                Ok(data) => data,
+                Ok(data) => Some(data),
                 Err(e) => {
                     tracing::warn!(
                         "Failed to parse dist/server/config.json: {}. Using defaults.",
                         e
                     );
-                    return Ok(config);
+                    None
                 }
             };
-            if let Some(csp_data) = config_data.get("csp") {
-                if let Some(script_src) = csp_data.get("scriptSrc").and_then(|v| v.as_array()) {
-                    config.csp.script_src = script_src
-                        .iter()
-                        .filter_map(|v| v.as_str().map(ToString::to_string))
-                        .collect();
+            if let Some(config_data) = config_data {
+                if let Some(csp_data) = config_data.get("csp") {
+                    if let Some(script_src) = csp_data.get("scriptSrc").and_then(|v| v.as_array()) {
+                        config.csp.script_src = script_src
+                            .iter()
+                            .filter_map(|v| v.as_str().map(ToString::to_string))
+                            .collect();
+                    }
+                    if let Some(style_src) = csp_data.get("styleSrc").and_then(|v| v.as_array()) {
+                        config.csp.style_src = style_src
+                            .iter()
+                            .filter_map(|v| v.as_str().map(ToString::to_string))
+                            .collect();
+                    }
+                    if let Some(img_src) = csp_data.get("imgSrc").and_then(|v| v.as_array()) {
+                        config.csp.img_src = img_src
+                            .iter()
+                            .filter_map(|v| v.as_str().map(ToString::to_string))
+                            .collect();
+                    }
+                    if let Some(font_src) = csp_data.get("fontSrc").and_then(|v| v.as_array()) {
+                        config.csp.font_src = font_src
+                            .iter()
+                            .filter_map(|v| v.as_str().map(ToString::to_string))
+                            .collect();
+                    }
+                    if let Some(connect_src) = csp_data.get("connectSrc").and_then(|v| v.as_array())
+                    {
+                        config.csp.connect_src = connect_src
+                            .iter()
+                            .filter_map(|v| v.as_str().map(ToString::to_string))
+                            .collect();
+                    }
+                    if let Some(default_src) = csp_data.get("defaultSrc").and_then(|v| v.as_array())
+                    {
+                        config.csp.default_src = default_src
+                            .iter()
+                            .filter_map(|v| v.as_str().map(ToString::to_string))
+                            .collect();
+                    }
+                    if let Some(worker_src) = csp_data.get("workerSrc").and_then(|v| v.as_array()) {
+                        config.csp.worker_src = worker_src
+                            .iter()
+                            .filter_map(|v| v.as_str().map(ToString::to_string))
+                            .collect();
+                    }
                 }
-                if let Some(style_src) = csp_data.get("styleSrc").and_then(|v| v.as_array()) {
-                    config.csp.style_src = style_src
-                        .iter()
-                        .filter_map(|v| v.as_str().map(ToString::to_string))
-                        .collect();
-                }
-                if let Some(img_src) = csp_data.get("imgSrc").and_then(|v| v.as_array()) {
-                    config.csp.img_src = img_src
-                        .iter()
-                        .filter_map(|v| v.as_str().map(ToString::to_string))
-                        .collect();
-                }
-                if let Some(font_src) = csp_data.get("fontSrc").and_then(|v| v.as_array()) {
-                    config.csp.font_src = font_src
-                        .iter()
-                        .filter_map(|v| v.as_str().map(ToString::to_string))
-                        .collect();
-                }
-                if let Some(connect_src) = csp_data.get("connectSrc").and_then(|v| v.as_array()) {
-                    config.csp.connect_src = connect_src
-                        .iter()
-                        .filter_map(|v| v.as_str().map(ToString::to_string))
-                        .collect();
-                }
-                if let Some(default_src) = csp_data.get("defaultSrc").and_then(|v| v.as_array()) {
-                    config.csp.default_src = default_src
-                        .iter()
-                        .filter_map(|v| v.as_str().map(ToString::to_string))
-                        .collect();
-                }
-                if let Some(worker_src) = csp_data.get("workerSrc").and_then(|v| v.as_array()) {
-                    config.csp.worker_src = worker_src
-                        .iter()
-                        .filter_map(|v| v.as_str().map(ToString::to_string))
-                        .collect();
-                }
-            }
 
-            if let Some(action_data) = config_data.get("action")
-                && let Some(allowed_origins) =
-                    action_data.get("allowedOrigins").and_then(|v| v.as_array())
-            {
-                config.action.allowed_origins = allowed_origins
-                    .iter()
-                    .filter_map(|v| v.as_str().map(ToString::to_string))
-                    .collect();
-            }
+                if let Some(action_data) = config_data.get("action")
+                    && let Some(allowed_origins) =
+                        action_data.get("allowedOrigins").and_then(|v| v.as_array())
+                {
+                    config.action.allowed_origins = allowed_origins
+                        .iter()
+                        .filter_map(|v| v.as_str().map(ToString::to_string))
+                        .collect();
+                }
 
-            if let Some(cache_control_data) = config_data.get("cacheControl")
-                && let Some(routes) = cache_control_data.get("routes").and_then(|v| v.as_object())
-            {
-                for (route, cache_value) in routes {
-                    if let Some(cache_str) = cache_value.as_str() {
-                        if HeaderValue::from_str(cache_str).is_ok() {
-                            config.caching.routes.insert(route.clone(), cache_str.to_string());
+                if let Some(pool_size) =
+                    config_data.get("jsPoolSize").and_then(serde_json::Value::as_u64)
+                {
+                    match usize::try_from(pool_size) {
+                        Ok(0) | Err(_) => {
+                            tracing::warn!(
+                                "jsPoolSize must be >= 1 and fit in usize; ignoring value from config.json"
+                            );
+                        }
+                        Ok(size) => {
+                            config.server.js_pool_size = size;
+                        }
+                    }
+                }
+
+                if let Some(pattern) =
+                    config_data.get("htmlLimitedBots").and_then(serde_json::Value::as_str)
+                {
+                    match validate_html_limited_bots_pattern(pattern) {
+                        Ok(()) => {
+                            config.html_limited_bots = Some(pattern.to_string());
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                "Invalid htmlLimitedBots regex in config.json ({pattern:?}): {err}. Using default list."
+                            );
+                        }
+                    }
+                }
+
+                if let Some(cache_control_data) = config_data.get("cacheControl")
+                    && let Some(routes) =
+                        cache_control_data.get("routes").and_then(|v| v.as_object())
+                {
+                    for (route, cache_value) in routes {
+                        if let Some(cache_str) = cache_value.as_str() {
+                            if HeaderValue::from_str(cache_str).is_ok() {
+                                config.caching.routes.insert(route.clone(), cache_str.to_string());
+                            } else {
+                                tracing::warn!(
+                                    "Invalid cache-control header value for route '{}': '{}' (contains invalid characters)",
+                                    route,
+                                    cache_str
+                                );
+                            }
                         } else {
                             tracing::warn!(
-                                "Invalid cache-control header value for route '{}': '{}' (contains invalid characters)",
+                                "Invalid cache-control value type for route '{}': expected string, got {:?}",
                                 route,
-                                cache_str
-                            );
-                        }
-                    } else {
-                        tracing::warn!(
-                            "Invalid cache-control value type for route '{}': expected string, got {:?}",
-                            route,
-                            cache_value
-                        );
-                    }
-                }
-            }
-
-            if let Some(cache_data) = config_data.get("cache")
-                && let Some(layers_data) = cache_data.get("layers").and_then(|v| v.as_object())
-            {
-                for (layer_name, layer_value) in layers_data {
-                    if !layer_value.is_object() {
-                        tracing::warn!(
-                            "Invalid cache.layers.{} value type: expected object, got {:?}",
-                            layer_name,
-                            layer_value
-                        );
-                        continue;
-                    }
-                    match serde_json::from_value::<CacheLayerConfig>(layer_value.clone()) {
-                        Ok(layer) => {
-                            config.cache.layers.insert(layer_name.clone(), layer);
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                "Failed to parse cache.layers.{}: {}. Using default.",
-                                layer_name,
-                                e
+                                cache_value
                             );
                         }
                     }
                 }
-            }
 
-            if let Some(use_cache_data) = config_data.get("useCache") {
-                if let Some(build_id) =
-                    use_cache_data.get("buildId").and_then(|value| value.as_str())
+                if let Some(cache_data) = config_data.get("cache")
+                    && let Some(layers_data) = cache_data.get("layers").and_then(|v| v.as_object())
                 {
-                    config.use_cache.build_id = Some(build_id.to_string());
-                }
-
-                if let Some(remote_value) = use_cache_data.get("remote") {
-                    match serde_json::from_value::<CacheLayerConfig>(remote_value.clone()) {
-                        Ok(mut layer) => {
-                            let trimmed_url = layer.url.as_deref().map(str::trim);
-                            let missing_url = trimmed_url.is_none_or(str::is_empty);
-
-                            match layer.handler.as_str() {
-                                "test" if config.mode == Mode::Production => {
-                                    tracing::warn!(
-                                        "Invalid useCache.remote: handler='test' is for e2e tests only and is not allowed in production. Ignoring remote cache config."
-                                    );
-                                }
-                                "redis" | "redb" if missing_url => {
-                                    tracing::warn!(
-                                        "Invalid useCache.remote: handler={} requires a non-empty url. Ignoring remote cache config.",
-                                        layer.handler
-                                    );
-                                }
-                                "redis" | "redb" | "test" => {
-                                    layer.url = trimmed_url.map(String::from);
-                                    config.use_cache.remote = Some(layer);
-                                }
-                                _ => {
-                                    tracing::warn!(
-                                        "Invalid useCache.remote: handler='{}' is not supported (allowed: test, redis, redb). Ignoring remote cache config.",
-                                        layer.handler
-                                    );
-                                }
+                    for (layer_name, layer_value) in layers_data {
+                        if !layer_value.is_object() {
+                            tracing::warn!(
+                                "Invalid cache.layers.{} value type: expected object, got {:?}",
+                                layer_name,
+                                layer_value
+                            );
+                            continue;
+                        }
+                        match serde_json::from_value::<CacheLayerConfig>(layer_value.clone()) {
+                            Ok(layer) => {
+                                config.cache.layers.insert(layer_name.clone(), layer);
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    "Failed to parse cache.layers.{}: {}. Using default.",
+                                    layer_name,
+                                    e
+                                );
                             }
                         }
-                        Err(e) => {
-                            tracing::warn!(
-                                "Failed to parse useCache.remote: {}. Using default.",
-                                e
-                            );
+                    }
+                }
+
+                if let Some(use_cache_data) = config_data.get("useCache") {
+                    if let Some(build_id) =
+                        use_cache_data.get("buildId").and_then(|value| value.as_str())
+                    {
+                        config.use_cache.build_id = Some(build_id.to_string());
+                    }
+
+                    if let Some(remote_value) = use_cache_data.get("remote") {
+                        match serde_json::from_value::<CacheLayerConfig>(remote_value.clone()) {
+                            Ok(mut layer) => {
+                                let trimmed_url = layer.url.as_deref().map(str::trim);
+                                let missing_url = trimmed_url.is_none_or(str::is_empty);
+
+                                match layer.handler.as_str() {
+                                    "test" if config.mode == Mode::Production => {
+                                        tracing::warn!(
+                                            "Invalid useCache.remote: handler='test' is for e2e tests only and is not allowed in production. Ignoring remote cache config."
+                                        );
+                                    }
+                                    "redis" | "redb" if missing_url => {
+                                        tracing::warn!(
+                                            "Invalid useCache.remote: handler={} requires a non-empty url. Ignoring remote cache config.",
+                                            layer.handler
+                                        );
+                                    }
+                                    "redis" | "redb" | "test" => {
+                                        layer.url = trimmed_url.map(String::from);
+                                        config.use_cache.remote = Some(layer);
+                                    }
+                                    _ => {
+                                        tracing::warn!(
+                                            "Invalid useCache.remote: handler='{}' is not supported (allowed: test, redis, redb). Ignoring remote cache config.",
+                                            layer.handler
+                                        );
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    "Failed to parse useCache.remote: {}. Using default.",
+                                    e
+                                );
+                            }
                         }
                     }
                 }
-            }
+            } // if let Some(config_data)
         } else {
             tracing::debug!("No dist/server/config.json found, using defaults");
+        }
+
+        // Env wins over config.json for deploy-time overrides.
+        if let Ok(pool_size_str) = env::var("RARI_JS_POOL_SIZE") {
+            let pool_size: usize = pool_size_str
+                .parse()
+                .map_err(|_| ConfigError::Config("RARI_JS_POOL_SIZE".to_string()))?;
+            if pool_size == 0 {
+                return Err(ConfigError::Config("RARI_JS_POOL_SIZE must be >= 1".to_string()));
+            }
+            config.server.js_pool_size = pool_size;
         }
 
         if config.mode == Mode::Development {
@@ -1082,6 +1137,55 @@ mod tests {
             !config.caching.routes.contains_key("/invalid-type"),
             "Non-string cache-control value should be rejected"
         );
+    }
+
+    #[test]
+    fn test_js_pool_size_config_json_and_env_precedence() {
+        let temp_dir = env::temp_dir().join(format!("rari_test_pool_size_{}", process::id()));
+        let dist_server_dir = temp_dir.join("dist").join("server");
+        fs::create_dir_all(&dist_server_dir).unwrap();
+
+        let prev = env::var("RARI_JS_POOL_SIZE").ok();
+        // SAFETY: test-only env mutation; restored below. Keep both cases in one
+        // test so parallel suite workers cannot race on this process-global var.
+        unsafe { env::remove_var("RARI_JS_POOL_SIZE") };
+
+        fs::write(dist_server_dir.join("config.json"), r#"{"jsPoolSize":3}"#).unwrap();
+        let from_json = Config::from_env_with_base(Some(&temp_dir)).unwrap();
+        assert_eq!(from_json.server.js_pool_size, 3);
+
+        unsafe { env::set_var("RARI_JS_POOL_SIZE", "4") };
+        let from_env = Config::from_env_with_base(Some(&temp_dir)).unwrap();
+        assert_eq!(from_env.server.js_pool_size, 4);
+
+        let _ = fs::remove_dir_all(&temp_dir);
+        match prev {
+            Some(v) => unsafe { env::set_var("RARI_JS_POOL_SIZE", v) },
+            None => unsafe { env::remove_var("RARI_JS_POOL_SIZE") },
+        }
+    }
+
+    #[test]
+    fn test_html_limited_bots_config_validates_regex() {
+        let temp_dir =
+            env::temp_dir().join(format!("rari_test_html_limited_bots_{}", process::id()));
+        let dist_server_dir = temp_dir.join("dist").join("server");
+        fs::create_dir_all(&dist_server_dir).unwrap();
+
+        fs::write(dist_server_dir.join("config.json"), r#"{"htmlLimitedBots":"OnlyMyBot"}"#)
+            .unwrap();
+        let valid = Config::from_env_with_base(Some(&temp_dir)).unwrap();
+        assert_eq!(valid.html_limited_bots.as_deref(), Some("OnlyMyBot"));
+
+        fs::write(dist_server_dir.join("config.json"), r#"{"htmlLimitedBots":"(OnlyMyBot"}"#)
+            .unwrap();
+        let invalid = Config::from_env_with_base(Some(&temp_dir)).unwrap();
+        assert!(
+            invalid.html_limited_bots.is_none(),
+            "invalid regex must fall back to default (None override)"
+        );
+
+        let _ = fs::remove_dir_all(&temp_dir);
     }
 
     #[test]

--- a/crates/rari/src/server/core/mod.rs
+++ b/crates/rari/src/server/core/mod.rs
@@ -16,6 +16,7 @@ use axum::{
     extract::DefaultBodyLimit,
     middleware::{self},
     routing,
+    serve::ListenerExt,
 };
 use colored::Colorize;
 use dashmap::DashMap;
@@ -115,7 +116,11 @@ impl Server {
         };
 
         let env_vars: rustc_hash::FxHashMap<String, String> = env::vars().collect();
-        let js_runtime = Arc::new(JsExecutionRuntime::new(Some(env_vars)));
+        let js_runtime = Arc::new(JsExecutionRuntime::with_pool_size(
+            Some(env_vars),
+            config.server.js_pool_size,
+        ));
+        js_runtime.set_setup_mode(true);
         let mut renderer =
             RscRenderer::with_resource_limits(Arc::clone(&js_runtime), resource_limits);
         renderer.initialize().await?;
@@ -137,6 +142,7 @@ impl Server {
 
         ComponentLoader::load_ssr_client_components(&renderer.runtime).await?;
         ComponentLoader::load_client_reference_manifest(&renderer.runtime).await?;
+        js_runtime.set_setup_mode(false);
 
         let routes_manifest = RoutesManifest::load_from_file(ROUTES_MANIFEST_PATH).await;
 
@@ -167,6 +173,17 @@ impl Server {
         };
 
         let renderer_arc = Arc::new(Mutex::new(renderer));
+
+        {
+            let renderer_for_hook = Arc::clone(&renderer_arc);
+            js_runtime.set_post_rebuild_hook(Arc::new(move |_idx, slot_runtime| {
+                let renderer_for_hook = Arc::clone(&renderer_for_hook);
+                Box::pin(async move {
+                    let renderer = renderer_for_hook.lock().await;
+                    renderer.resync_slot(slot_runtime).await
+                })
+            }));
+        }
 
         let project_root = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
@@ -394,7 +411,15 @@ impl Server {
     ) -> Result<(), RariError> {
         self.display_startup_message();
 
-        axum::serve(self.listener, self.router.into_make_service_with_connect_info::<SocketAddr>())
+        // Disable Nagle so the final streaming chunk is not delayed ~20–40ms waiting
+        // for a delayed ACK (classic last-byte tax on short responses / localhost).
+        let listener = self.listener.tap_io(|tcp_stream| {
+            if let Err(err) = tcp_stream.set_nodelay(true) {
+                tracing::warn!("failed to set TCP_NODELAY on incoming connection: {err}");
+            }
+        });
+
+        axum::serve(listener, self.router.into_make_service_with_connect_info::<SocketAddr>())
             .with_graceful_shutdown(shutdown)
             .await
             .map_err(|e| RariError::network(format!("Server error: {e}")))?;

--- a/crates/rari/src/server/loader.rs
+++ b/crates/rari/src/server/loader.rs
@@ -83,42 +83,31 @@ impl ComponentLoader {
                     continue;
                 }
 
-                match renderer.runtime.load_es_module(component_id).await {
-                    Ok(module_id) => {
-                        if let Err(e) = renderer.runtime.evaluate_module(module_id).await {
-                            tracing::error!(
-                                "Failed to evaluate module {} (id: {}): {}",
-                                component_id,
-                                module_id,
-                                e
-                            );
-                            continue;
-                        }
+                if let Err(e) = renderer.runtime.load_and_evaluate_module(component_id).await {
+                    tracing::error!(
+                        "Failed to load/evaluate component {} as ESM module: {}",
+                        component_id,
+                        e
+                    );
+                    continue;
+                }
 
-                        match renderer.runtime.get_module_namespace(module_id).await {
-                            Ok(_namespace) => {
-                                let specifier_json = serde_json::to_string(specifier)
-                                    .unwrap_or_else(|e| {
-                                        tracing::error!(
-                                            "Failed to serialize module specifier for {}: {}",
-                                            component_id,
-                                            e
-                                        );
-                                        "\"\"".to_string()
-                                    });
-                                let component_id_json = serde_json::to_string(component_id)
-                                    .unwrap_or_else(|e| {
-                                        tracing::error!(
-                                            "Failed to serialize component_id {}: {}",
-                                            component_id,
-                                            e
-                                        );
-                                        "\"\"".to_string()
-                                    });
+                let specifier_json = serde_json::to_string(specifier).unwrap_or_else(|e| {
+                    tracing::error!(
+                        "Failed to serialize module specifier for {}: {}",
+                        component_id,
+                        e
+                    );
+                    "\"\"".to_string()
+                });
+                let component_id_json = serde_json::to_string(component_id).unwrap_or_else(|e| {
+                    tracing::error!("Failed to serialize component_id {}: {}", component_id, e);
+                    "\"\"".to_string()
+                });
 
-                                if is_server_action {
-                                    let action_registration_script = format!(
-                                        r#"(async function() {{
+                if is_server_action {
+                    let action_registration_script = format!(
+                        r#"(async function() {{
                                             try {{
                                                 const moduleNamespace = await import({specifier_json});
                                                 if (!globalThis['~rari']) {{
@@ -152,97 +141,71 @@ impl ComponentLoader {
                                                 return {{ success: false, error: error.message }};
                                             }}
                                         }})()"#
-                                    );
+                    );
 
-                                    match renderer
-                                        .runtime
-                                        .execute_script(
-                                            format!(
-                                                "register_action_{}.js",
-                                                component_id.cow_replace('/', "_")
-                                            ),
-                                            action_registration_script,
-                                        )
-                                        .await
-                                    {
-                                        Ok(result) => {
-                                            if let Some(success) = result
-                                                .get("success")
-                                                .and_then(serde_json::Value::as_bool)
-                                                && !success
-                                            {
-                                                tracing::error!(
-                                                    "Failed to register server action {}: {:?}",
-                                                    component_id,
-                                                    result.get("error")
-                                                );
-                                            }
-                                        }
-                                        Err(e) => {
-                                            tracing::error!(
-                                                "Failed to register server action {}: {}",
-                                                component_id,
-                                                e
-                                            );
-                                        }
-                                    }
-                                }
-
-                                if !is_server_action {
-                                    let skip_global_binding = component_id.starts_with("lib/");
-                                    let registration_script = format!(
-                                        r"globalThis['~rari'].componentLoader.registerComponent({specifier_json}, {component_id_json}, {skip_global_binding})"
-                                    );
-
-                                    match renderer
-                                        .runtime
-                                        .execute_script(
-                                            format!(
-                                                "register_{}.js",
-                                                component_id.cow_replace('/', "_")
-                                            ),
-                                            registration_script,
-                                        )
-                                        .await
-                                    {
-                                        Ok(result) => {
-                                            if let Some(success) = result
-                                                .get("success")
-                                                .and_then(serde_json::Value::as_bool)
-                                                && !success
-                                            {
-                                                tracing::error!(
-                                                    "Failed to register component {} to globalThis: {:?}",
-                                                    component_id,
-                                                    result.get("error")
-                                                );
-                                            }
-                                        }
-                                        Err(e) => {
-                                            tracing::error!(
-                                                "Failed to register component {} to globalThis: {}",
-                                                component_id,
-                                                e
-                                            );
-                                        }
-                                    }
-                                }
-                            }
-                            Err(e) => {
+                    match renderer
+                        .runtime
+                        .execute_script(
+                            format!("register_action_{}.js", component_id.cow_replace('/', "_")),
+                            action_registration_script,
+                        )
+                        .await
+                    {
+                        Ok(result) => {
+                            if let Some(success) =
+                                result.get("success").and_then(serde_json::Value::as_bool)
+                                && !success
+                            {
                                 tracing::error!(
-                                    "Failed to get module namespace for {}: {}",
+                                    "Failed to register server action {}: {:?}",
                                     component_id,
-                                    e
+                                    result.get("error")
                                 );
                             }
                         }
+                        Err(e) => {
+                            tracing::error!(
+                                "Failed to register server action {}: {}",
+                                component_id,
+                                e
+                            );
+                        }
                     }
-                    Err(e) => {
-                        tracing::error!(
-                            "Failed to load component {} as ESM module: {}",
-                            component_id,
-                            e
-                        );
+                }
+
+                if !is_server_action {
+                    let skip_global_binding = component_id.starts_with("lib/");
+                    let registration_script = format!(
+                        r"globalThis['~rari'].componentLoader.registerComponent({specifier_json}, {component_id_json}, {skip_global_binding})"
+                    );
+
+                    match renderer
+                        .runtime
+                        .execute_script(
+                            format!("register_{}.js", component_id.cow_replace('/', "_")),
+                            registration_script,
+                        )
+                        .await
+                    {
+                        Ok(result) => {
+                            if let Some(success) =
+                                result.get("success").and_then(serde_json::Value::as_bool)
+                                && !success
+                            {
+                                tracing::error!(
+                                    "Failed to register component {} to globalThis: {:?}",
+                                    component_id,
+                                    result.get("error")
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                "Failed to register component {} to globalThis: {}",
+                                component_id,
+                                e
+                            );
+                        }
                     }
                 }
             } else {
@@ -328,40 +291,36 @@ impl ComponentLoader {
                                         .await;
 
                                     if esm_load_result.is_ok() {
-                                        match renderer.runtime.load_es_module(&action_id).await {
-                                            Ok(module_id) => {
-                                                if let Err(e) = renderer
-                                                    .runtime
-                                                    .evaluate_module(module_id)
-                                                    .await
-                                                {
-                                                    tracing::error!(
-                                                        "Failed to evaluate server action module {}: {}",
-                                                        action_id,
-                                                        e
-                                                    );
-                                                } else {
-                                                    let module_specifier_json = serde_json::to_string(&module_specifier)
+                                        if let Err(e) = renderer
+                                            .runtime
+                                            .load_and_evaluate_module(&action_id)
+                                            .await
+                                        {
+                                            tracing::error!(
+                                                "Failed to load/evaluate server action module {}: {}",
+                                                action_id,
+                                                e
+                                            );
+                                        } else {
+                                            let module_specifier_json = serde_json::to_string(&module_specifier)
                                                         .map_err(|e| {
                                                             tracing::error!("Failed to serialize module_specifier for {}: {}", action_id, e);
                                                             RariError::internal(format!("Failed to serialize module_specifier: {e}"))
                                                         })?;
-                                                    let action_id_json = serde_json::to_string(
-                                                        &action_id,
-                                                    )
-                                                    .map_err(|e| {
-                                                        tracing::error!(
-                                                            "Failed to serialize action_id {}: {}",
-                                                            action_id,
-                                                            e
-                                                        );
-                                                        RariError::internal(format!(
-                                                            "Failed to serialize action_id: {e}"
-                                                        ))
-                                                    })?;
+                                            let action_id_json = serde_json::to_string(&action_id)
+                                                .map_err(|e| {
+                                                    tracing::error!(
+                                                        "Failed to serialize action_id {}: {}",
+                                                        action_id,
+                                                        e
+                                                    );
+                                                    RariError::internal(format!(
+                                                        "Failed to serialize action_id: {e}"
+                                                    ))
+                                                })?;
 
-                                                    let registration_script = format!(
-                                                        r#"(async function() {{
+                                            let registration_script = format!(
+                                                r#"(async function() {{
                                                             try {{
                                                                 const moduleNamespace = await import({module_specifier_json});
                                                                 if (!globalThis['~rari']) {{
@@ -395,59 +354,49 @@ impl ComponentLoader {
                                                                 return {{ success: false, error: error.message }};
                                                             }}
                                                         }})()"#
-                                                    );
+                                            );
 
-                                                    match renderer
-                                                        .runtime
-                                                        .execute_script(
-                                                            format!(
-                                                                "register_action_{}.js",
-                                                                action_id.cow_replace('/', "_")
-                                                            ),
-                                                            registration_script,
-                                                        )
-                                                        .await
+                                            match renderer
+                                                .runtime
+                                                .execute_script(
+                                                    format!(
+                                                        "register_action_{}.js",
+                                                        action_id.cow_replace('/', "_")
+                                                    ),
+                                                    registration_script,
+                                                )
+                                                .await
+                                            {
+                                                Ok(result) => {
+                                                    if let Some(success) = result
+                                                        .get("success")
+                                                        .and_then(serde_json::Value::as_bool)
+                                                        && !success
                                                     {
-                                                        Ok(result) => {
-                                                            if let Some(success) =
-                                                                result.get("success").and_then(
-                                                                    serde_json::Value::as_bool,
-                                                                )
-                                                                && !success
-                                                            {
-                                                                if let Some(error_msg) = result
-                                                                    .get("error")
-                                                                    .and_then(|v| v.as_str())
-                                                                {
-                                                                    tracing::error!(
-                                                                        "Failed to register server action {}: {}",
-                                                                        action_id,
-                                                                        error_msg
-                                                                    );
-                                                                } else {
-                                                                    tracing::error!(
-                                                                        "Failed to register server action {}: unknown error",
-                                                                        action_id
-                                                                    );
-                                                                }
-                                                            }
-                                                        }
-                                                        Err(e) => {
+                                                        if let Some(error_msg) = result
+                                                            .get("error")
+                                                            .and_then(|v| v.as_str())
+                                                        {
                                                             tracing::error!(
                                                                 "Failed to register server action {}: {}",
                                                                 action_id,
-                                                                e
+                                                                error_msg
+                                                            );
+                                                        } else {
+                                                            tracing::error!(
+                                                                "Failed to register server action {}: unknown error",
+                                                                action_id
                                                             );
                                                         }
                                                     }
                                                 }
-                                            }
-                                            Err(e) => {
-                                                tracing::error!(
-                                                    "Failed to load server action {} as ESM module: {}",
-                                                    action_id,
-                                                    e
-                                                );
+                                                Err(e) => {
+                                                    tracing::error!(
+                                                        "Failed to register server action {}: {}",
+                                                        action_id,
+                                                        e
+                                                    );
+                                                }
                                             }
                                         }
                                     } else {
@@ -555,44 +504,40 @@ impl ComponentLoader {
                             .await;
 
                         if esm_load_result.is_ok() {
-                            match renderer.runtime.load_es_module(&relative_str).await {
-                                Ok(module_id) => {
-                                    if let Err(e) =
-                                        renderer.runtime.evaluate_module(module_id).await
-                                    {
+                            if let Err(e) =
+                                renderer.runtime.load_and_evaluate_module(&relative_str).await
+                            {
+                                tracing::error!(
+                                    "Failed to load/evaluate server action module {}: {}",
+                                    relative_str,
+                                    e
+                                );
+                            } else {
+                                let module_specifier_json =
+                                    serde_json::to_string(&module_specifier).map_err(|e| {
                                         tracing::error!(
-                                            "Failed to evaluate server action module {}: {}",
+                                            "Failed to serialize module_specifier for {}: {}",
                                             relative_str,
                                             e
                                         );
-                                    } else {
-                                        let module_specifier_json = serde_json::to_string(
-                                            &module_specifier,
-                                        )
-                                        .map_err(|e| {
-                                            tracing::error!(
-                                                "Failed to serialize module_specifier for {}: {}",
-                                                relative_str,
-                                                e
-                                            );
-                                            RariError::internal(format!(
-                                                "Failed to serialize module_specifier: {e}"
-                                            ))
-                                        })?;
-                                        let relative_str_json =
-                                            serde_json::to_string(&relative_str).map_err(|e| {
-                                                tracing::error!(
-                                                    "Failed to serialize relative_str {}: {}",
-                                                    relative_str,
-                                                    e
-                                                );
-                                                RariError::internal(format!(
-                                                    "Failed to serialize relative_str: {e}"
-                                                ))
-                                            })?;
+                                        RariError::internal(format!(
+                                            "Failed to serialize module_specifier: {e}"
+                                        ))
+                                    })?;
+                                let relative_str_json = serde_json::to_string(&relative_str)
+                                    .map_err(|e| {
+                                        tracing::error!(
+                                            "Failed to serialize relative_str {}: {}",
+                                            relative_str,
+                                            e
+                                        );
+                                        RariError::internal(format!(
+                                            "Failed to serialize relative_str: {e}"
+                                        ))
+                                    })?;
 
-                                        let registration_script = format!(
-                                            r#"(async function() {{
+                                let registration_script = format!(
+                                    r#"(async function() {{
                                                 try {{
                                                     const moduleNamespace = await import({module_specifier_json});
                                                     if (!globalThis['~rari']) {{
@@ -626,57 +571,48 @@ impl ComponentLoader {
                                                     return {{ success: false, error: error.message }};
                                                 }}
                                             }})()"#
-                                        );
+                                );
 
-                                        match renderer
-                                            .runtime
-                                            .execute_script(
-                                                format!(
-                                                    "register_{}.js",
-                                                    relative_str.cow_replace('/', "_")
-                                                ),
-                                                registration_script,
-                                            )
-                                            .await
+                                match renderer
+                                    .runtime
+                                    .execute_script(
+                                        format!(
+                                            "register_{}.js",
+                                            relative_str.cow_replace('/', "_")
+                                        ),
+                                        registration_script,
+                                    )
+                                    .await
+                                {
+                                    Ok(result) => {
+                                        if let Some(success) = result
+                                            .get("success")
+                                            .and_then(serde_json::Value::as_bool)
+                                            && !success
                                         {
-                                            Ok(result) => {
-                                                if let Some(success) = result
-                                                    .get("success")
-                                                    .and_then(serde_json::Value::as_bool)
-                                                    && !success
-                                                {
-                                                    if let Some(error_msg) =
-                                                        result.get("error").and_then(|v| v.as_str())
-                                                    {
-                                                        tracing::error!(
-                                                            "Failed to register server functions from {}: {}",
-                                                            relative_str,
-                                                            error_msg
-                                                        );
-                                                    } else {
-                                                        tracing::error!(
-                                                            "Failed to register server functions from {}: unknown error",
-                                                            relative_str
-                                                        );
-                                                    }
-                                                }
-                                            }
-                                            Err(e) => {
+                                            if let Some(error_msg) =
+                                                result.get("error").and_then(|v| v.as_str())
+                                            {
                                                 tracing::error!(
                                                     "Failed to register server functions from {}: {}",
                                                     relative_str,
-                                                    e
+                                                    error_msg
+                                                );
+                                            } else {
+                                                tracing::error!(
+                                                    "Failed to register server functions from {}: unknown error",
+                                                    relative_str
                                                 );
                                             }
                                         }
                                     }
-                                }
-                                Err(e) => {
-                                    tracing::error!(
-                                        "Failed to load server action {} as ESM module: {}",
-                                        relative_str,
-                                        e
-                                    );
+                                    Err(e) => {
+                                        tracing::error!(
+                                            "Failed to register server functions from {}: {}",
+                                            relative_str,
+                                            e
+                                        );
+                                    }
                                 }
                             }
                         } else {
@@ -739,83 +675,79 @@ impl ComponentLoader {
                         .await;
 
                     if esm_load_result.is_ok() {
-                        match renderer.runtime.load_es_module(&component_id).await {
-                            Ok(module_id) => {
-                                if let Err(e) = renderer.runtime.evaluate_module(module_id).await {
+                        if let Err(e) =
+                            renderer.runtime.load_and_evaluate_module(&component_id).await
+                        {
+                            tracing::error!(
+                                "Failed to load/evaluate ESM module {}: {}",
+                                component_id,
+                                e
+                            );
+                        } else {
+                            let skip_global_binding = component_id.starts_with("lib/");
+                            let module_specifier_json = serde_json::to_string(&module_specifier)
+                                .map_err(|e| {
                                     tracing::error!(
-                                        "Failed to evaluate ESM module {} (id: {}): {}",
+                                        "Failed to serialize module_specifier for {}: {}",
                                         component_id,
-                                        module_id,
                                         e
                                     );
-                                } else {
-                                    let skip_global_binding = component_id.starts_with("lib/");
-                                    let module_specifier_json =
-                                        serde_json::to_string(&module_specifier).map_err(|e| {
-                                            tracing::error!(
-                                                "Failed to serialize module_specifier for {}: {}",
-                                                component_id,
-                                                e
-                                            );
-                                            RariError::internal(format!(
-                                                "Failed to serialize module_specifier: {e}"
-                                            ))
-                                        })?;
-                                    let component_id_json = serde_json::to_string(&component_id)
-                                        .map_err(|e| {
+                                    RariError::internal(format!(
+                                        "Failed to serialize module_specifier: {e}"
+                                    ))
+                                })?;
+                            let component_id_json =
+                                serde_json::to_string(&component_id).map_err(|e| {
+                                    tracing::error!(
+                                        "Failed to serialize component_id {}: {}",
+                                        component_id,
+                                        e
+                                    );
+                                    RariError::internal(format!(
+                                        "Failed to serialize component_id: {e}"
+                                    ))
+                                })?;
+                            let registration_script = format!(
+                                r"globalThis['~rari'].componentLoader.registerComponent({module_specifier_json}, {component_id_json}, {skip_global_binding})"
+                            );
+
+                            match renderer
+                                .runtime
+                                .execute_script(
+                                    format!("register_{}.js", component_id.cow_replace('/', "_")),
+                                    registration_script,
+                                )
+                                .await
+                            {
+                                Ok(result) => {
+                                    let registration_succeeded = result
+                                        .get("success")
+                                        .and_then(serde_json::Value::as_bool)
+                                        .unwrap_or(false);
+
+                                    if !registration_succeeded {
+                                        tracing::error!(
+                                            "Failed to register component {} to globalThis: {:?}",
+                                            component_id,
+                                            result.get("error")
+                                        );
+                                    }
+
+                                    if registration_succeeded && is_client_component {
+                                        let component_id_json = serde_json::to_string(
+                                            &component_id,
+                                        )
+                                        .unwrap_or_else(|e| {
                                             tracing::error!(
                                                 "Failed to serialize component_id {}: {}",
                                                 component_id,
                                                 e
                                             );
-                                            RariError::internal(format!(
-                                                "Failed to serialize component_id: {e}"
-                                            ))
-                                        })?;
-                                    let registration_script = format!(
-                                        r"globalThis['~rari'].componentLoader.registerComponent({module_specifier_json}, {component_id_json}, {skip_global_binding})"
-                                    );
-
-                                    match renderer
-                                        .runtime
-                                        .execute_script(
+                                            "\"\"".to_string()
+                                        });
+                                        let mark_client_script = if skip_global_binding {
                                             format!(
-                                                "register_{}.js",
-                                                component_id.cow_replace('/', "_")
-                                            ),
-                                            registration_script,
-                                        )
-                                        .await
-                                    {
-                                        Ok(result) => {
-                                            let registration_succeeded = result
-                                                .get("success")
-                                                .and_then(serde_json::Value::as_bool)
-                                                .unwrap_or(false);
-
-                                            if !registration_succeeded {
-                                                tracing::error!(
-                                                    "Failed to register component {} to globalThis: {:?}",
-                                                    component_id,
-                                                    result.get("error")
-                                                );
-                                            }
-
-                                            if registration_succeeded && is_client_component {
-                                                let component_id_json = serde_json::to_string(
-                                                    &component_id,
-                                                )
-                                                .unwrap_or_else(|e| {
-                                                    tracing::error!(
-                                                        "Failed to serialize component_id {}: {}",
-                                                        component_id,
-                                                        e
-                                                    );
-                                                    "\"\"".to_string()
-                                                });
-                                                let mark_client_script = if skip_global_binding {
-                                                    format!(
-                                                        r"(function() {{
+                                                r"(function() {{
                                                             const module = globalThis['~rsc']?.modules?.[{component_id_json}];
                                                             if (module) {{
                                                                 const comp = module.default || Object.values(module).find(v => typeof v === 'function');
@@ -826,10 +758,10 @@ impl ComponentLoader {
                                                             }}
                                                             return {{ componentId: {component_id_json}, isClient: true }};
                                                         }})()"
-                                                    )
-                                                } else {
-                                                    format!(
-                                                        r"(function() {{
+                                            )
+                                        } else {
+                                            format!(
+                                                r"(function() {{
                                                             const comp = globalThis[{component_id_json}];
                                                             if (comp && typeof comp === 'function') {{
                                                                 comp['~isClientComponent'] = true;
@@ -837,44 +769,35 @@ impl ComponentLoader {
                                                             }}
                                                             return {{ componentId: {component_id_json}, isClient: true }};
                                                         }})()"
-                                                    )
-                                                };
+                                            )
+                                        };
 
-                                                if let Err(e) = renderer
-                                                    .runtime
-                                                    .execute_script(
-                                                        format!(
-                                                            "mark_client_{}.js",
-                                                            component_id.cow_replace('/', "_")
-                                                        ),
-                                                        mark_client_script,
-                                                    )
-                                                    .await
-                                                {
-                                                    tracing::error!(
-                                                        "Failed to mark component {} as client: {}",
-                                                        component_id,
-                                                        e
-                                                    );
-                                                }
-                                            }
-                                        }
-                                        Err(e) => {
+                                        if let Err(e) = renderer
+                                            .runtime
+                                            .execute_script(
+                                                format!(
+                                                    "mark_client_{}.js",
+                                                    component_id.cow_replace('/', "_")
+                                                ),
+                                                mark_client_script,
+                                            )
+                                            .await
+                                        {
                                             tracing::error!(
-                                                "Failed to register component {}: {}",
+                                                "Failed to mark component {} as client: {}",
                                                 component_id,
                                                 e
                                             );
                                         }
                                     }
                                 }
-                            }
-                            Err(e) => {
-                                tracing::error!(
-                                    "Failed to load component {} as ESM module: {}",
-                                    component_id,
-                                    e
-                                );
+                                Err(e) => {
+                                    tracing::error!(
+                                        "Failed to register component {}: {}",
+                                        component_id,
+                                        e
+                                    );
+                                }
                             }
                         }
                     } else {

--- a/crates/rari/src/server/loader.rs
+++ b/crates/rari/src/server/loader.rs
@@ -138,74 +138,48 @@ impl ComponentLoader {
                                                 return {{ success: true }};
                                             }} catch (error) {{
                                                 console.error("Failed to register server action " + {component_id_json}, error);
-                                                return {{ success: false, error: error.message }};
+                                                throw error;
                                             }}
                                         }})()"#
                     );
 
-                    match renderer
+                    if let Err(e) = renderer
                         .runtime
-                        .execute_script(
-                            format!("register_action_{}.js", component_id.cow_replace('/', "_")),
-                            action_registration_script,
+                        .broadcast_script(
+                            &format!("register_action_{}.js", component_id.cow_replace('/', "_")),
+                            &action_registration_script,
                         )
                         .await
                     {
-                        Ok(result) => {
-                            if let Some(success) =
-                                result.get("success").and_then(serde_json::Value::as_bool)
-                                && !success
-                            {
-                                tracing::error!(
-                                    "Failed to register server action {}: {:?}",
-                                    component_id,
-                                    result.get("error")
-                                );
-                            }
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                "Failed to register server action {}: {}",
-                                component_id,
-                                e
-                            );
-                        }
+                        tracing::error!("Failed to register server action {}: {}", component_id, e);
                     }
                 }
 
                 if !is_server_action {
                     let skip_global_binding = component_id.starts_with("lib/");
                     let registration_script = format!(
-                        r"globalThis['~rari'].componentLoader.registerComponent({specifier_json}, {component_id_json}, {skip_global_binding})"
+                        r"(async function() {{
+                            const result = await globalThis['~rari'].componentLoader.registerComponent({specifier_json}, {component_id_json}, {skip_global_binding});
+                            if (!result || result.success !== true) {{
+                                throw new Error((result && result.error) || 'Component registration failed');
+                            }}
+                            return result;
+                        }})()"
                     );
 
-                    match renderer
+                    if let Err(e) = renderer
                         .runtime
-                        .execute_script(
-                            format!("register_{}.js", component_id.cow_replace('/', "_")),
-                            registration_script,
+                        .broadcast_script(
+                            &format!("register_{}.js", component_id.cow_replace('/', "_")),
+                            &registration_script,
                         )
                         .await
                     {
-                        Ok(result) => {
-                            if let Some(success) =
-                                result.get("success").and_then(serde_json::Value::as_bool)
-                                && !success
-                            {
-                                tracing::error!(
-                                    "Failed to register component {} to globalThis: {:?}",
-                                    component_id,
-                                    result.get("error")
-                                );
-                            }
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                "Failed to register component {} to globalThis: {}",
-                                component_id,
-                                e
-                            );
-                        }
+                        tracing::error!(
+                            "Failed to register component {} to globalThis: {}",
+                            component_id,
+                            e
+                        );
                     }
                 }
             } else {
@@ -351,76 +325,48 @@ impl ComponentLoader {
                                                                 return {{ success: true }};
                                                             }} catch (error) {{
                                                                 console.error("Failed to register server action " + {action_id_json}, error);
-                                                                return {{ success: false, error: error.message }};
+                                                                throw error;
                                                             }}
                                                         }})()"#
                                             );
 
-                                            match renderer
+                                            if let Err(e) = renderer
                                                 .runtime
-                                                .execute_script(
-                                                    format!(
+                                                .broadcast_script(
+                                                    &format!(
                                                         "register_action_{}.js",
                                                         action_id.cow_replace('/', "_")
                                                     ),
-                                                    registration_script,
+                                                    &registration_script,
                                                 )
                                                 .await
                                             {
-                                                Ok(result) => {
-                                                    if let Some(success) = result
-                                                        .get("success")
-                                                        .and_then(serde_json::Value::as_bool)
-                                                        && !success
-                                                    {
-                                                        if let Some(error_msg) = result
-                                                            .get("error")
-                                                            .and_then(|v| v.as_str())
-                                                        {
-                                                            tracing::error!(
-                                                                "Failed to register server action {}: {}",
-                                                                action_id,
-                                                                error_msg
-                                                            );
-                                                        } else {
-                                                            tracing::error!(
-                                                                "Failed to register server action {}: unknown error",
-                                                                action_id
-                                                            );
-                                                        }
-                                                    }
-                                                }
-                                                Err(e) => {
-                                                    tracing::error!(
-                                                        "Failed to register server action {}: {}",
-                                                        action_id,
-                                                        e
-                                                    );
-                                                }
+                                                tracing::error!(
+                                                    "Failed to register server action {}: {}",
+                                                    action_id,
+                                                    e
+                                                );
                                             }
                                         }
                                     } else {
                                         let wrapped_code =
                                             wrap_server_action_module(&dist_code, &action_id);
-                                        match renderer
+                                        if let Err(e) = renderer
                                             .runtime
-                                            .execute_script(
-                                                format!(
+                                            .broadcast_script(
+                                                &format!(
                                                     "load_action_{}.js",
                                                     action_id.cow_replace('/', "_")
                                                 ),
-                                                wrapped_code,
+                                                &wrapped_code,
                                             )
                                             .await
                                         {
-                                            Ok(_) => {}
-                                            Err(e) => {
-                                                tracing::error!(
-                                                    "Failed to load server action {}: {}",
-                                                    action_id,
-                                                    e
-                                                );
-                                            }
+                                            tracing::error!(
+                                                "Failed to load server action {}: {}",
+                                                action_id,
+                                                e
+                                            );
                                         }
                                     }
                                 }
@@ -568,72 +514,45 @@ impl ComponentLoader {
                                                     return {{ success: true }};
                                                 }} catch (error) {{
                                                     console.error("Failed to register server action " + {relative_str_json}, error);
-                                                    return {{ success: false, error: error.message }};
+                                                    throw error;
                                                 }}
                                             }})()"#
                                 );
 
-                                match renderer
+                                if let Err(e) = renderer
                                     .runtime
-                                    .execute_script(
-                                        format!(
+                                    .broadcast_script(
+                                        &format!(
                                             "register_{}.js",
                                             relative_str.cow_replace('/', "_")
                                         ),
-                                        registration_script,
+                                        &registration_script,
                                     )
                                     .await
                                 {
-                                    Ok(result) => {
-                                        if let Some(success) = result
-                                            .get("success")
-                                            .and_then(serde_json::Value::as_bool)
-                                            && !success
-                                        {
-                                            if let Some(error_msg) =
-                                                result.get("error").and_then(|v| v.as_str())
-                                            {
-                                                tracing::error!(
-                                                    "Failed to register server functions from {}: {}",
-                                                    relative_str,
-                                                    error_msg
-                                                );
-                                            } else {
-                                                tracing::error!(
-                                                    "Failed to register server functions from {}: unknown error",
-                                                    relative_str
-                                                );
-                                            }
-                                        }
-                                    }
-                                    Err(e) => {
-                                        tracing::error!(
-                                            "Failed to register server functions from {}: {}",
-                                            relative_str,
-                                            e
-                                        );
-                                    }
+                                    tracing::error!(
+                                        "Failed to register server functions from {}: {}",
+                                        relative_str,
+                                        e
+                                    );
                                 }
                             }
                         } else {
                             let wrapped_code =
                                 wrap_server_action_module(&component_code, &relative_str);
-                            match renderer
+                            if let Err(e) = renderer
                                 .runtime
-                                .execute_script(
-                                    format!("load_{}.js", relative_str.cow_replace('/', "_")),
-                                    wrapped_code,
+                                .broadcast_script(
+                                    &format!("load_{}.js", relative_str.cow_replace('/', "_")),
+                                    &wrapped_code,
                                 )
                                 .await
                             {
-                                Ok(_) => {}
-                                Err(e) => {
-                                    tracing::error!(
-                                        "Failed to load server actions from {}: {}",
-                                        relative_str,
-                                        e
-                                    );
-                                }
+                                tracing::error!(
+                                    "Failed to load server actions from {}: {}",
+                                    relative_str,
+                                    e
+                                );
                             }
                         }
                         continue;
@@ -708,32 +627,25 @@ impl ComponentLoader {
                                     ))
                                 })?;
                             let registration_script = format!(
-                                r"globalThis['~rari'].componentLoader.registerComponent({module_specifier_json}, {component_id_json}, {skip_global_binding})"
+                                r"(async function() {{
+                                    const result = await globalThis['~rari'].componentLoader.registerComponent({module_specifier_json}, {component_id_json}, {skip_global_binding});
+                                    if (!result || result.success !== true) {{
+                                        throw new Error((result && result.error) || 'Component registration failed');
+                                    }}
+                                    return result;
+                                }})()"
                             );
 
                             match renderer
                                 .runtime
-                                .execute_script(
-                                    format!("register_{}.js", component_id.cow_replace('/', "_")),
-                                    registration_script,
+                                .broadcast_script(
+                                    &format!("register_{}.js", component_id.cow_replace('/', "_")),
+                                    &registration_script,
                                 )
                                 .await
                             {
-                                Ok(result) => {
-                                    let registration_succeeded = result
-                                        .get("success")
-                                        .and_then(serde_json::Value::as_bool)
-                                        .unwrap_or(false);
-
-                                    if !registration_succeeded {
-                                        tracing::error!(
-                                            "Failed to register component {} to globalThis: {:?}",
-                                            component_id,
-                                            result.get("error")
-                                        );
-                                    }
-
-                                    if registration_succeeded && is_client_component {
+                                Ok(()) => {
+                                    if is_client_component {
                                         let component_id_json = serde_json::to_string(
                                             &component_id,
                                         )
@@ -774,12 +686,12 @@ impl ComponentLoader {
 
                                         if let Err(e) = renderer
                                             .runtime
-                                            .execute_script(
-                                                format!(
+                                            .broadcast_script(
+                                                &format!(
                                                     "mark_client_{}.js",
                                                     component_id.cow_replace('/', "_")
                                                 ),
-                                                mark_client_script,
+                                                &mark_client_script,
                                             )
                                             .await
                                         {
@@ -803,13 +715,13 @@ impl ComponentLoader {
                     } else {
                         match renderer
                             .runtime
-                            .execute_script(
-                                format!("load_{}.js", component_id.cow_replace('/', "_")),
-                                transformed_module_code,
+                            .broadcast_script(
+                                &format!("load_{}.js", component_id.cow_replace('/', "_")),
+                                &transformed_module_code,
                             )
                             .await
                         {
-                            Ok(_) => {
+                            Ok(()) => {
                                 if is_client_component {
                                     let skip_global_binding = component_id.starts_with("lib/");
                                     let component_id_json = serde_json::to_string(&component_id)
@@ -851,12 +763,12 @@ impl ComponentLoader {
 
                                     if let Err(e) = renderer
                                         .runtime
-                                        .execute_script(
-                                            format!(
+                                        .broadcast_script(
+                                            &format!(
                                                 "mark_client_{}.js",
                                                 component_id.cow_replace('/', "_")
                                             ),
-                                            mark_client_script,
+                                            &mark_client_script,
                                         )
                                         .await
                                     {
@@ -947,7 +859,7 @@ impl ComponentLoader {
             }
         ";
         runtime
-            .execute_script("init_ssr_modules".to_string(), init_script.to_string())
+            .broadcast_script("init_ssr_modules", init_script)
             .await
             .map_err(|e| RariError::internal(format!("Failed to initialize ssrModules: {e}")))?;
 
@@ -1003,7 +915,7 @@ impl ComponentLoader {
                         const mod = await import({specifier});
                         if (!globalThis['~rari'] || !globalThis['~rari'].ssrModules) {{
                             console.error('[rari] SSR: globalThis[~rari].ssrModules not initialized');
-                            return false;
+                            throw new Error('globalThis[~rari].ssrModules not initialized');
                         }}
                         globalThis['~rari'].ssrModules[{path}] = mod;
 
@@ -1016,7 +928,7 @@ impl ComponentLoader {
                         return true;
                     }} catch (e) {{
                         console.error('[rari] SSR: Failed to import module ' + {path} + ':', e?.message || e);
-                        return false;
+                        throw e instanceof Error ? e : new Error(String(e?.message || e));
                     }}
                 }})()",
                 specifier = serde_json::to_string(&module_specifier).unwrap_or_default(),
@@ -1025,9 +937,9 @@ impl ComponentLoader {
             );
 
             if let Err(e) = runtime
-                .execute_script(
-                    format!("ssr_load_{}.js", module_path.cow_replace('/', "_")),
-                    register_script,
+                .broadcast_script(
+                    &format!("ssr_load_{}.js", module_path.cow_replace('/', "_")),
+                    &register_script,
                 )
                 .await
             {
@@ -1060,12 +972,9 @@ impl ComponentLoader {
             }})()"
         );
 
-        runtime
-            .execute_script("init_client_reference_manifest".to_string(), init_script)
-            .await
-            .map_err(|e| {
-                RariError::internal(format!("Failed to initialize client reference manifest: {e}"))
-            })?;
+        runtime.broadcast_script("init_client_reference_manifest", &init_script).await.map_err(
+            |e| RariError::internal(format!("Failed to initialize client reference manifest: {e}")),
+        )?;
 
         Ok(())
     }
@@ -1095,13 +1004,9 @@ impl ComponentLoader {
             }})()"
         );
 
-        renderer
-            .runtime
-            .execute_script("init_use_cache_build_id".to_string(), init_script)
-            .await
-            .map_err(|e| {
-            RariError::internal(format!("Failed to initialize use cache build id: {e}"))
-        })?;
+        renderer.runtime.broadcast_script("init_use_cache_build_id", &init_script).await.map_err(
+            |e| RariError::internal(format!("Failed to initialize use cache build id: {e}")),
+        )?;
 
         Ok(())
     }

--- a/crates/rari/src/server/middleware/proxy.rs
+++ b/crates/rari/src/server/middleware/proxy.rs
@@ -304,35 +304,19 @@ pub async fn initialize_proxy(state: &ServerState) -> Result<(), RariError> {
             try {{
                 const {{ initializeProxyExecutor }} = await import("{executor_specifier}");
                 const success = await initializeProxyExecutor("{proxy_specifier}", "{rari_request_specifier}");
-                return {{ success }};
+                if (!success) {{
+                    throw new Error("initializeProxyExecutor returned false");
+                }}
+                return {{ success: true }};
             }} catch (error) {{
                 console.error("[rari] Proxy: Failed to initialize:", error);
-                return {{ success: false, error: error.message }};
+                throw error;
             }}
         }})()"#
     );
 
-    match runtime.execute_script("initialize_proxy_executor".to_string(), init_script).await {
-        Ok(result) => {
-            if let Some(success) = result.get("success").and_then(serde_json::Value::as_bool) {
-                if success {
-                    Ok(())
-                } else {
-                    let error_msg = result
-                        .get("error")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("Unknown error during proxy initialization");
-                    tracing::error!("Proxy initialization failed: {error_msg}");
-                    Err(RariError::js_runtime(format!("Proxy initialization failed: {error_msg}")))
-                }
-            } else {
-                tracing::error!("Proxy initialization returned invalid result format");
-                Err(RariError::js_runtime("Proxy initialization returned invalid result format"))
-            }
-        }
-        Err(e) => {
-            tracing::error!("Failed to register proxy function: {}", e);
-            Err(e)
-        }
-    }
+    runtime.broadcast_script("initialize_proxy_executor", &init_script).await.map_err(|e| {
+        tracing::error!("Failed to register proxy function: {}", e);
+        e
+    })
 }

--- a/crates/rari/src/server/rendering/html_bots.rs
+++ b/crates/rari/src/server/rendering/html_bots.rs
@@ -1,0 +1,87 @@
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+pub const HTML_LIMITED_BOT_UA_RE: &str = r"[\w-]+-Google|Google-[\w-]+|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti|googleweblight";
+
+static DEFAULT_HTML_LIMITED_BOTS: LazyLock<Regex> = LazyLock::new(|| {
+    #[expect(clippy::expect_used, reason = "Infallible operation with valid inputs")]
+    Regex::new(HTML_LIMITED_BOT_UA_RE).expect("default htmlLimitedBots regex is valid")
+});
+
+/// Validate an `htmlLimitedBots` override pattern. Returns `Ok` when it compiles.
+///
+/// # Errors
+///
+/// Returns the underlying [`regex::Error`] when `pattern` is not a valid regex.
+pub fn validate_html_limited_bots_pattern(pattern: &str) -> Result<(), regex::Error> {
+    Regex::new(pattern).map(|_| ())
+}
+
+pub fn is_html_limited_bot(user_agent: Option<&str>, override_pattern: Option<&str>) -> bool {
+    let Some(ua) = user_agent.map(str::trim).filter(|s| !s.is_empty()) else {
+        return false;
+    };
+
+    match override_pattern {
+        Some(pattern) => match Regex::new(pattern) {
+            Ok(re) => re.is_match(ua),
+            Err(err) => {
+                tracing::warn!(
+                    "Invalid htmlLimitedBots regex {pattern:?}: {err}. Falling back to default list."
+                );
+                DEFAULT_HTML_LIMITED_BOTS.is_match(ua)
+            }
+        },
+        None => DEFAULT_HTML_LIMITED_BOTS.is_match(ua),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_social_and_search_bots() {
+        assert!(is_html_limited_bot(Some("Twitterbot/1.0"), None));
+        assert!(is_html_limited_bot(Some("Slackbot-LinkExpanding 1.0"), None));
+        assert!(is_html_limited_bot(Some("facebookexternalhit/1.1"), None));
+        assert!(is_html_limited_bot(Some("LinkedInBot/1.0"), None));
+        assert!(is_html_limited_bot(Some("Bingbot/2.0"), None));
+        assert!(is_html_limited_bot(
+            Some("AdsBot-Google (+http://www.google.com/adsbot.html)"),
+            None
+        ));
+        assert!(is_html_limited_bot(Some("Google-InspectionTool"), None));
+        assert!(is_html_limited_bot(Some("Chrome-Lighthouse"), None));
+    }
+
+    #[test]
+    fn allows_browsers_and_googlebot() {
+        assert!(!is_html_limited_bot(
+            Some("Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"),
+            None
+        ));
+        assert!(!is_html_limited_bot(
+            Some(
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0"
+            ),
+            None
+        ));
+        assert!(!is_html_limited_bot(None, None));
+        assert!(!is_html_limited_bot(Some(""), None));
+    }
+
+    #[test]
+    fn override_replaces_default_list() {
+        assert!(!is_html_limited_bot(Some("Twitterbot/1.0"), Some(r"OnlyMyBot")));
+        assert!(is_html_limited_bot(Some("OnlyMyBot/2.0"), Some(r"OnlyMyBot")));
+    }
+
+    #[test]
+    fn invalid_override_falls_back_to_default() {
+        assert!(is_html_limited_bot(Some("Twitterbot/1.0"), Some(r"(OnlyMyBot")));
+        assert!(validate_html_limited_bots_pattern(r"(OnlyMyBot").is_err());
+        assert!(validate_html_limited_bots_pattern(r"OnlyMyBot").is_ok());
+    }
+}

--- a/crates/rari/src/server/rendering/html_bots.rs
+++ b/crates/rari/src/server/rendering/html_bots.rs
@@ -9,30 +9,31 @@ static DEFAULT_HTML_LIMITED_BOTS: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(HTML_LIMITED_BOT_UA_RE).expect("default htmlLimitedBots regex is valid")
 });
 
+/// Compile an `htmlLimitedBots` override pattern.
+///
+/// # Errors
+///
+/// Returns the underlying [`regex::Error`] when `pattern` is not a valid regex.
+pub fn compile_html_limited_bots_pattern(pattern: &str) -> Result<Regex, regex::Error> {
+    Regex::new(pattern)
+}
+
 /// Validate an `htmlLimitedBots` override pattern. Returns `Ok` when it compiles.
 ///
 /// # Errors
 ///
 /// Returns the underlying [`regex::Error`] when `pattern` is not a valid regex.
 pub fn validate_html_limited_bots_pattern(pattern: &str) -> Result<(), regex::Error> {
-    Regex::new(pattern).map(|_| ())
+    compile_html_limited_bots_pattern(pattern).map(|_| ())
 }
 
-pub fn is_html_limited_bot(user_agent: Option<&str>, override_pattern: Option<&str>) -> bool {
+pub fn is_html_limited_bot(user_agent: Option<&str>, override_regex: Option<&Regex>) -> bool {
     let Some(ua) = user_agent.map(str::trim).filter(|s| !s.is_empty()) else {
         return false;
     };
 
-    match override_pattern {
-        Some(pattern) => match Regex::new(pattern) {
-            Ok(re) => re.is_match(ua),
-            Err(err) => {
-                tracing::warn!(
-                    "Invalid htmlLimitedBots regex {pattern:?}: {err}. Falling back to default list."
-                );
-                DEFAULT_HTML_LIMITED_BOTS.is_match(ua)
-            }
-        },
+    match override_regex {
+        Some(re) => re.is_match(ua),
         None => DEFAULT_HTML_LIMITED_BOTS.is_match(ua),
     }
 }
@@ -74,13 +75,14 @@ mod tests {
 
     #[test]
     fn override_replaces_default_list() {
-        assert!(!is_html_limited_bot(Some("Twitterbot/1.0"), Some(r"OnlyMyBot")));
-        assert!(is_html_limited_bot(Some("OnlyMyBot/2.0"), Some(r"OnlyMyBot")));
+        #[expect(clippy::expect_used, reason = "test fixture with known-valid pattern")]
+        let only_mine = compile_html_limited_bots_pattern(r"OnlyMyBot").expect("valid");
+        assert!(!is_html_limited_bot(Some("Twitterbot/1.0"), Some(&only_mine)));
+        assert!(is_html_limited_bot(Some("OnlyMyBot/2.0"), Some(&only_mine)));
     }
 
     #[test]
-    fn invalid_override_falls_back_to_default() {
-        assert!(is_html_limited_bot(Some("Twitterbot/1.0"), Some(r"(OnlyMyBot")));
+    fn invalid_override_rejected_by_validate() {
         assert!(validate_html_limited_bots_pattern(r"(OnlyMyBot").is_err());
         assert!(validate_html_limited_bots_pattern(r"OnlyMyBot").is_ok());
     }

--- a/crates/rari/src/server/rendering/metadata_injection.rs
+++ b/crates/rari/src/server/rendering/metadata_injection.rs
@@ -2,7 +2,9 @@ use std::fmt::Write;
 
 use crate::{
     rendering::{
-        layout::types::{IconValue, OpenGraphImage, PageMetadata, ThemeColorMetadata},
+        layout::types::{
+            IconValue, LayoutRenderContext, OpenGraphImage, PageMetadata, ThemeColorMetadata,
+        },
         r#static::escape_html,
     },
     server::image::ImageOptimizer,
@@ -531,6 +533,64 @@ pub fn inject_metadata(
     result
 }
 
+/// Head-inner HTML for streaming injection (title/meta/og/etc.) without a full document wrap.
+/// Used when Fizz has already started; tags may land before or after `<head>` closes and
+/// browsers/crawlers that buffer the full response still apply them.
+pub fn metadata_head_fragment(
+    metadata: &PageMetadata,
+    image_optimizer: Option<&ImageOptimizer>,
+) -> String {
+    let stub = "<!DOCTYPE html><html><head><title></title></head><body></body></html>";
+    let injected = inject_metadata(stub, metadata, image_optimizer);
+    let Some(head_open) = injected.find("<head>") else {
+        return String::new();
+    };
+    let inner_start = head_open + "<head>".len();
+    let Some(rel_end) = injected[inner_start..].find("</head>") else {
+        return String::new();
+    };
+    injected[inner_start..inner_start + rel_end].replace("<title></title>", "").trim().to_string()
+}
+
+/// Apply resolved metadata for HTML-limited bots: store on context and attach
+/// head tags so Fizz emits them inside the initial `<head>`.
+pub fn apply_blocking_streaming_metadata(
+    context: &mut LayoutRenderContext,
+    metadata: Option<PageMetadata>,
+    image_optimizer: Option<&ImageOptimizer>,
+) {
+    context.metadata = metadata;
+    if let Some(ref meta) = context.metadata {
+        let fragment = metadata_head_fragment(meta, image_optimizer);
+        if !fragment.is_empty() {
+            context.streaming_head_extra = Some(fragment);
+        }
+    }
+}
+
+/// Tags to flush into a streaming HTML body when deferred metadata resolves.
+pub fn streaming_metadata_chunk(
+    metadata: Option<&PageMetadata>,
+    image_optimizer: Option<&ImageOptimizer>,
+) -> Option<String> {
+    let metadata = metadata?;
+    let tags = metadata_head_fragment(metadata, image_optimizer);
+    if tags.is_empty() { None } else { Some(tags) }
+}
+
+/// Merge bot blocking head tags into the Fizz document head content.
+pub fn merge_streaming_head_content(template_head: &str, extra: Option<&str>) -> String {
+    match extra.filter(|s| !s.is_empty()) {
+        Some(extra) => {
+            let mut head = String::with_capacity(template_head.len() + extra.len());
+            head.push_str(template_head);
+            head.push_str(extra);
+            head
+        }
+        None => template_head.to_string(),
+    }
+}
+
 #[cfg(test)]
 #[expect(clippy::expect_used)]
 mod tests {
@@ -538,8 +598,8 @@ mod tests {
 
     use super::*;
     use crate::rendering::layout::types::{
-        AlternatesMetadata, OpenGraphImage, OpenGraphImageDescriptor, OpenGraphMetadata,
-        RobotsMetadata, TwitterMetadata,
+        AlternatesMetadata, LayoutRenderContext, OpenGraphImage, OpenGraphImageDescriptor,
+        OpenGraphMetadata, RobotsMetadata, TwitterMetadata,
     };
 
     #[test]
@@ -574,6 +634,100 @@ mod tests {
         assert!(result.contains("<title>Test Page</title>"));
         assert!(result.contains(r#"<meta name="description" content="Test description" />"#));
         assert!(result.contains(r#"<meta name="keywords" content="test, page" />"#));
+    }
+
+    #[test]
+    fn test_metadata_head_fragment_includes_title() {
+        let metadata = PageMetadata {
+            title: Some("Hello".to_string()),
+            description: Some("World".to_string()),
+            keywords: None,
+            open_graph: None,
+            twitter: None,
+            robots: None,
+            viewport: None,
+            canonical: None,
+            icons: None,
+            manifest: None,
+            theme_color: None,
+            apple_web_app: None,
+            alternates: None,
+        };
+        let fragment = metadata_head_fragment(&metadata, None);
+        assert!(fragment.contains("<title>Hello</title>"), "{fragment}");
+        assert!(fragment.contains(r#"content="World""#), "{fragment}");
+    }
+
+    #[test]
+    fn bot_blocking_metadata_lands_in_streaming_head_extra() {
+        let metadata = PageMetadata {
+            title: Some("Bot Title".to_string()),
+            description: Some("Bot Desc".to_string()),
+            keywords: None,
+            open_graph: None,
+            twitter: None,
+            robots: None,
+            viewport: None,
+            canonical: None,
+            icons: None,
+            manifest: None,
+            theme_color: None,
+            apple_web_app: None,
+            alternates: None,
+        };
+        let mut context = LayoutRenderContext {
+            params: FxHashMap::default(),
+            search_params: FxHashMap::default(),
+            headers: FxHashMap::default(),
+            pathname: "/stream".to_string(),
+            template_navigation_id: None,
+            metadata: None,
+            streaming_head_extra: None,
+        };
+        apply_blocking_streaming_metadata(&mut context, Some(metadata), None);
+        let extra = context.streaming_head_extra.as_deref().expect("bot head tags");
+        assert!(extra.contains("<title>Bot Title</title>"), "{extra}");
+        assert!(extra.contains(r#"content="Bot Desc""#), "{extra}");
+        assert!(context.metadata.is_some());
+
+        let merged = merge_streaming_head_content(
+            r#"<link rel="stylesheet" href="/app.css" />"#,
+            context.streaming_head_extra.as_deref(),
+        );
+        assert!(merged.contains("app.css"));
+        assert!(merged.contains("<title>Bot Title</title>"));
+        // Tags must appear in the same head string Fizz will emit (before </head>).
+        assert!(merged.find("app.css").expect("css") < merged.find("<title>").expect("title"));
+    }
+
+    #[test]
+    fn deferred_metadata_chunk_for_streaming_flush() {
+        let metadata = PageMetadata {
+            title: Some("Late Title".to_string()),
+            description: Some("Late Desc".to_string()),
+            keywords: None,
+            open_graph: None,
+            twitter: None,
+            robots: None,
+            viewport: None,
+            canonical: None,
+            icons: None,
+            manifest: None,
+            theme_color: None,
+            apple_web_app: None,
+            alternates: None,
+        };
+        let chunk = streaming_metadata_chunk(Some(&metadata), None).expect("chunk");
+        assert!(chunk.contains("<title>Late Title</title>"), "{chunk}");
+        assert!(chunk.contains(r#"content="Late Desc""#), "{chunk}");
+        assert!(streaming_metadata_chunk(None, None).is_none());
+    }
+
+    #[test]
+    fn merge_streaming_head_skips_empty_extra() {
+        assert_eq!(merge_streaming_head_content("base", None), "base");
+        assert_eq!(merge_streaming_head_content("base", Some("")), "base");
+        assert_eq!(merge_streaming_head_content("base", Some("extra")), "baseextra");
     }
 
     #[test]

--- a/crates/rari/src/server/rendering/mod.rs
+++ b/crates/rari/src/server/rendering/mod.rs
@@ -1,3 +1,4 @@
+pub mod html_bots;
 pub mod metadata;
 pub mod metadata_injection;
 pub mod pretty_html;

--- a/crates/rari/src/server/routing/api_routes.rs
+++ b/crates/rari/src/server/routing/api_routes.rs
@@ -334,94 +334,91 @@ impl ApiRouteHandler {
                 .with_http_headers(extract_headers(&parts.headers)),
         );
 
-        self.runtime
-            .execute_with_request_context(request_context, async {
-                let dist_path = Self::resolve_route_dist_path(&route_match.route);
-                let canonical_path = fs::canonicalize(&dist_path).await.map_err(|e| {
-                    RariError::io(format!(
-                        "Failed to canonicalize API route path {}: {e}",
-                        dist_path.display()
-                    ))
-                })?;
-                let module_specifier = url::Url::from_file_path(&canonical_path)
-                    .map_err(|()| {
-                        RariError::configuration(format!(
-                            "Failed to create file URL from path: {}",
-                            canonical_path.display()
-                        ))
-                    })?
-                    .to_string();
+        let dist_path = Self::resolve_route_dist_path(&route_match.route);
+        let canonical_path = fs::canonicalize(&dist_path).await.map_err(|e| {
+            RariError::io(format!(
+                "Failed to canonicalize API route path {}: {e}",
+                dist_path.display()
+            ))
+        })?;
+        let module_specifier = url::Url::from_file_path(&canonical_path)
+            .map_err(|()| {
+                RariError::configuration(format!(
+                    "Failed to create file URL from path: {}",
+                    canonical_path.display()
+                ))
+            })?
+            .to_string();
 
-                let component_id = create_component_id(&route_match.route.file_path);
+        let component_id = create_component_id(&route_match.route.file_path);
 
-                if let Err(e) =
-                    self.runtime.add_module_to_loader(&module_specifier, handler.code.clone()).await
-                {
-                    tracing::error!(
-                        route_path = %route_match.route.path,
-                        method = %route_match.method,
-                        component_id = %component_id,
-                        error = %e,
-                        "Failed to add API route module to loader"
-                    );
-                    return Err(RariError::js_execution(format!(
-                        "Failed to add module to loader: {e}"
-                    )));
-                }
+        if let Err(e) =
+            self.runtime.add_module_to_loader(&module_specifier, handler.code.clone()).await
+        {
+            tracing::error!(
+                route_path = %route_match.route.path,
+                method = %route_match.method,
+                component_id = %component_id,
+                error = %e,
+                "Failed to add API route module to loader"
+            );
+            return Err(RariError::js_execution(format!("Failed to add module to loader: {e}")));
+        }
 
-                let module_id = self.runtime.load_es_module(&component_id).await.map_err(|e| {
-                    tracing::error!(
-                        route_path = %route_match.route.path,
-                        method = %route_match.method,
-                        component_id = %component_id,
-                        error = %e,
-                        "Failed to load API route as ES module"
-                    );
-                    RariError::js_execution(format!("Failed to load ES module: {e}"))
-                })?;
+        // Ensure the module is evaluated on every isolate before the sticky request path runs.
+        if let Err(e) = self.runtime.load_and_evaluate_module(&component_id).await {
+            tracing::error!(
+                route_path = %route_match.route.path,
+                method = %route_match.method,
+                component_id = %component_id,
+                error = %e,
+                "Failed to load/evaluate API route module"
+            );
+            return Err(RariError::js_execution(format!("Failed to load/evaluate ES module: {e}")));
+        }
 
-                if let Err(e) = self.runtime.evaluate_module(module_id).await {
-                    tracing::error!(
-                        route_path = %route_match.route.path,
-                        method = %route_match.method,
-                        component_id = %component_id,
-                        error = %e,
-                        "Failed to evaluate API route module"
-                    );
-                    return Err(RariError::js_execution(format!("Failed to evaluate module: {e}")));
-                }
+        let method = route_match.method.clone();
+        let route_path = route_match.route.path.clone();
+        let runtime = Arc::clone(&self.runtime);
+        let request_json = serde_json::to_string(&request_obj)
+            .map_err(|e| RariError::serialization(format!("Failed to serialize request: {e}")))?;
+        let script = format!(
+            r#"globalThis['~rari'].apiHandler.callHandler({}, "{}", "{}")"#,
+            request_json,
+            module_specifier.cow_replace('\\', "\\\\").cow_replace('"', "\\\""),
+            method.cow_replace('\\', "\\\\").cow_replace('"', "\\\"")
+        );
+        let trimmed = module_specifier.trim_start_matches("file://");
+        let with_underscores = trimmed.cow_replace('/', "_");
+        let script_name = format!("api_route_call_{}", with_underscores.cow_replace(':', "_"));
 
-                let result = self
-                    .execute_handler_from_namespace(
-                        &route_match.method,
-                        &request_obj,
-                        &module_specifier,
-                    )
+        let result = runtime
+            .with_request_context(request_context, move |rt| async move {
+                rt.execute_script(script_name, script)
                     .await
-                    .map_err(|e| {
-                        tracing::error!(
-                            route_path = %route_match.route.path,
-                            method = %route_match.method,
-                            component_id = %component_id,
-                            error = %e,
-                            "Handler execution failed"
-                        );
-                        RariError::js_execution(format!("Handler execution failed: {e}"))
-                    })?;
-
-                let response = Self::create_response(&result).map_err(|e| {
-                    tracing::error!(
-                        route_path = %route_match.route.path,
-                        method = %route_match.method,
-                        error = %e,
-                        "Failed to create response from handler result"
-                    );
-                    e
-                })?;
-
-                Ok(response)
+                    .map_err(|e| RariError::js_execution(format!("Failed to execute handler: {e}")))
             })
             .await
+            .map_err(|e| {
+                tracing::error!(
+                    route_path = %route_path,
+                    method = %method,
+                    component_id = %component_id,
+                    error = %e,
+                    "Handler execution failed"
+                );
+                RariError::js_execution(format!("Handler execution failed: {e}"))
+            })?;
+
+        Self::create_response(&result).map_err(|e| {
+            tracing::error!(
+                route_path = %route_path,
+                method = %method,
+                error = %e,
+                "Failed to create response from handler result"
+            );
+            e
+        })
     }
     #[expect(clippy::unnecessary_wraps, reason = "Result return type maintains API consistency")]
     fn create_request_object(
@@ -447,32 +444,6 @@ impl ApiRouteHandler {
         });
 
         Ok(request_obj)
-    }
-
-    async fn execute_handler_from_namespace(
-        &self,
-        method: &str,
-        request_obj: &Value,
-        module_specifier: &str,
-    ) -> Result<Value, RariError> {
-        let request_json = serde_json::to_string(request_obj)
-            .map_err(|e| RariError::serialization(format!("Failed to serialize request: {e}")))?;
-
-        let script = format!(
-            r#"globalThis['~rari'].apiHandler.callHandler({}, "{}", "{}")"#,
-            request_json,
-            module_specifier.cow_replace('\\', "\\\\").cow_replace('"', "\\\""),
-            method.cow_replace('\\', "\\\\").cow_replace('"', "\\\"")
-        );
-
-        let trimmed = module_specifier.trim_start_matches("file://");
-        let with_underscores = trimmed.cow_replace('/', "_");
-        let script_name = with_underscores.cow_replace(':', "_");
-
-        self.runtime
-            .execute_script(format!("api_route_call_{script_name}"), script)
-            .await
-            .map_err(|e| RariError::js_execution(format!("Failed to execute handler: {e}")))
     }
 
     fn create_response(result: &Value) -> Result<Response<Body>, RariError> {

--- a/crates/rari/src/server/routing/app.rs
+++ b/crates/rari/src/server/routing/app.rs
@@ -998,8 +998,13 @@ pub async fn render_streaming_with_layout(
         RenderResult::Static(html) => {
             use crate::server::compression::compress_body;
 
-            if let Some(rx) = metadata_rx {
-                context.metadata = rx.await.ok().flatten();
+            // Deferred metadata_rx is only fed after this function returns
+            // (Fizz-first spawn in the caller). Static fallback must resolve
+            // metadata here or the request deadlocks waiting on a sender that
+            // never starts.
+            if metadata_rx.is_some() {
+                drop(metadata_rx);
+                context.metadata = collect_page_metadata(&state, &route_match, &context).await;
             }
 
             let html_with_assets = match inject_assets_into_html(&html, &state.config).await {
@@ -1576,7 +1581,7 @@ pub async fn handle_app_route(
                 // crawlers get streaming metadata flushed when ready.
                 let user_agent = context.headers.get("user-agent").map(String::as_str);
                 let block_metadata =
-                    is_html_limited_bot(user_agent, state.config.html_limited_bots.as_deref());
+                    is_html_limited_bot(user_agent, state.config.html_limited_bots_regex.as_ref());
 
                 let response = if block_metadata {
                     let mut context = context.clone();
@@ -1821,8 +1826,10 @@ pub async fn handle_app_route(
                             .await;
                         }
                     };
-                    let etag = response::ResponseCache::generate_etag(html.as_bytes());
-                    (html, etag)
+                    let final_html =
+                        wrap_html_with_metadata(html, context.metadata.as_ref(), &state);
+                    let etag = response::ResponseCache::generate_etag(final_html.as_bytes());
+                    (final_html, etag)
                 }
                 RenderResult::StaticBinary(_bytes) => {
                     tracing::error!("StaticBinary not supported in build mode");

--- a/crates/rari/src/server/routing/app.rs
+++ b/crates/rari/src/server/routing/app.rs
@@ -23,7 +23,10 @@ use rari_error::RariError;
 use rustc_hash::FxHashMap;
 use tokio::{
     fs,
-    sync::mpsc::Receiver,
+    sync::{
+        mpsc::{Receiver, error::TryRecvError},
+        oneshot,
+    },
     time::{self, Duration},
 };
 
@@ -56,7 +59,10 @@ use crate::{
         error_response,
         middleware::request_context::RequestContext,
         rendering::{
-            metadata_injection::inject_metadata,
+            html_bots::is_html_limited_bot,
+            metadata_injection::{
+                apply_blocking_streaming_metadata, inject_metadata, streaming_metadata_chunk,
+            },
             pretty_html::pretty_print_html,
             utils::{inject_assets_into_html, inject_vite_client},
         },
@@ -208,6 +214,22 @@ fn should_use_streaming(route_match: &AppRouteMatch, config: &Config) -> bool {
         return false;
     }
     config.loading.enabled && route_match.loading.is_some()
+}
+
+/// Start `generateMetadata` off the critical path. Caller awaits/joins before
+/// injecting into a static document, or passes the receiver into streaming so
+/// tags can be flushed without blocking Fizz/Suspense start.
+fn spawn_page_metadata(
+    state: ServerState,
+    route_match: AppRouteMatch,
+    context: LayoutRenderContext,
+) -> oneshot::Receiver<Option<PageMetadata>> {
+    let (tx, rx) = oneshot::channel();
+    tokio::spawn(async move {
+        let metadata = collect_page_metadata(&state, &route_match, &context).await;
+        let _ = tx.send(metadata);
+    });
+    rx
 }
 
 pub(crate) async fn collect_page_metadata(
@@ -367,6 +389,7 @@ pub async fn render_with_fallback(
     route_match: AppRouteMatch,
     context: LayoutRenderContext,
     accept_encoding: Option<&str>,
+    metadata_rx: Option<oneshot::Receiver<Option<PageMetadata>>>,
 ) -> Result<Response, StatusCode> {
     let layout_renderer = LayoutRenderer::with_shared_cache(
         Arc::clone(&state.renderer),
@@ -379,6 +402,7 @@ pub async fn render_with_fallback(
         context.clone(),
         &layout_renderer,
         accept_encoding,
+        metadata_rx,
     )
     .await
     {
@@ -413,6 +437,7 @@ pub async fn render_rsc_navigation_streaming(
             &context,
             Some(Arc::clone(&request_context)),
             true,
+            None,
         )
         .await
     {
@@ -442,6 +467,7 @@ pub async fn render_rsc_navigation_streaming(
             chunks,
             is_not_found,
             accept_encoding,
+            None,
         )),
         RenderResult::Chunked { content_type: ChunkedContentType::Html, .. } => {
             tracing::error!("HTML chunked render not supported in RSC-only mode");
@@ -514,39 +540,202 @@ fn render_chunked_response(
     mut chunks: Receiver<Result<Vec<u8>, RariError>>,
     is_not_found: bool,
     accept_encoding: Option<&str>,
+    mut metadata_rx: Option<oneshot::Receiver<Option<PageMetadata>>>,
 ) -> http::Response<Body> {
     let stall_timeout = Duration::from_millis(chunked_stream_stall_timeout_ms());
+    let image_optimizer = state.image_optimizer.clone();
 
     let byte_stream = async_stream::stream! {
         match content_type {
             ChunkedContentType::Html => {
+                // After Suspense starts resolving, a large HTML chunk is often
+                // followed within ~1ms by the final flight/complete tail on the
+                // isolate thread. Wait only after large chunks so we don't tax
+                // every small endgame write.
+                const ENDGAME_AFTER: Duration = Duration::from_millis(800);
+                const ENDGAME_WAIT: Duration = Duration::from_micros(500);
+                const ENDGAME_LARGE_MIN: usize = 1024;
+
+                let t0 = Instant::now();
+                let mut finished = false;
+
                 yield Ok::<_, Error>(shell);
 
-                loop {
+                // Stream metadata for browsers without blocking UI.
+                // Flush head tags when ready without awaiting before Fizz start;
+                // Suspense timers already run in the isolate.
+                let mut metadata_pending = metadata_rx.take();
+                match metadata_pending.as_mut().map(oneshot::Receiver::try_recv) {
+                    Some(Ok(metadata)) => {
+                        if let Some(tags) =
+                            streaming_metadata_chunk(metadata.as_ref(), image_optimizer.as_deref())
+                        {
+                            yield Ok(Bytes::from(tags));
+                        }
+                        metadata_pending = None;
+                    }
+                    Some(Err(oneshot::error::TryRecvError::Closed)) => {
+                        metadata_pending = None;
+                    }
+                    Some(Err(oneshot::error::TryRecvError::Empty)) | None => {}
+                }
+
+                while !finished {
+                    if let Some(ref mut rx) = metadata_pending {
+                        tokio::select! {
+                            biased;
+                            metadata = &mut *rx => {
+                                metadata_pending = None;
+                                if let Ok(metadata) = metadata
+                                    && let Some(tags) = streaming_metadata_chunk(
+                                        metadata.as_ref(),
+                                        image_optimizer.as_deref(),
+                                    )
+                                {
+                                    yield Ok(Bytes::from(tags));
+                                }
+                                continue;
+                            }
+                            chunk = time::timeout(stall_timeout, chunks.recv()) => {
+                                match chunk {
+                                    Ok(Some(Ok(chunk_bytes))) => {
+                                        if chunk_bytes.is_empty() {
+                                            continue;
+                                        }
+                                        yield Ok(Bytes::from(chunk_bytes));
+                                    }
+                                    Ok(Some(Err(e))) => {
+                                        tracing::error!("Error in chunked HTML stream: {}", e);
+                                        yield Err(Error::other(e.to_string()));
+                                        finished = true;
+                                    }
+                                    Ok(None) => {
+                                        finished = true;
+                                    }
+                                    Err(_) => {
+                                        tracing::error!(
+                                            "Chunked HTML stream stalled: no chunk received within {} ms",
+                                            stall_timeout.as_millis()
+                                        );
+                                        yield Ok(chunked_stream_error_chunk(
+                                            "Stream timed out waiting for content",
+                                        ));
+                                        finished = true;
+                                    }
+                                }
+                                continue;
+                            }
+                        }
+                    }
+
                     match time::timeout(stall_timeout, chunks.recv()).await {
                         Ok(Some(Ok(chunk_bytes))) => {
-                            if !chunk_bytes.is_empty() {
-                                yield Ok(Bytes::from(chunk_bytes));
+                            if chunk_bytes.is_empty() {
+                                continue;
+                            }
+                            let mut buf = chunk_bytes;
+                            let mut stream_error: Option<RariError> = None;
+
+                            loop {
+                                match chunks.try_recv() {
+                                    Ok(Ok(more)) => {
+                                        if !more.is_empty() {
+                                            buf.extend_from_slice(&more);
+                                        }
+                                    }
+                                    Ok(Err(e)) => {
+                                        stream_error = Some(e);
+                                        finished = true;
+                                        break;
+                                    }
+                                    Err(TryRecvError::Empty) => break,
+                                    Err(TryRecvError::Disconnected) => {
+                                        finished = true;
+                                        break;
+                                    }
+                                }
+                            }
+
+                            if !finished
+                                && stream_error.is_none()
+                                && t0.elapsed() >= ENDGAME_AFTER
+                                && buf.len() >= ENDGAME_LARGE_MIN
+                            {
+                                match time::timeout(ENDGAME_WAIT, chunks.recv()).await {
+                                    Ok(Some(Ok(more))) => {
+                                        if !more.is_empty() {
+                                            buf.extend_from_slice(&more);
+                                        }
+                                        loop {
+                                            match chunks.try_recv() {
+                                                Ok(Ok(more)) => {
+                                                    if !more.is_empty() {
+                                                        buf.extend_from_slice(&more);
+                                                    }
+                                                }
+                                                Ok(Err(e)) => {
+                                                    stream_error = Some(e);
+                                                    finished = true;
+                                                    break;
+                                                }
+                                                Err(TryRecvError::Empty) => break,
+                                                Err(TryRecvError::Disconnected) => {
+                                                    finished = true;
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                    }
+                                    Ok(Some(Err(e))) => {
+                                        stream_error = Some(e);
+                                        finished = true;
+                                    }
+                                    Ok(None) => {
+                                        finished = true;
+                                    }
+                                    Err(_) => {}
+                                }
+                            }
+
+                            yield Ok(Bytes::from(buf));
+
+                            if let Some(e) = stream_error {
+                                tracing::error!("Error in chunked HTML stream: {}", e);
+                                yield Err(Error::other(e.to_string()));
                             }
                         }
                         Ok(Some(Err(e))) => {
                             tracing::error!("Error in chunked HTML stream: {}", e);
                             yield Err(Error::other(e.to_string()));
-                            break;
+                            finished = true;
                         }
-                        Ok(None) => break,
+                        Ok(None) => {
+                            finished = true;
+                        }
                         Err(_) => {
                             tracing::error!(
                                 "Chunked HTML stream stalled: no chunk received within {} ms",
                                 stall_timeout.as_millis()
                             );
-                            yield Ok(chunked_stream_error_chunk("Stream timed out waiting for content"));
-                            break;
+                            yield Ok(chunked_stream_error_chunk(
+                                "Stream timed out waiting for content",
+                            ));
+                            finished = true;
                         }
                     }
                 }
 
-                yield Ok(closing);
+                if let Some(rx) = metadata_pending
+                    && let Ok(metadata) = rx.await
+                    && let Some(tags) =
+                        streaming_metadata_chunk(metadata.as_ref(), image_optimizer.as_deref())
+                {
+                    yield Ok(Bytes::from(tags));
+                }
+
+                if !closing.is_empty() {
+                    yield Ok(closing);
+                }
             }
             ChunkedContentType::RscFlight => {
                 loop {
@@ -581,7 +770,11 @@ fn render_chunked_response(
         }
     };
 
-    let encoding = CompressionEncoding::from_accept_encoding(accept_encoding);
+    let encoding = match content_type {
+        // Prefer identity for streaming HTML so compressor setup does not delay the shell.
+        ChunkedContentType::Html => CompressionEncoding::Identity,
+        ChunkedContentType::RscFlight => CompressionEncoding::from_accept_encoding(accept_encoding),
+    };
     let compressed_stream = compress_stream(byte_stream, encoding);
     let vary =
         if encoding.as_header_value().is_some() { "Accept, Accept-Encoding" } else { "Accept" };
@@ -659,7 +852,7 @@ pub async fn render_synchronous(
     let is_not_found = route_match.not_found.is_some();
 
     match layout_renderer
-        .render_route_with_streaming(&route_match, &context, Some(request_context), false)
+        .render_route_with_streaming(&route_match, &context, Some(request_context), false, None)
         .await
     {
         Ok(render_result) => match render_result {
@@ -706,6 +899,7 @@ pub async fn render_synchronous(
                 chunks,
                 is_not_found,
                 accept_encoding,
+                None,
             )),
             RenderResult::StaticBinary(bytes) => {
                 let html_content = String::from_utf8_lossy(&bytes).into_owned();
@@ -738,9 +932,10 @@ pub async fn render_synchronous(
 pub async fn render_streaming_with_layout(
     state: Arc<ServerState>,
     route_match: AppRouteMatch,
-    context: LayoutRenderContext,
+    mut context: LayoutRenderContext,
     layout_renderer: &LayoutRenderer,
     accept_encoding: Option<&str>,
+    metadata_rx: Option<oneshot::Receiver<Option<PageMetadata>>>,
 ) -> Result<Response, StatusCode> {
     let layout_count = route_match.layouts.len();
     let is_not_found = route_match.not_found.is_some();
@@ -750,8 +945,10 @@ pub async fn render_streaming_with_layout(
             .with_http_headers(context.headers.clone()),
     );
 
+    // Keep metadata_rx for HTTP injection / static wrap. Do not pass it into
+    // Fizz setup — try_recv there would drop a still-pending receiver.
     let render_result = match layout_renderer
-        .render_route_with_streaming(&route_match, &context, Some(request_context), false)
+        .render_route_with_streaming(&route_match, &context, Some(request_context), false, None)
         .await
     {
         Ok(result) => result,
@@ -796,9 +993,14 @@ pub async fn render_streaming_with_layout(
             chunks,
             is_not_found,
             accept_encoding,
+            metadata_rx,
         )),
         RenderResult::Static(html) => {
             use crate::server::compression::compress_body;
+
+            if let Some(rx) = metadata_rx {
+                context.metadata = rx.await.ok().flatten();
+            }
 
             let html_with_assets = match inject_assets_into_html(&html, &state.config).await {
                 Ok(html) => html,
@@ -1192,13 +1394,16 @@ pub async fn handle_app_route(
                     .expect("Valid cached RSC response"));
             }
 
-            context.metadata = collect_page_metadata(&state, &route_match, &context).await;
+            let metadata_rx =
+                spawn_page_metadata(state.clone(), route_match.clone(), context.clone());
 
             match layout_renderer
                 .render_route_by_mode(&route_match, &context, Some(Arc::clone(&request_context)))
                 .await
             {
                 Ok(rsc_flight_protocol) => {
+                    context.metadata = metadata_rx.await.ok().flatten();
+
                     let status_code = if route_match.not_found.is_some() {
                         StatusCode::NOT_FOUND
                     } else {
@@ -1363,18 +1568,59 @@ pub async fn handle_app_route(
                     .expect("Valid cached response"));
             }
 
-            context.metadata = collect_page_metadata(&state, &route_match, &context).await;
-
             let use_streaming = should_use_streaming(&route_match, &state.config);
 
             if use_streaming {
-                let response = render_with_fallback(
-                    Arc::new(state.clone()),
-                    route_match.clone(),
-                    context.clone(),
-                    accept_encoding,
-                )
-                .await?;
+                // HTML-limited bots (Twitterbot, Slackbot, …) block on
+                // generateMetadata so tags land in the initial <head>. Browsers/capable
+                // crawlers get streaming metadata flushed when ready.
+                let user_agent = context.headers.get("user-agent").map(String::as_str);
+                let block_metadata =
+                    is_html_limited_bot(user_agent, state.config.html_limited_bots.as_deref());
+
+                let response = if block_metadata {
+                    let mut context = context.clone();
+                    let metadata = collect_page_metadata(&state, &route_match, &context).await;
+                    apply_blocking_streaming_metadata(
+                        &mut context,
+                        metadata,
+                        state.image_optimizer.as_deref(),
+                    );
+                    render_with_fallback(
+                        Arc::new(state.clone()),
+                        route_match.clone(),
+                        context,
+                        accept_encoding,
+                        None,
+                    )
+                    .await?
+                } else {
+                    // Start Fizz first (priority queue), then collect metadata.
+                    // Spawning collect before Fizz contended for isolate time and
+                    // pushed lastByte behind Next; after queue, Suspense timers are
+                    // already running so metadata can share the wait window.
+                    let (metadata_tx, metadata_rx) = oneshot::channel();
+                    let response = render_with_fallback(
+                        Arc::new(state.clone()),
+                        route_match.clone(),
+                        context.clone(),
+                        accept_encoding,
+                        Some(metadata_rx),
+                    )
+                    .await?;
+
+                    let state_meta = state.clone();
+                    let route_match_meta = route_match.clone();
+                    let context_meta = context.clone();
+                    tokio::spawn(async move {
+                        let metadata =
+                            collect_page_metadata(&state_meta, &route_match_meta, &context_meta)
+                                .await;
+                        let _ = metadata_tx.send(metadata);
+                    });
+
+                    response
+                };
 
                 if (response.status() == StatusCode::OK
                     || response.status() == StatusCode::NOT_FOUND)
@@ -1505,12 +1751,16 @@ pub async fn handle_app_route(
                 return Ok(response);
             }
 
+            let metadata_rx =
+                spawn_page_metadata(state.clone(), route_match.clone(), context.clone());
+
             let render_result = match layout_renderer
                 .render_route_with_streaming(
                     &route_match,
                     &context,
                     Some(Arc::clone(&request_context)),
                     false,
+                    None,
                 )
                 .await
             {
@@ -1521,6 +1771,9 @@ pub async fn handle_app_route(
                         .await;
                 }
             };
+
+            let metadata = metadata_rx.await.ok().flatten();
+            context.metadata = metadata;
 
             let cache_control_value = state.config.get_cache_control_for_route(path);
             let cache_policy =

--- a/crates/rari/src/server/vite/hmr.rs
+++ b/crates/rari/src/server/vite/hmr.rs
@@ -344,9 +344,9 @@ async fn handle_invalidate(
 
             renderer
                 .runtime
-                .execute_script(
-                    format!("hmr_clear_cache_{}.js", component_id.cow_replace('/', "_")),
-                    clear_script,
+                .broadcast_script(
+                    &format!("hmr_clear_cache_{}.js", component_id.cow_replace('/', "_")),
+                    &clear_script,
                 )
                 .await
         })

--- a/crates/rari/src/server/vite/rsc.rs
+++ b/crates/rari/src/server/vite/rsc.rs
@@ -57,9 +57,9 @@ pub async fn register_component(
 
                 if let Err(e) = renderer
                     .runtime
-                    .execute_script(
-                        format!("mark_client_{}.js", component_id.cow_replace('/', "_")),
-                        mark_script,
+                    .broadcast_script(
+                        &format!("mark_client_{}.js", component_id.cow_replace('/', "_")),
+                        &mark_script,
                     )
                     .await
                 {
@@ -225,9 +225,9 @@ pub async fn reload_component_from_dist(
 
             let execution_result = renderer
                 .runtime
-                .execute_script(
-                    format!("hmr_reload_{}.js", component_id.cow_replace('/', "_")),
-                    wrapped_code.clone(),
+                .broadcast_script(
+                    &format!("hmr_reload_{}.js", component_id.cow_replace('/', "_")),
+                    &wrapped_code,
                 )
                 .await;
 
@@ -267,64 +267,34 @@ pub async fn reload_component_from_dist(
         }})()"
         );
 
-        let result_json = match renderer
+        let checked_verification = format!(
+            r"(function() {{
+                const result = {verification_script};
+                if (!result || result.success !== true) {{
+                    throw new Error(
+                        'Component missing after reload: ' + String(result?.expectedKey || '{component_id}')
+                    );
+                }}
+                return result;
+            }})()"
+        );
+
+        if let Err(e) = renderer
             .runtime
-            .execute_script(
-                format!("verify_{}.js", component_id.cow_replace('/', "_")),
-                verification_script,
+            .broadcast_script(
+                &format!("verify_{}.js", component_id.cow_replace('/', "_")),
+                &checked_verification,
             )
             .await
         {
-            Ok(json) => json,
-            Err(e) => {
-                tracing::error!(
-                    component_id = component_id.as_str(),
-                    error = %e,
-                    "Failed to execute verification script. Last known good version will be preserved."
-                );
-                return Err(RariError::js_execution(format!(
-                    "Failed to verify component reload: {e}. Last known good version will be preserved."
-                )));
-            }
-        };
-
-        if let Some(success) = result_json.get("success").and_then(serde_json::Value::as_bool) {
-            if !success {
-                let actual_keys = result_json
-                    .get("actualKeys")
-                    .and_then(|v| v.as_array())
-                    .map(|arr| {
-                        arr.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>().join(", ")
-                    })
-                    .unwrap_or_else(|| "unknown".to_string());
-
-                let expected_key = result_json
-                    .get("expectedKey")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or(&component_id);
-
-                tracing::error!(
-                    component_id = component_id.as_str(),
-                    expected_key = expected_key,
-                    actual_keys = actual_keys,
-                    verification_result = ?result_json,
-                    "Component not found in globalThis after reload. Expected key '{}' not found. Available keys: [{}]. Last known good version will be preserved.",
-                    expected_key,
-                    actual_keys
-                );
-                return Err(RariError::js_runtime(format!(
-                    "Component '{component_id}' not found in globalThis after reload. Expected key '{expected_key}' but found keys: [{actual_keys}]. Last known good version will be preserved."
-                )));
-            }
-        } else {
             tracing::error!(
                 component_id = component_id.as_str(),
-                verification_result = ?result_json,
-                "Invalid verification result format. Last known good version will be preserved."
+                error = %e,
+                "Failed to execute verification script. Last known good version will be preserved."
             );
-            return Err(RariError::internal(
-                "Invalid verification result format. Last known good version will be preserved."
-            ));
+            return Err(RariError::js_execution(format!(
+                "Failed to verify component reload: {e}. Last known good version will be preserved."
+            )));
         }
 
         if is_esm {

--- a/packages/rari/src/vite/index.ts
+++ b/packages/rari/src/vite/index.ts
@@ -355,6 +355,15 @@ export function defineRariOptions(config: RariOptions): RariOptions {
 }
 
 export function rari(options: RariOptions = {}): RariPlugin[] {
+  if (options.jsPoolSize != null) {
+    const size = options.jsPoolSize
+    if (!Number.isInteger(size) || size < 1 || !Number.isFinite(size)) {
+      throw new Error(
+        `jsPoolSize must be a finite positive integer; received ${String(size)}`,
+      )
+    }
+  }
+
   const componentTypeCache = new Map<string, 'client' | 'server' | 'unknown'>()
   const clientComponents = new Set<string>()
   const moduleAnalysisCache = new ModuleAnalysisCache()
@@ -1458,9 +1467,12 @@ ${clientTransformedCode}`
             ...process.env,
             RUST_LOG: process.env.RUST_LOG || 'error',
             RARI_VITE_PORT: vitePort.toString(),
-            // Dev starts the binary before config.json is written; pass pool size via env.
+            // Dev starts the binary before config.json is written; pass pool size / bots via env.
             ...(options.jsPoolSize != null && !process.env.RARI_JS_POOL_SIZE
               ? { RARI_JS_POOL_SIZE: String(options.jsPoolSize) }
+              : {}),
+            ...(options.htmlLimitedBots != null && !process.env.RARI_HTML_LIMITED_BOTS
+              ? { RARI_HTML_LIMITED_BOTS: options.htmlLimitedBots }
               : {}),
           },
         })

--- a/packages/rari/src/vite/index.ts
+++ b/packages/rari/src/vite/index.ts
@@ -162,6 +162,8 @@ export interface RariOptions {
   cacheControl?: {
     routes: Record<string, string>
   }
+  jsPoolSize?: number
+  htmlLimitedBots?: string
   cache?: ServerCacheConfig
   experimental?: {
     useCache?: boolean
@@ -1291,6 +1293,8 @@ ${clientTransformedCode}`
             csp: options.csp,
             cacheControl: options.cacheControl,
             cache: options.cache,
+            jsPoolSize: options.jsPoolSize,
+            htmlLimitedBots: options.htmlLimitedBots,
             experimental: options.experimental,
             moduleAnalysisCache,
           })
@@ -1454,6 +1458,10 @@ ${clientTransformedCode}`
             ...process.env,
             RUST_LOG: process.env.RUST_LOG || 'error',
             RARI_VITE_PORT: vitePort.toString(),
+            // Dev starts the binary before config.json is written; pass pool size via env.
+            ...(options.jsPoolSize != null && !process.env.RARI_JS_POOL_SIZE
+              ? { RARI_JS_POOL_SIZE: String(options.jsPoolSize) }
+              : {}),
           },
         })
 
@@ -2246,6 +2254,8 @@ export const createTemporaryReferenceSet = module.exports.createTemporaryReferen
     csp: options.csp,
     cacheControl: options.cacheControl,
     cache: options.cache,
+    jsPoolSize: options.jsPoolSize,
+    htmlLimitedBots: options.htmlLimitedBots,
     experimental: options.experimental,
     moduleAnalysisCache,
     mdx: options.mdx,

--- a/packages/rari/src/vite/server/build.ts
+++ b/packages/rari/src/vite/server/build.ts
@@ -207,6 +207,8 @@ export interface ServerBuildOptions {
   csp?: ServerCSPConfig
   cacheControl?: ServerCacheControlConfig
   cache?: ServerCacheConfig
+  jsPoolSize?: number
+  htmlLimitedBots?: string
   moduleAnalysisCache?: ModuleAnalysisCache
   experimental?: {
     useCache?: boolean
@@ -222,11 +224,13 @@ export interface ComponentRebuildResult {
   error?: string
 }
 
-type ResolvedServerBuildOptions = Required<Omit<ServerBuildOptions, 'csp' | 'cacheControl' | 'cache' | 'define' | 'serverConfigPath' | 'experimental' | 'moduleAnalysisCache' | 'mdx'>> & {
+type ResolvedServerBuildOptions = Required<Omit<ServerBuildOptions, 'csp' | 'cacheControl' | 'cache' | 'jsPoolSize' | 'htmlLimitedBots' | 'define' | 'serverConfigPath' | 'experimental' | 'moduleAnalysisCache' | 'mdx'>> & {
   serverConfigPath: string
   csp?: ServerBuildOptions['csp']
   cacheControl?: ServerBuildOptions['cacheControl']
   cache?: ServerBuildOptions['cache']
+  jsPoolSize?: ServerBuildOptions['jsPoolSize']
+  htmlLimitedBots?: ServerBuildOptions['htmlLimitedBots']
   define?: ServerBuildOptions['define']
   experimental?: ServerBuildOptions['experimental']
   moduleAnalysisCache?: ModuleAnalysisCache
@@ -423,6 +427,8 @@ export class ServerComponentBuilder {
       define: options.define,
       csp: options.csp,
       cacheControl: options.cacheControl,
+      cache: options.cache,
+      jsPoolSize: options.jsPoolSize,
       experimental: options.experimental,
       mdx: options.mdx,
     }
@@ -1379,6 +1385,10 @@ export default registerClientReference(null, ${JSON.stringify(componentId)}, "de
       serverConfig.cacheControl = this.options.cacheControl
     if (this.options.cache)
       serverConfig.cache = this.options.cache
+    if (this.options.jsPoolSize != null)
+      serverConfig.jsPoolSize = this.options.jsPoolSize
+    if (this.options.htmlLimitedBots != null)
+      serverConfig.htmlLimitedBots = this.options.htmlLimitedBots
     if (this.options.experimental?.useCacheRemote || this.useCacheBuildId) {
       serverConfig.useCache = {
         ...(this.options.experimental?.useCacheRemote

--- a/packages/rari/src/vite/server/build.ts
+++ b/packages/rari/src/vite/server/build.ts
@@ -429,6 +429,7 @@ export class ServerComponentBuilder {
       cacheControl: options.cacheControl,
       cache: options.cache,
       jsPoolSize: options.jsPoolSize,
+      htmlLimitedBots: options.htmlLimitedBots,
       experimental: options.experimental,
       mdx: options.mdx,
     }

--- a/packages/rari/src/vite/server/config.ts
+++ b/packages/rari/src/vite/server/config.ts
@@ -33,4 +33,6 @@ export interface ServerConfig {
   cacheControl?: ServerCacheControlConfig
   cache?: ServerCacheConfig
   useCache?: ServerUseCacheConfig
+  jsPoolSize?: number
+  htmlLimitedBots?: string
 }

--- a/packages/use-cache/src/runtime/shared/rari-global.ts
+++ b/packages/use-cache/src/runtime/shared/rari-global.ts
@@ -10,6 +10,7 @@ export interface RariGlobalSlice {
   pageCacheTags?: Set<string>
   invalidateUseCache?: (input: InvalidateUseCacheInput) => Promise<void>
   markUseCacheDynamic?: () => void
+  currentRequestId?: () => string
 }
 
 export interface RariGlobal {

--- a/packages/use-cache/src/runtime/storage/remote-ops.ts
+++ b/packages/use-cache/src/runtime/storage/remote-ops.ts
@@ -115,7 +115,8 @@ export function getPrivateCachePartitionKey(): string {
 
   const cookiesOp = runtime.Deno?.core?.ops?.op_get_cookies
   if (typeof cookiesOp === 'function') {
-    const raw = cookiesOp()
+    const requestId = getRariGlobal().currentRequestId?.() ?? ''
+    const raw = cookiesOp(requestId)
     if (typeof raw === 'string' && raw.length > 0)
       return raw
   }

--- a/test/e2e/streaming-load.spec.ts
+++ b/test/e2e/streaming-load.spec.ts
@@ -82,22 +82,21 @@ test.describe('Streaming load validation', () => {
 
     expect(results).toHaveLength(concurrency)
 
-    const timestamps = results.map(({ body }, index) => {
+    const runIds = results.map(({ body }, index) => {
       expect(body.startsWith('<!DOCTYPE html>')).toBe(true)
       expect(body).toContain('__rari_f')
       expect(body).toContain('component-a')
       expect(body).toContain('component-c')
+      expect(body).toContain(`data-testid="run-id">${index}`)
       expect(body.indexOf('</body>')).toBeGreaterThan(body.indexOf('__rari_f'))
 
       const match = body.match(/data-testid="component-c"[^>]*>[\s\S]*?(\d{4}-\d{2}-\d{2}T[\d:.]+Z)/)
       expect(match, `response ${index} should include a component-c timestamp`).toBeTruthy()
-      return match![1]
+      return String(index)
     })
 
-    expect(new Set(timestamps).size).toBe(concurrency)
-
-    const uniqueBodies = new Set(results.map(result => result.body))
-    expect(uniqueBodies.size).toBe(concurrency)
+    expect(new Set(runIds).size).toBe(concurrency)
+    expect(new Set(results.map(result => result.body)).size).toBe(concurrency)
   })
 
   test('should recover after a mid-stream client abort', async ({ page, request }) => {

--- a/test/e2e/streaming-load.spec.ts
+++ b/test/e2e/streaming-load.spec.ts
@@ -92,7 +92,10 @@ test.describe('Streaming load validation', () => {
 
       const match = body.match(/data-testid="component-c"[^>]*>[\s\S]*?(\d{4}-\d{2}-\d{2}T[\d:.]+Z)/)
       expect(match, `response ${index} should include a component-c timestamp`).toBeTruthy()
-      return String(index)
+
+      const runId = body.match(/data-testid="run-id">(\d+)/)?.[1]
+      expect(runId, `response ${index} should include a run-id`).toBe(String(index))
+      return runId
     })
 
     expect(new Set(runIds).size).toBe(concurrency)

--- a/test/fixtures/app/src/app/suspense-streaming/page.tsx
+++ b/test/fixtures/app/src/app/suspense-streaming/page.tsx
@@ -6,10 +6,13 @@ interface SlowProps {
   delay: number
 }
 
-export default function SuspenseStreamingPage(_params: PageProps) {
+export default function SuspenseStreamingPage({ searchParams }: PageProps) {
+  const rawRun = searchParams?.run
+  const runId = Array.isArray(rawRun) ? rawRun[0] : rawRun
   return (
     <div>
       <h1>Suspense Streaming Test</h1>
+      {runId ? <div data-testid="run-id">{runId}</div> : null}
       <Suspense fallback={<div data-testid="loading-a">Loading A...</div>}>
         <SlowComponent name="A" delay={1000} />
       </Suspense>

--- a/test/unit/streaming/html-boundaries.test.ts
+++ b/test/unit/streaming/html-boundaries.test.ts
@@ -1,0 +1,130 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import vm from 'node:vm'
+import { describe, expect, it } from 'vite-plus/test'
+
+interface HtmlBoundaryTracker {
+  reset: () => void
+  safeToInjectFlight: () => boolean
+  trackHtmlBoundaries: (text: string) => boolean
+  getState: () => string
+}
+
+function loadTracker(): () => HtmlBoundaryTracker {
+  const sourcePath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../../../crates/rari/src/rendering/layout/js/html_boundaries.ts',
+  )
+  const source = fs.readFileSync(sourcePath, 'utf8')
+    .replace(/\(text: string\)/g, '(text)')
+  const sandbox: { rariCreateHtmlBoundaryTracker?: () => HtmlBoundaryTracker } = {}
+  vm.runInNewContext(`${source}\nthis.rariCreateHtmlBoundaryTracker = rariCreateHtmlBoundaryTracker`, sandbox)
+  const create = sandbox.rariCreateHtmlBoundaryTracker
+  if (typeof create !== 'function')
+    throw new Error('failed to load rariCreateHtmlBoundaryTracker from html_boundaries.ts')
+
+  return create
+}
+
+const createTracker = loadTracker()
+
+function feed(chunks: string[]) {
+  const tracker = createTracker()
+  const states: Array<{ chunk: string, safe: boolean, state: string }> = []
+  for (const chunk of chunks) {
+    const safe = tracker.trackHtmlBoundaries(chunk)
+    states.push({ chunk, safe, state: tracker.getState() })
+  }
+
+  return { tracker, states }
+}
+
+function assertAllSplits(full: string) {
+  for (let split = 1; split < full.length; split++) {
+    const { tracker, states } = feed([full.slice(0, split), full.slice(split)])
+    expect(
+      tracker.getState(),
+      `split=${split} final state for ${JSON.stringify(full)}`,
+    ).toBe('outside')
+    expect(
+      tracker.safeToInjectFlight(),
+      `split=${split} should be safe after full input`,
+    ).toBe(true)
+    const first = states[0]!
+    if (first.state !== 'outside')
+      expect(first.safe).toBe(false)
+  }
+}
+
+describe('html boundary tracker (Fizz mux)', () => {
+  it('treats complete plain HTML as safe', () => {
+    const tracker = createTracker()
+    expect(tracker.trackHtmlBoundaries('<div>hi</div>')).toBe(true)
+    expect(tracker.getState()).toBe('outside')
+  })
+
+  it('covers every split of an opening tag', () => {
+    assertAllSplits('<div class="x">body</div>')
+  })
+
+  it('covers every split of an inline script open/close', () => {
+    assertAllSplits('<script>alert(1)</script>')
+  })
+
+  it('covers every split of </script> after entering script', () => {
+    const prefix = '<script>x'
+    const close = '</script>'
+    for (let split = 1; split < close.length; split++) {
+      const tracker = createTracker()
+      expect(tracker.trackHtmlBoundaries(prefix)).toBe(false)
+      expect(tracker.getState()).toBe('in_inline_script')
+      expect(tracker.trackHtmlBoundaries(close.slice(0, split))).toBe(false)
+      expect(tracker.trackHtmlBoundaries(close.slice(split))).toBe(true)
+      expect(tracker.getState()).toBe('outside')
+    }
+  })
+
+  it('covers every split of raw-text style close', () => {
+    const prefix = '<style>.a{color:red}'
+    const close = '</style>'
+    for (let split = 1; split < close.length; split++) {
+      const tracker = createTracker()
+      expect(tracker.trackHtmlBoundaries(prefix)).toBe(false)
+      expect(tracker.getState()).toBe('in_raw_text')
+      expect(tracker.trackHtmlBoundaries(close.slice(0, split))).toBe(false)
+      expect(tracker.trackHtmlBoundaries(close.slice(split))).toBe(true)
+      expect(tracker.getState()).toBe('outside')
+    }
+  })
+
+  it('covers every split for title/textarea/xmp closers', () => {
+    for (const tag of ['title', 'textarea', 'xmp'] as const) {
+      const prefix = `<${tag}>content`
+      const close = `</${tag}>`
+      for (let split = 1; split < close.length; split++) {
+        const tracker = createTracker()
+        expect(tracker.trackHtmlBoundaries(prefix)).toBe(false)
+        expect(tracker.getState()).toBe('in_raw_text')
+        expect(tracker.trackHtmlBoundaries(close.slice(0, split))).toBe(false)
+        expect(tracker.trackHtmlBoundaries(close.slice(split))).toBe(true)
+        expect(tracker.getState()).toBe('outside')
+      }
+    }
+  })
+
+  it('does not treat external script as inline', () => {
+    const tracker = createTracker()
+    expect(tracker.trackHtmlBoundaries('<script src="/x.js"></script>')).toBe(true)
+    expect(tracker.getState()).toBe('outside')
+  })
+
+  it('reset returns to outside', () => {
+    const tracker = createTracker()
+    tracker.trackHtmlBoundaries('<script>')
+    expect(tracker.safeToInjectFlight()).toBe(false)
+    tracker.reset()
+    expect(tracker.safeToInjectFlight()).toBe(true)
+    expect(tracker.getState()).toBe('outside')
+  })
+})

--- a/test/unit/vite/server-build.test.ts
+++ b/test/unit/vite/server-build.test.ts
@@ -649,13 +649,19 @@ export async function action() { return {} }`)
           scriptSrc: ['self'],
         },
         jsPoolSize: 2,
+        htmlLimitedBots: 'OnlyMyBot',
       })
 
       await builderWithConfig.buildServerComponents()
 
       expect(fsSync.promises.writeFile).toHaveBeenCalledWith(
         expect.stringContaining('config.json'),
-        expect.stringContaining('"jsPoolSize":2'),
+        expect.stringMatching(/"jsPoolSize":2/),
+        'utf-8',
+      )
+      expect(fsSync.promises.writeFile).toHaveBeenCalledWith(
+        expect.stringContaining('config.json'),
+        expect.stringContaining('"htmlLimitedBots":"OnlyMyBot"'),
         'utf-8',
       )
     })

--- a/test/unit/vite/server-build.test.ts
+++ b/test/unit/vite/server-build.test.ts
@@ -648,13 +648,14 @@ export async function action() { return {} }`)
         csp: {
           scriptSrc: ['self'],
         },
+        jsPoolSize: 2,
       })
 
       await builderWithConfig.buildServerComponents()
 
       expect(fsSync.promises.writeFile).toHaveBeenCalledWith(
         expect.stringContaining('config.json'),
-        expect.any(String),
+        expect.stringContaining('"jsPoolSize":2'),
         'utf-8',
       )
     })


### PR DESCRIPTION
Route streaming through the pool with request-scoped ALS for cookies/headers/fetch, and speed up the path with eager Fizz queueing and HTTP endgame coalesce. Also stream metadata for browsers and block it for HTML-limited bots (jsPoolSize / htmlLimitedBots config).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable JavaScript runtime pool sizing (`jsPoolSize`) and optional HTML-limited bot detection (`htmlLimitedBots`).
  * Enhanced streaming rendering to be request/stream aware, with safer Flight injection and more reliable streaming metadata handling.
  * Introduced request-scoped cookies/headers/cache and request-aware fetch behavior.
* **Bug Fixes**
  * Improved streaming chunking, completion, and error propagation; reduced redundant client JS setup via shared/broadcast initialization.
  * Improved server component/module registration reliability and HMR invalidation behavior.
* **Tests**
  * Expanded coverage for runtime pool selection, streaming boundaries, metadata timing, config precedence, and bot detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->