### PR TITLE
fix(http): preserve multiple Set-Cookie headers on API and proxy responses

### DIFF
--- a/crates/rari/src/runtime/ext/rari/http/api_handler.ts
+++ b/crates/rari/src/runtime/ext/rari/http/api_handler.ts
@@ -30,10 +30,16 @@ function serializeResponseHeaders(
   extraSetCookies: string[] = [],
 ): Record<string, string | string[]> {
   const out: Record<string, string | string[]> = {}
+  const setCookiesFromForEach: string[] = []
+  const hasGetSetCookie = typeof headers.getSetCookie === 'function'
 
   headers.forEach((value, key) => {
-    if (key.toLowerCase() === 'set-cookie')
+    if (key.toLowerCase() === 'set-cookie') {
+      if (!hasGetSetCookie)
+        setCookiesFromForEach.push(value)
+
       return
+    }
     const existing = out[key]
     if (existing === undefined)
       out[key] = value
@@ -44,7 +50,7 @@ function serializeResponseHeaders(
   })
 
   const setCookies = [
-    ...(typeof headers.getSetCookie === 'function' ? headers.getSetCookie() : []),
+    ...(hasGetSetCookie ? headers.getSetCookie() : setCookiesFromForEach),
     ...extraSetCookies,
   ]
   if (setCookies.length === 1)

--- a/crates/rari/src/runtime/ext/rari/http/api_handler.ts
+++ b/crates/rari/src/runtime/ext/rari/http/api_handler.ts
@@ -11,7 +11,7 @@ interface RequestData {
 interface ApiResponse {
   status: number
   statusText: string
-  headers: Record<string, string>
+  headers: Record<string, string | string[]>
   body: string
 }
 
@@ -20,6 +20,48 @@ interface ApiContext {
 }
 
 type ApiHandler = (request: Request, context: ApiContext) => Promise<Response | unknown>
+
+interface ResponseCookiesLike {
+  toSetCookieHeaders?: () => string[]
+}
+
+function serializeResponseHeaders(
+  headers: Headers,
+  extraSetCookies: string[] = [],
+): Record<string, string | string[]> {
+  const out: Record<string, string | string[]> = {}
+
+  headers.forEach((value, key) => {
+    if (key.toLowerCase() === 'set-cookie')
+      return
+    const existing = out[key]
+    if (existing === undefined)
+      out[key] = value
+    else if (Array.isArray(existing))
+      existing.push(value)
+    else
+      out[key] = [existing, value]
+  })
+
+  const setCookies = [
+    ...(typeof headers.getSetCookie === 'function' ? headers.getSetCookie() : []),
+    ...extraSetCookies,
+  ]
+  if (setCookies.length === 1)
+    out['set-cookie'] = setCookies[0]!
+  else if (setCookies.length > 1)
+    out['set-cookie'] = setCookies
+
+  return out
+}
+
+function cookiesFromResponse(result: Response): string[] {
+  const cookies = (result as Response & { cookies?: ResponseCookiesLike }).cookies
+  if (cookies && typeof cookies.toSetCookieHeaders === 'function')
+    return cookies.toSetCookieHeaders()
+
+  return []
+}
 
 async function callHandler(
   requestData: RequestData,
@@ -56,15 +98,10 @@ async function callHandler(
 
     if (result instanceof Response) {
       const body = await result.text()
-      const responseHeaders: Record<string, string> = {}
-      result.headers.forEach((value, key) => {
-        responseHeaders[key] = value
-      })
-
       return {
         status: result.status,
         statusText: result.statusText,
-        headers: responseHeaders,
+        headers: serializeResponseHeaders(result.headers, cookiesFromResponse(result)),
         body,
       }
     }

--- a/crates/rari/src/server/middleware/proxy.rs
+++ b/crates/rari/src/server/middleware/proxy.rs
@@ -62,15 +62,28 @@ fn append_header_map(headers: &mut HeaderMap, map: FxHashMap<String, JsonHeaderV
 }
 
 fn apply_response_headers(headers: &mut HeaderMap, map: FxHashMap<String, JsonHeaderValue>) {
-    for (key, value) in map {
+    let mut entries: Vec<(String, JsonHeaderValue)> = map.into_iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut grouped: FxHashMap<HeaderName, Vec<String>> = FxHashMap::default();
+    for (key, value) in entries {
         let Ok(header_name) = key.parse::<HeaderName>() else {
             continue;
         };
+        let values: Vec<String> = value.as_strs().into_iter().map(str::to_owned).collect();
+        if header_name == header::SET_COOKIE {
+            grouped.entry(header_name).or_default().extend(values);
+        } else {
+            grouped.insert(header_name, values);
+        }
+    }
+
+    for (header_name, values) in grouped {
         if header_name != header::SET_COOKIE {
             headers.remove(&header_name);
         }
-        for value_str in value.as_strs() {
-            let Ok(header_value) = value_str.parse::<HeaderValue>() else {
+        for value_str in values {
+            let Ok(header_value) = HeaderValue::from_str(&value_str) else {
                 continue;
             };
             headers.append(header_name.clone(), header_value);
@@ -422,5 +435,39 @@ mod tests {
         let set_cookies: Vec<_> =
             headers.get_all(header::SET_COOKIE).iter().map(|v| v.to_str().unwrap()).collect();
         assert_eq!(set_cookies, vec!["a=1", "b=2", "c=3"]);
+    }
+
+    #[test]
+    fn apply_response_headers_case_variants_last_win_deterministically() {
+        let mut headers = HeaderMap::new();
+        headers
+            .insert(HeaderName::from_static("content-type"), HeaderValue::from_static("text/html"));
+
+        let mut map = FxHashMap::default();
+        map.insert("Content-Type".to_string(), JsonHeaderValue::Single("text/plain".to_string()));
+        map.insert(
+            "content-type".to_string(),
+            JsonHeaderValue::Single("application/json".to_string()),
+        );
+
+        apply_response_headers(&mut headers, map);
+
+        let content_types: Vec<_> =
+            headers.get_all("content-type").iter().map(|v| v.to_str().unwrap()).collect();
+        assert_eq!(content_types, vec!["application/json"]);
+    }
+
+    #[test]
+    fn apply_response_headers_set_cookie_case_variants_concatenate_in_key_order() {
+        let mut headers = HeaderMap::new();
+        let mut map = FxHashMap::default();
+        map.insert("Set-Cookie".to_string(), JsonHeaderValue::Single("a=1".to_string()));
+        map.insert("set-cookie".to_string(), JsonHeaderValue::Single("b=2".to_string()));
+
+        apply_response_headers(&mut headers, map);
+
+        let set_cookies: Vec<_> =
+            headers.get_all(header::SET_COOKIE).iter().map(|v| v.to_str().unwrap()).collect();
+        assert_eq!(set_cookies, vec!["a=1", "b=2"]);
     }
 }

--- a/crates/rari/src/server/middleware/proxy.rs
+++ b/crates/rari/src/server/middleware/proxy.rs
@@ -61,6 +61,21 @@ fn append_header_map(headers: &mut HeaderMap, map: FxHashMap<String, JsonHeaderV
     }
 }
 
+fn apply_request_headers(headers: &mut HeaderMap, map: FxHashMap<String, JsonHeaderValue>) {
+    for (key, value) in map {
+        let Ok(header_name) = key.parse::<HeaderName>() else {
+            continue;
+        };
+        headers.remove(&header_name);
+        for value_str in value.as_strs() {
+            let Ok(header_value) = value_str.parse::<HeaderValue>() else {
+                continue;
+            };
+            headers.append(header_name.clone(), header_value);
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 struct ProxyResult {
     #[serde(rename = "continue")]
@@ -223,17 +238,7 @@ where
                     }
 
                     if let Some(headers) = result.request_headers {
-                        for (key, value) in headers {
-                            if let Ok(header_name) = key.parse::<HeaderName>() {
-                                for value_str in value.as_strs() {
-                                    if let Ok(header_value) = value_str.parse::<HeaderValue>() {
-                                        request
-                                            .headers_mut()
-                                            .append(header_name.clone(), header_value);
-                                    }
-                                }
-                            }
-                        }
+                        apply_request_headers(request.headers_mut(), headers);
                     }
 
                     if let Some(proxy_response) = result.response {
@@ -344,4 +349,33 @@ pub async fn initialize_proxy(state: &ServerState) -> Result<(), RariError> {
         tracing::error!("Failed to register proxy function: {}", e);
         e
     })
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apply_request_headers_replaces_existing_authorization() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_static("Bearer old"),
+        );
+        headers.insert(HeaderName::from_static("x-keep"), HeaderValue::from_static("1"));
+
+        let mut map = FxHashMap::default();
+        map.insert(
+            "authorization".to_string(),
+            JsonHeaderValue::Single("Bearer proxy".to_string()),
+        );
+
+        apply_request_headers(&mut headers, map);
+
+        let auth: Vec<_> =
+            headers.get_all("authorization").iter().map(|v| v.to_str().unwrap()).collect();
+        assert_eq!(auth, vec!["Bearer proxy"]);
+        assert_eq!(headers.get("x-keep").and_then(|v| v.to_str().ok()), Some("1"));
+    }
 }

--- a/crates/rari/src/server/middleware/proxy.rs
+++ b/crates/rari/src/server/middleware/proxy.rs
@@ -10,7 +10,7 @@ use std::{
 use axum::{
     body::Body,
     extract::Request,
-    http::{HeaderMap, HeaderName, HeaderValue, StatusCode},
+    http::{HeaderMap, HeaderName, HeaderValue, StatusCode, header},
     response::Response,
 };
 use futures_util::future::BoxFuture;
@@ -52,6 +52,23 @@ fn append_header_map(headers: &mut HeaderMap, map: FxHashMap<String, JsonHeaderV
         let Ok(header_name) = key.parse::<HeaderName>() else {
             continue;
         };
+        for value_str in value.as_strs() {
+            let Ok(header_value) = value_str.parse::<HeaderValue>() else {
+                continue;
+            };
+            headers.append(header_name.clone(), header_value);
+        }
+    }
+}
+
+fn apply_response_headers(headers: &mut HeaderMap, map: FxHashMap<String, JsonHeaderValue>) {
+    for (key, value) in map {
+        let Ok(header_name) = key.parse::<HeaderName>() else {
+            continue;
+        };
+        if header_name != header::SET_COOKIE {
+            headers.remove(&header_name);
+        }
         for value_str in value.as_strs() {
             let Ok(header_value) = value_str.parse::<HeaderValue>() else {
                 continue;
@@ -257,7 +274,7 @@ where
                         let mut response = inner.call(request).await?;
 
                         if let Some(headers) = result.response_headers {
-                            append_header_map(response.headers_mut(), headers);
+                            apply_response_headers(response.headers_mut(), headers);
                         }
 
                         return Ok(response);
@@ -377,5 +394,33 @@ mod tests {
             headers.get_all("authorization").iter().map(|v| v.to_str().unwrap()).collect();
         assert_eq!(auth, vec!["Bearer proxy"]);
         assert_eq!(headers.get("x-keep").and_then(|v| v.to_str().ok()), Some("1"));
+    }
+
+    #[test]
+    fn apply_response_headers_replaces_content_type_but_appends_set_cookie() {
+        let mut headers = HeaderMap::new();
+        headers
+            .insert(HeaderName::from_static("content-type"), HeaderValue::from_static("text/html"));
+        headers.append(header::SET_COOKIE, HeaderValue::from_static("a=1"));
+
+        let mut map = FxHashMap::default();
+        map.insert(
+            "content-type".to_string(),
+            JsonHeaderValue::Single("application/json".to_string()),
+        );
+        map.insert(
+            "set-cookie".to_string(),
+            JsonHeaderValue::Multiple(vec!["b=2".to_string(), "c=3".to_string()]),
+        );
+
+        apply_response_headers(&mut headers, map);
+
+        let content_types: Vec<_> =
+            headers.get_all("content-type").iter().map(|v| v.to_str().unwrap()).collect();
+        assert_eq!(content_types, vec!["application/json"]);
+
+        let set_cookies: Vec<_> =
+            headers.get_all(header::SET_COOKIE).iter().map(|v| v.to_str().unwrap()).collect();
+        assert_eq!(set_cookies, vec!["a=1", "b=2", "c=3"]);
     }
 }

--- a/crates/rari/src/server/middleware/proxy.rs
+++ b/crates/rari/src/server/middleware/proxy.rs
@@ -10,7 +10,7 @@ use std::{
 use axum::{
     body::Body,
     extract::Request,
-    http::{HeaderName, HeaderValue, StatusCode},
+    http::{HeaderMap, HeaderName, HeaderValue, StatusCode},
     response::Response,
 };
 use futures_util::future::BoxFuture;
@@ -32,14 +32,44 @@ async fn clone_renderer_runtime(state: &ServerState) -> Arc<JsExecutionRuntime> 
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+enum JsonHeaderValue {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+impl JsonHeaderValue {
+    fn as_strs(&self) -> Vec<&str> {
+        match self {
+            Self::Single(value) => vec![value.as_str()],
+            Self::Multiple(values) => values.iter().map(String::as_str).collect(),
+        }
+    }
+}
+
+fn append_header_map(headers: &mut HeaderMap, map: FxHashMap<String, JsonHeaderValue>) {
+    for (key, value) in map {
+        let Ok(header_name) = key.parse::<HeaderName>() else {
+            continue;
+        };
+        for value_str in value.as_strs() {
+            let Ok(header_value) = value_str.parse::<HeaderValue>() else {
+                continue;
+            };
+            headers.append(header_name.clone(), header_value);
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 struct ProxyResult {
     #[serde(rename = "continue")]
     continue_: bool,
     response: Option<ProxyResponse>,
     #[serde(rename = "requestHeaders")]
-    request_headers: Option<FxHashMap<String, String>>,
+    request_headers: Option<FxHashMap<String, JsonHeaderValue>>,
     #[serde(rename = "responseHeaders")]
-    response_headers: Option<FxHashMap<String, String>>,
+    response_headers: Option<FxHashMap<String, JsonHeaderValue>>,
     rewrite: Option<String>,
     redirect: Option<RedirectInfo>,
 }
@@ -47,7 +77,7 @@ struct ProxyResult {
 #[derive(Debug, Serialize, Deserialize)]
 struct ProxyResponse {
     status: u16,
-    headers: FxHashMap<String, String>,
+    headers: FxHashMap<String, JsonHeaderValue>,
     body: Option<String>,
 }
 
@@ -194,40 +224,35 @@ where
 
                     if let Some(headers) = result.request_headers {
                         for (key, value) in headers {
-                            if let Ok(header_name) = key.parse::<HeaderName>()
-                                && let Ok(header_value) = value.parse::<HeaderValue>()
-                            {
-                                request.headers_mut().insert(header_name, header_value);
+                            if let Ok(header_name) = key.parse::<HeaderName>() {
+                                for value_str in value.as_strs() {
+                                    if let Ok(header_value) = value_str.parse::<HeaderValue>() {
+                                        request
+                                            .headers_mut()
+                                            .append(header_name.clone(), header_value);
+                                    }
+                                }
                             }
                         }
                     }
 
                     if let Some(proxy_response) = result.response {
-                        let mut response_builder =
-                            Response::builder().status(proxy_response.status);
-
-                        for (key, value) in proxy_response.headers {
-                            response_builder = response_builder.header(key, value);
-                        }
-
-                        let body = proxy_response.body.unwrap_or_default();
-                        return match response_builder.body(Body::from(body)) {
-                            Ok(response) => Ok(response),
-                            Err(_) => inner.call(request).await,
+                        let Ok(mut response) = Response::builder()
+                            .status(proxy_response.status)
+                            .body(Body::from(proxy_response.body.unwrap_or_default()))
+                        else {
+                            return inner.call(request).await;
                         };
+
+                        append_header_map(response.headers_mut(), proxy_response.headers);
+                        return Ok(response);
                     }
 
                     if result.continue_ {
                         let mut response = inner.call(request).await?;
 
                         if let Some(headers) = result.response_headers {
-                            for (key, value) in headers {
-                                if let Ok(header_name) = key.parse::<HeaderName>()
-                                    && let Ok(header_value) = value.parse::<HeaderValue>()
-                                {
-                                    response.headers_mut().insert(header_name, header_value);
-                                }
-                            }
+                            append_header_map(response.headers_mut(), headers);
                         }
 
                         return Ok(response);

--- a/crates/rari/src/server/routing/api_routes.rs
+++ b/crates/rari/src/server/routing/api_routes.rs
@@ -7,7 +7,7 @@ use std::{
 use axum::{
     body,
     body::Body,
-    http::{HeaderMap, Request, Response, StatusCode},
+    http::{HeaderMap, HeaderName, HeaderValue, Request, Response, StatusCode},
 };
 use cow_utils::CowUtils;
 use dashmap::DashMap;
@@ -468,19 +468,17 @@ impl ApiRouteHandler {
                 StatusCode::from_u16(status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
             let body_str = result.get("body").and_then(|v| v.as_str()).unwrap_or("").to_string();
 
-            let mut response = Response::builder().status(status_code);
+            let mut response =
+                Response::builder()
+                    .status(status_code)
+                    .body(Body::from(body_str))
+                    .map_err(|e| RariError::internal(format!("Failed to build response: {e}")))?;
 
             if let Some(headers_obj) = result.get("headers").and_then(|v| v.as_object()) {
-                for (key, value) in headers_obj {
-                    if let Some(value_str) = value.as_str() {
-                        response = response.header(key, value_str);
-                    }
-                }
+                append_json_headers(response.headers_mut(), headers_obj);
             }
 
-            response
-                .body(Body::from(body_str))
-                .map_err(|e| RariError::internal(format!("Failed to build response: {e}")))
+            Ok(response)
         } else {
             let body = serde_json::to_string(&result).map_err(|e| {
                 RariError::serialization(format!("Failed to serialize response: {e}"))
@@ -491,6 +489,25 @@ impl ApiRouteHandler {
                 .header("content-type", "application/json")
                 .body(Body::from(body))
                 .map_err(|e| RariError::internal(format!("Failed to build response: {e}")))
+        }
+    }
+}
+
+fn append_json_headers(headers: &mut HeaderMap, headers_obj: &serde_json::Map<String, Value>) {
+    for (key, value) in headers_obj {
+        let Ok(header_name) = HeaderName::from_bytes(key.as_bytes()) else {
+            continue;
+        };
+        let values: Vec<&str> = match value {
+            Value::String(s) => vec![s.as_str()],
+            Value::Array(items) => items.iter().filter_map(Value::as_str).collect(),
+            _ => continue,
+        };
+        for value_str in values {
+            let Ok(header_value) = HeaderValue::from_str(value_str) else {
+                continue;
+            };
+            headers.append(header_name.clone(), header_value);
         }
     }
 }
@@ -551,6 +568,26 @@ mod tests {
         assert_eq!(response.status(), StatusCode::CREATED);
         assert_eq!(response.headers().get("content-type").unwrap(), "application/json");
         assert_eq!(response.headers().get("x-custom").unwrap(), "value");
+    }
+
+    #[tokio::test]
+    async fn test_create_response_preserves_multiple_set_cookie_headers() {
+        let response_json = json!({
+            "status": 200,
+            "headers": {
+                "content-type": "application/json",
+                "set-cookie": ["foo=bar; Path=/", "hello=world; Path=/"]
+            },
+            "body": r#"{"ok":true}"#
+        });
+
+        let response = ApiRouteHandler::create_response(&response_json).unwrap();
+        let set_cookies: Vec<_> =
+            response.headers().get_all("set-cookie").iter().map(|v| v.to_str().unwrap()).collect();
+
+        assert_eq!(set_cookies.len(), 2);
+        assert!(set_cookies.iter().any(|v| v.starts_with("foo=bar")));
+        assert!(set_cookies.iter().any(|v| v.starts_with("hello=world")));
     }
 
     #[tokio::test]

--- a/packages/rari/src/proxy/http/types.ts
+++ b/packages/rari/src/proxy/http/types.ts
@@ -39,6 +39,7 @@ export interface ResponseCookies {
   getAll: () => Array<{ name: string, value: string, path?: string }>
   set: ((name: string, value: string, options?: CookieOptions) => void) & ((options: { name: string, value: string } & CookieOptions) => void)
   delete: (name: string) => void
+  toSetCookieHeaders: () => string[]
 }
 
 export interface CookieOptions {
@@ -90,8 +91,8 @@ export interface ProxyModule {
 export interface ProxyResult {
   continue: boolean
   response?: Response
-  requestHeaders?: Record<string, string>
-  responseHeaders?: Record<string, string>
+  requestHeaders?: Record<string, string | string[]>
+  responseHeaders?: Record<string, string | string[]>
   rewrite?: string
   redirect?: {
     destination: string

--- a/packages/rari/src/proxy/runtime/executor.ts
+++ b/packages/rari/src/proxy/runtime/executor.ts
@@ -138,9 +138,16 @@ export class ProxyExecutor {
           target[key] = [existing, value]
       }
 
+      const setCookiesFromForEach: string[] = []
+      const hasGetSetCookie = typeof response.headers.getSetCookie === 'function'
+
       response.headers.forEach((value, key) => {
-        if (key.toLowerCase() === 'set-cookie')
+        if (key.toLowerCase() === 'set-cookie') {
+          if (!hasGetSetCookie)
+            setCookiesFromForEach.push(value)
+
           return
+        }
         if (key.startsWith('x-rari-proxy-request-')) {
           const headerName = key.replace('x-rari-proxy-request-', '')
           merge(requestHeaders, headerName, value)
@@ -150,7 +157,10 @@ export class ProxyExecutor {
         }
       })
 
-      for (const value of response.headers.getSetCookie())
+      const setCookies = hasGetSetCookie
+        ? response.headers.getSetCookie()
+        : setCookiesFromForEach
+      for (const value of setCookies)
         merge(responseHeaders, 'set-cookie', value)
 
       if ('cookies' in response && typeof response.cookies.toSetCookieHeaders === 'function') {

--- a/packages/rari/src/proxy/runtime/executor.ts
+++ b/packages/rari/src/proxy/runtime/executor.ts
@@ -121,18 +121,42 @@ export class ProxyExecutor {
     }
 
     if (continueHeader === 'true') {
-      const requestHeaders: Record<string, string> = {}
-      const responseHeaders: Record<string, string> = {}
+      const requestHeaders: Record<string, string | string[]> = {}
+      const responseHeaders: Record<string, string | string[]> = {}
+
+      const merge = (
+        target: Record<string, string | string[]>,
+        key: string,
+        value: string,
+      ) => {
+        const existing = target[key]
+        if (existing === undefined)
+          target[key] = value
+        else if (Array.isArray(existing))
+          existing.push(value)
+        else
+          target[key] = [existing, value]
+      }
 
       response.headers.forEach((value, key) => {
+        if (key.toLowerCase() === 'set-cookie')
+          return
         if (key.startsWith('x-rari-proxy-request-')) {
           const headerName = key.replace('x-rari-proxy-request-', '')
-          requestHeaders[headerName] = value
+          merge(requestHeaders, headerName, value)
         }
         else if (!key.startsWith('x-rari-proxy-')) {
-          responseHeaders[key] = value
+          merge(responseHeaders, key, value)
         }
       })
+
+      for (const value of response.headers.getSetCookie())
+        merge(responseHeaders, 'set-cookie', value)
+
+      if ('cookies' in response && typeof response.cookies.toSetCookieHeaders === 'function') {
+        for (const value of response.cookies.toSetCookieHeaders())
+          merge(responseHeaders, 'set-cookie', value)
+      }
 
       return {
         continue: true,

--- a/packages/rari/src/proxy/runtime/executor.ts
+++ b/packages/rari/src/proxy/runtime/executor.ts
@@ -163,8 +163,9 @@ export class ProxyExecutor {
       for (const value of setCookies)
         merge(responseHeaders, 'set-cookie', value)
 
-      if ('cookies' in response && typeof response.cookies.toSetCookieHeaders === 'function') {
-        for (const value of response.cookies.toSetCookieHeaders())
+      const cookies = 'cookies' in response ? response.cookies : undefined
+      if (cookies && typeof cookies.toSetCookieHeaders === 'function') {
+        for (const value of cookies.toSetCookieHeaders())
           merge(responseHeaders, 'set-cookie', value)
       }
 

--- a/packages/rari/src/proxy/runtime/shared/headers.ts
+++ b/packages/rari/src/proxy/runtime/shared/headers.ts
@@ -14,6 +14,36 @@ function mergeHeader(
   }
 }
 
+function collectSetCookieHeaders(headers: ResponseLike['headers']): string[] {
+  if (!headers)
+    return []
+
+  if (typeof headers.getSetCookie === 'function')
+    return headers.getSetCookie()
+
+  const collected: string[] = []
+  if (headers.forEach) {
+    headers.forEach((value, key) => {
+      if (key.toLowerCase() === 'set-cookie')
+        collected.push(value)
+    })
+  }
+
+  return collected
+}
+
+export function applyResponseCookies(
+  result: ResponseLike,
+  responseHeaders: Record<string, string | string[]>,
+): void {
+  const cookies = result.cookies
+  if (!cookies || typeof cookies.toSetCookieHeaders !== 'function')
+    return
+
+  for (const value of cookies.toSetCookieHeaders())
+    mergeHeader(responseHeaders, 'set-cookie', value)
+}
+
 export function extractProxyHeaders(headers: ResponseLike['headers']): { requestHeaders?: Record<string, string | string[]>, responseHeaders?: Record<string, string | string[]> } {
   const requestHeaders: Record<string, string | string[]> = {}
   const responseHeaders: Record<string, string | string[]> = {}
@@ -21,6 +51,9 @@ export function extractProxyHeaders(headers: ResponseLike['headers']): { request
   if (headers?.forEach) {
     headers.forEach((value: string, key: string) => {
       const lowerKey = key.toLowerCase()
+
+      if (lowerKey === 'set-cookie')
+        return
 
       if (lowerKey.startsWith('x-rari-proxy-request-')) {
         const headerName = lowerKey.replace('x-rari-proxy-request-', '')
@@ -31,6 +64,9 @@ export function extractProxyHeaders(headers: ResponseLike['headers']): { request
       }
     })
   }
+
+  for (const value of collectSetCookieHeaders(headers))
+    mergeHeader(responseHeaders, 'set-cookie', value)
 
   return {
     requestHeaders: Object.keys(requestHeaders).length > 0 ? requestHeaders : undefined,
@@ -43,9 +79,14 @@ export function collectAllHeaders(headers: ResponseLike['headers']): Record<stri
 
   if (headers?.forEach) {
     headers.forEach((value: string, key: string) => {
+      if (key.toLowerCase() === 'set-cookie')
+        return
       mergeHeader(result, key.toLowerCase(), value)
     })
   }
+
+  for (const value of collectSetCookieHeaders(headers))
+    mergeHeader(result, 'set-cookie', value)
 
   return result
 }

--- a/packages/rari/src/proxy/runtime/shared/process-result.ts
+++ b/packages/rari/src/proxy/runtime/shared/process-result.ts
@@ -1,5 +1,5 @@
 import type { ResponseLike, SimpleProxyResult } from './types'
-import { collectAllHeaders, extractProxyHeaders } from './headers'
+import { applyResponseCookies, collectAllHeaders, extractProxyHeaders } from './headers'
 
 export function checkForRewrite(result: ResponseLike | null): SimpleProxyResult | null {
   if (!result)
@@ -37,16 +37,18 @@ export function checkForRedirect(result: ResponseLike | null): SimpleProxyResult
 }
 
 export function handleContinueWithHeaders(result: ResponseLike): SimpleProxyResult {
-  const { requestHeaders, responseHeaders } = extractProxyHeaders(result.headers)
+  const { requestHeaders, responseHeaders = {} } = extractProxyHeaders(result.headers)
+  applyResponseCookies(result, responseHeaders)
   return {
     continue: true,
     requestHeaders,
-    responseHeaders,
+    responseHeaders: Object.keys(responseHeaders).length > 0 ? responseHeaders : undefined,
   }
 }
 
 export async function handleDirectResponse(result: ResponseLike): Promise<SimpleProxyResult> {
   const headers = collectAllHeaders(result.headers)
+  applyResponseCookies(result, headers)
 
   let body: string | undefined
   try {

--- a/packages/rari/src/proxy/runtime/shared/types.ts
+++ b/packages/rari/src/proxy/runtime/shared/types.ts
@@ -24,7 +24,11 @@ export interface ResponseLike {
   status?: number
   headers?: {
     get?: (name: string) => string | null
+    getSetCookie?: () => string[]
     forEach?: (callback: (value: string, key: string) => void) => void
+  }
+  cookies?: {
+    toSetCookieHeaders?: () => string[]
   }
   text?: () => Promise<string>
   body?: any

--- a/test/unit/proxy/rari-response.test.ts
+++ b/test/unit/proxy/rari-response.test.ts
@@ -114,7 +114,7 @@ describe('RariResponse', () => {
 
       res.cookies.set('session', 'abc123')
 
-      const headers = (res.cookies as any).toSetCookieHeaders()
+      const headers = res.cookies.toSetCookieHeaders()
 
       expect(headers).toHaveLength(1)
       expect(headers[0]).toBe('session=abc123')
@@ -125,7 +125,7 @@ describe('RariResponse', () => {
 
       res.cookies.set('token', 'xyz', { path: '/api' })
 
-      const headers = (res.cookies as any).toSetCookieHeaders()
+      const headers = res.cookies.toSetCookieHeaders()
 
       expect(headers[0]).toBe('token=xyz; Path=/api')
     })
@@ -135,7 +135,7 @@ describe('RariResponse', () => {
 
       res.cookies.set('user', 'john', { domain: 'example.com' })
 
-      const headers = (res.cookies as any).toSetCookieHeaders()
+      const headers = res.cookies.toSetCookieHeaders()
 
       expect(headers[0]).toBe('user=john; Domain=example.com')
     })
@@ -145,7 +145,7 @@ describe('RariResponse', () => {
 
       res.cookies.set('temp', 'value', { maxAge: 3600 })
 
-      const headers = (res.cookies as any).toSetCookieHeaders()
+      const headers = res.cookies.toSetCookieHeaders()
 
       expect(headers[0]).toBe('temp=value; Max-Age=3600')
     })
@@ -156,7 +156,7 @@ describe('RariResponse', () => {
 
       res.cookies.set('persistent', 'value', { expires })
 
-      const headers = (res.cookies as any).toSetCookieHeaders()
+      const headers = res.cookies.toSetCookieHeaders()
 
       expect(headers[0]).toBe(`persistent=value; Expires=${expires.toUTCString()}`)
     })
@@ -166,7 +166,7 @@ describe('RariResponse', () => {
 
       res.cookies.set('secure', 'value', { httpOnly: true })
 
-      const headers = (res.cookies as any).toSetCookieHeaders()
+      const headers = res.cookies.toSetCookieHeaders()
 
       expect(headers[0]).toBe('secure=value; HttpOnly')
     })
@@ -176,7 +176,7 @@ describe('RariResponse', () => {
 
       res.cookies.set('token', 'value', { secure: true })
 
-      const headers = (res.cookies as any).toSetCookieHeaders()
+      const headers = res.cookies.toSetCookieHeaders()
 
       expect(headers[0]).toBe('token=value; Secure')
     })
@@ -186,7 +186,7 @@ describe('RariResponse', () => {
 
       res.cookies.set('session', 'token', { sameSite: 'strict' })
 
-      const headers = (res.cookies as any).toSetCookieHeaders()
+      const headers = res.cookies.toSetCookieHeaders()
 
       expect(headers[0]).toBe('session=token; SameSite=strict')
     })
@@ -205,7 +205,7 @@ describe('RariResponse', () => {
         sameSite: 'lax',
       })
 
-      const headers = (res.cookies as any).toSetCookieHeaders()
+      const headers = res.cookies.toSetCookieHeaders()
 
       expect(headers[0]).toBe(
         `full=value; Path=/app; Domain=example.com; Max-Age=3600; Expires=${expires.toUTCString()}; HttpOnly; Secure; SameSite=lax`,
@@ -218,7 +218,7 @@ describe('RariResponse', () => {
       res.cookies.set('a', '1', { path: '/a' })
       res.cookies.set('b', '2', { path: '/b' })
 
-      const headers = (res.cookies as any).toSetCookieHeaders()
+      const headers = res.cookies.toSetCookieHeaders()
 
       expect(headers).toHaveLength(2)
       expect(headers).toContain('a=1; Path=/a')

--- a/test/unit/proxy/set-cookie-headers.test.ts
+++ b/test/unit/proxy/set-cookie-headers.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vite-plus/test'
+import { RariResponse } from '../../../packages/rari/src/proxy/http/response'
+import {
+  applyResponseCookies,
+  collectAllHeaders,
+  extractProxyHeaders,
+} from '../../../packages/rari/src/proxy/runtime/shared/headers'
+import {
+  handleContinueWithHeaders,
+  handleDirectResponse,
+} from '../../../packages/rari/src/proxy/runtime/shared/process-result'
+
+describe('proxy response Set-Cookie serialization', () => {
+  it('collects multiple Set-Cookie headers via getSetCookie', () => {
+    const headers = new Headers()
+    headers.append('Set-Cookie', 'foo=bar; Path=/')
+    headers.append('Set-Cookie', 'hello=world; Path=/')
+    headers.set('Content-Type', 'application/json')
+
+    const collected = collectAllHeaders(headers)
+
+    expect(collected['content-type']).toBe('application/json')
+    expect(collected['set-cookie']).toEqual([
+      'foo=bar; Path=/',
+      'hello=world; Path=/',
+    ])
+  })
+
+  it('applies RariResponse.cookies into response headers', () => {
+    const response = RariResponse.next()
+    response.cookies.set('foo', 'bar', { path: '/' })
+    response.cookies.set('hello', 'world', { path: '/' })
+
+    const headers: Record<string, string | string[]> = {}
+    applyResponseCookies(response, headers)
+
+    expect(headers['set-cookie']).toEqual([
+      'foo=bar; Path=/',
+      'hello=world; Path=/',
+    ])
+  })
+
+  it('flushes cookies on continue responses', () => {
+    const response = RariResponse.next()
+    response.cookies.set('visited', 'true', { path: '/' })
+    response.cookies.set('theme', 'dark', { path: '/' })
+
+    const result = handleContinueWithHeaders(response)
+
+    expect(result.continue).toBe(true)
+    expect(result.responseHeaders?.['set-cookie']).toEqual([
+      'visited=true; Path=/',
+      'theme=dark; Path=/',
+    ])
+  })
+
+  it('flushes cookies on direct responses', async () => {
+    const response = RariResponse.json({ ok: true })
+    response.cookies.set('a', '1')
+    response.cookies.set('b', '2')
+
+    const result = await handleDirectResponse(response)
+
+    expect(result.continue).toBe(false)
+    expect(result.response?.headers['set-cookie']).toEqual(['a=1', 'b=2'])
+  })
+
+  it('keeps proxy request headers separate from Set-Cookie', () => {
+    const headers = new Headers({
+      'x-rari-proxy-continue': 'true',
+      'x-rari-proxy-request-x-custom': '1',
+    })
+    headers.append('Set-Cookie', 'a=1')
+    headers.append('Set-Cookie', 'b=2')
+
+    const { requestHeaders, responseHeaders } = extractProxyHeaders(headers)
+
+    expect(requestHeaders).toEqual({ 'x-custom': '1' })
+    expect(responseHeaders?.['set-cookie']).toEqual(['a=1', 'b=2'])
+  })
+})

--- a/test/unit/proxy/set-cookie-headers.test.ts
+++ b/test/unit/proxy/set-cookie-headers.test.ts
@@ -78,4 +78,18 @@ describe('proxy response Set-Cookie serialization', () => {
     expect(requestHeaders).toEqual({ 'x-custom': '1' })
     expect(responseHeaders?.['set-cookie']).toEqual(['a=1', 'b=2'])
   })
+
+  it('falls back to forEach when getSetCookie is unavailable', () => {
+    const setCookieValues = ['a=1', 'b=2']
+    const headers = {
+      forEach(callback: (value: string, key: string) => void) {
+        callback('application/json', 'content-type')
+        for (const value of setCookieValues)
+          callback(value, 'set-cookie')
+      },
+    }
+
+    const collected = collectAllHeaders(headers)
+    expect(collected['set-cookie']).toEqual(setCookieValues)
+  })
 })


### PR DESCRIPTION
RariResponse.cookies never reached the wire, and multi-value Set-Cookie was collapsed to a single string in the JS to Rust envelope. Flush cookies via toSetCookieHeaders/getSetCookie and append each value in Rust so callers can set more than one cookie per response.

Fixes #309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved repeated HTTP header values end-to-end, including multiple `Set-Cookie` headers, without unintended overwrites.
  * Improved proxy header handling to correctly merge/replace headers and to serialize cookies from both response headers and cookie helpers for direct and “continue” flows.
  * Enhanced support for single-value vs array-provided headers when constructing responses and proxy requests/responses.

* **Tests**
  * Added unit coverage for multi-value `Set-Cookie` serialization and correct separation of proxy headers vs cookies.
  * Updated existing cookie unit tests to use the public `toSetCookieHeaders()` API directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->