### PR TITLE
fix(cache): cap static_fast_cache to stop unbounded RSS growth

### DIFF
--- a/crates/rari/src/server/cache/response.rs
+++ b/crates/rari/src/server/cache/response.rs
@@ -1,5 +1,6 @@
 use std::{
     env,
+    ops::Deref,
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -92,14 +93,45 @@ impl CachedResponse {
     }
 }
 
-pub fn invalidate_static_fast_cache_for_path(
-    cache: &DashMap<String, Arc<PrebuiltResponse>>,
-    path: &str,
-) {
-    cache.remove(path);
+pub struct StaticFastCache {
+    map: DashMap<String, Arc<PrebuiltResponse>>,
+    insert_lock: Mutex<()>,
+    entry_count: AtomicUsize,
+}
+
+impl StaticFastCache {
+    pub fn new() -> Self {
+        Self { map: DashMap::new(), insert_lock: Mutex::new(()), entry_count: AtomicUsize::new(0) }
+    }
+
+    pub fn entry_count(&self) -> usize {
+        self.entry_count.load(Ordering::Relaxed)
+    }
+}
+
+impl Default for StaticFastCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Deref for StaticFastCache {
+    type Target = DashMap<String, Arc<PrebuiltResponse>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.map
+    }
+}
+
+pub fn invalidate_static_fast_cache_for_path(cache: &StaticFastCache, path: &str) {
+    let _guard = cache.insert_lock.lock();
+    if cache.map.remove(path).is_some() {
+        cache.entry_count.fetch_sub(1, Ordering::Relaxed);
+    }
     let query_prefix = format!("{path}?");
     let hash_prefix = format!("{path}#");
     let keys: Vec<String> = cache
+        .map
         .iter()
         .filter(|entry| {
             let key = entry.key();
@@ -108,12 +140,14 @@ pub fn invalidate_static_fast_cache_for_path(
         .map(|entry| entry.key().clone())
         .collect();
     for key in keys {
-        cache.remove(&key);
+        if cache.map.remove(&key).is_some() {
+            cache.entry_count.fetch_sub(1, Ordering::Relaxed);
+        }
     }
 }
 
 pub fn insert_static_fast_cache(
-    cache: &DashMap<String, Arc<PrebuiltResponse>>,
+    cache: &StaticFastCache,
     key: &str,
     value: Arc<PrebuiltResponse>,
     max_entries: usize,
@@ -122,30 +156,39 @@ pub fn insert_static_fast_cache(
         return;
     }
 
-    let replacing = cache.contains_key(key);
-    cache.insert(key.to_string(), value);
+    let _guard = cache.insert_lock.lock();
+    let replacing = cache.map.insert(key.to_string(), value).is_some();
+    if !replacing {
+        cache.entry_count.fetch_add(1, Ordering::Relaxed);
+    }
     if replacing {
         return;
     }
 
-    while cache.len() > max_entries {
+    while cache.entry_count.load(Ordering::Relaxed) > max_entries {
         let victim = cache
+            .map
             .iter()
             .find(|entry| entry.key().as_str() != key && entry.key().contains('?'))
             .map(|entry| entry.key().clone())
             .or_else(|| {
                 cache
+                    .map
                     .iter()
                     .find(|entry| entry.key().as_str() != key)
                     .map(|entry| entry.key().clone())
             });
         match victim {
             Some(victim_key) => {
-                cache.remove(&victim_key);
+                if cache.map.remove(&victim_key).is_some() {
+                    cache.entry_count.fetch_sub(1, Ordering::Relaxed);
+                }
             }
             None => break,
         }
     }
+
+    debug_assert!(cache.entry_count.load(Ordering::Relaxed) <= max_entries);
 }
 
 #[derive(Clone, Debug)]
@@ -636,7 +679,7 @@ mod header_map_serde {
 #[cfg(test)]
 #[expect(clippy::expect_used, clippy::unwrap_used, clippy::clone_on_ref_ptr)]
 mod tests {
-    use std::{sync::Arc, time::Duration};
+    use std::{sync::Arc, thread, time::Duration};
 
     use parking_lot::Mutex as PMutex;
     use rustc_hash::FxHashMap;
@@ -1140,7 +1183,7 @@ mod tests {
 
     #[test]
     fn test_invalidate_static_fast_cache_for_path() {
-        let cache: DashMap<String, Arc<PrebuiltResponse>> = DashMap::new();
+        let cache = StaticFastCache::new();
         let body = Bytes::from("html");
         let make_entry = || {
             Arc::new(PrebuiltResponse {
@@ -1155,10 +1198,10 @@ mod tests {
             })
         };
 
-        cache.insert("/about".to_string(), make_entry());
-        cache.insert("/about?tab=1".to_string(), make_entry());
-        cache.insert("/about#cookie:abc123".to_string(), make_entry());
-        cache.insert("/other".to_string(), make_entry());
+        insert_static_fast_cache(&cache, "/about", make_entry(), 10);
+        insert_static_fast_cache(&cache, "/about?tab=1", make_entry(), 10);
+        insert_static_fast_cache(&cache, "/about#cookie:abc123", make_entry(), 10);
+        insert_static_fast_cache(&cache, "/other", make_entry(), 10);
 
         invalidate_static_fast_cache_for_path(&cache, "/about");
 
@@ -1166,11 +1209,12 @@ mod tests {
         assert!(!cache.contains_key("/about?tab=1"));
         assert!(!cache.contains_key("/about#cookie:abc123"));
         assert!(cache.contains_key("/other"));
+        assert_eq!(cache.entry_count(), 1);
     }
 
     #[test]
     fn test_insert_static_fast_cache_caps_and_prefers_query_eviction() {
-        let cache: DashMap<String, Arc<PrebuiltResponse>> = DashMap::new();
+        let cache = StaticFastCache::new();
         let body = Bytes::from("html");
         let make_entry = || {
             Arc::new(PrebuiltResponse {
@@ -1187,21 +1231,59 @@ mod tests {
 
         insert_static_fast_cache(&cache, "/", make_entry(), 2);
         insert_static_fast_cache(&cache, "/?utm=1", make_entry(), 2);
-        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.entry_count(), 2);
 
         insert_static_fast_cache(&cache, "/blog", make_entry(), 2);
-        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.entry_count(), 2);
         assert!(cache.contains_key("/"));
         assert!(cache.contains_key("/blog"));
         assert!(!cache.contains_key("/?utm=1"));
 
         insert_static_fast_cache(&cache, "/", make_entry(), 2);
-        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.entry_count(), 2);
         assert!(cache.contains_key("/"));
         assert!(cache.contains_key("/blog"));
 
         insert_static_fast_cache(&cache, "/x", make_entry(), 0);
         assert!(!cache.contains_key("/x"));
-        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.entry_count(), 2);
+    }
+
+    #[test]
+    fn test_insert_static_fast_cache_concurrent_never_exceeds_max() {
+        let cache = Arc::new(StaticFastCache::new());
+        let max_entries = 32usize;
+        let threads = 8usize;
+        let per_thread = 200usize;
+        let body = Bytes::from("html");
+
+        let mut handles = Vec::with_capacity(threads);
+        for thread_id in 0..threads {
+            let cache = Arc::clone(&cache);
+            let body = body.clone();
+            handles.push(thread::spawn(move || {
+                for i in 0..per_thread {
+                    let key = format!("/t{thread_id}?n={i}");
+                    let entry = Arc::new(PrebuiltResponse {
+                        identity: body.clone(),
+                        gzip: None,
+                        br: None,
+                        zstd: None,
+                        etag: "W/\"1\"".to_string(),
+                        content_type: "text/html; charset=utf-8".to_string(),
+                        cache_control: "public".to_string(),
+                        is_not_found: false,
+                    });
+                    insert_static_fast_cache(&cache, &key, entry, max_entries);
+                }
+            }));
+        }
+
+        for handle in handles {
+            handle.join().expect("worker thread panicked");
+        }
+
+        assert!(cache.entry_count() <= max_entries);
+        assert_eq!(cache.entry_count(), max_entries);
     }
 }

--- a/crates/rari/src/server/cache/response.rs
+++ b/crates/rari/src/server/cache/response.rs
@@ -112,6 +112,42 @@ pub fn invalidate_static_fast_cache_for_path(
     }
 }
 
+pub fn insert_static_fast_cache(
+    cache: &DashMap<String, Arc<PrebuiltResponse>>,
+    key: &str,
+    value: Arc<PrebuiltResponse>,
+    max_entries: usize,
+) {
+    if max_entries == 0 {
+        return;
+    }
+
+    let replacing = cache.contains_key(key);
+    cache.insert(key.to_string(), value);
+    if replacing {
+        return;
+    }
+
+    while cache.len() > max_entries {
+        let victim = cache
+            .iter()
+            .find(|entry| entry.key().as_str() != key && entry.key().contains('?'))
+            .map(|entry| entry.key().clone())
+            .or_else(|| {
+                cache
+                    .iter()
+                    .find(|entry| entry.key().as_str() != key)
+                    .map(|entry| entry.key().clone())
+            });
+        match victim {
+            Some(victim_key) => {
+                cache.remove(&victim_key);
+            }
+            None => break,
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct CacheConfig {
@@ -1130,5 +1166,42 @@ mod tests {
         assert!(!cache.contains_key("/about?tab=1"));
         assert!(!cache.contains_key("/about#cookie:abc123"));
         assert!(cache.contains_key("/other"));
+    }
+
+    #[test]
+    fn test_insert_static_fast_cache_caps_and_prefers_query_eviction() {
+        let cache: DashMap<String, Arc<PrebuiltResponse>> = DashMap::new();
+        let body = Bytes::from("html");
+        let make_entry = || {
+            Arc::new(PrebuiltResponse {
+                identity: body.clone(),
+                gzip: None,
+                br: None,
+                zstd: None,
+                etag: "W/\"1\"".to_string(),
+                content_type: "text/html; charset=utf-8".to_string(),
+                cache_control: "public".to_string(),
+                is_not_found: false,
+            })
+        };
+
+        insert_static_fast_cache(&cache, "/", make_entry(), 2);
+        insert_static_fast_cache(&cache, "/?utm=1", make_entry(), 2);
+        assert_eq!(cache.len(), 2);
+
+        insert_static_fast_cache(&cache, "/blog", make_entry(), 2);
+        assert_eq!(cache.len(), 2);
+        assert!(cache.contains_key("/"));
+        assert!(cache.contains_key("/blog"));
+        assert!(!cache.contains_key("/?utm=1"));
+
+        insert_static_fast_cache(&cache, "/", make_entry(), 2);
+        assert_eq!(cache.len(), 2);
+        assert!(cache.contains_key("/"));
+        assert!(cache.contains_key("/blog"));
+
+        insert_static_fast_cache(&cache, "/x", make_entry(), 0);
+        assert!(!cache.contains_key("/x"));
+        assert_eq!(cache.len(), 2);
     }
 }

--- a/crates/rari/src/server/cache/response.rs
+++ b/crates/rari/src/server/cache/response.rs
@@ -1,6 +1,5 @@
 use std::{
     env,
-    ops::Deref,
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -107,19 +106,19 @@ impl StaticFastCache {
     pub fn entry_count(&self) -> usize {
         self.entry_count.load(Ordering::Relaxed)
     }
+
+    pub fn get(&self, key: &str) -> Option<Arc<PrebuiltResponse>> {
+        self.map.get(key).map(|entry| Arc::clone(entry.value()))
+    }
+
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.map.contains_key(key)
+    }
 }
 
 impl Default for StaticFastCache {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-impl Deref for StaticFastCache {
-    type Target = DashMap<String, Arc<PrebuiltResponse>>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.map
     }
 }
 

--- a/crates/rari/src/server/cache/response.rs
+++ b/crates/rari/src/server/cache/response.rs
@@ -1249,6 +1249,35 @@ mod tests {
     }
 
     #[test]
+    fn test_insert_static_fast_cache_replace_updates_value_not_count() {
+        let cache = StaticFastCache::new();
+        let make_entry = |body: &'static str, etag: &'static str| {
+            Arc::new(PrebuiltResponse {
+                identity: Bytes::from(body),
+                gzip: None,
+                br: None,
+                zstd: None,
+                etag: etag.to_string(),
+                content_type: "text/html; charset=utf-8".to_string(),
+                cache_control: "public".to_string(),
+                is_not_found: false,
+            })
+        };
+
+        insert_static_fast_cache(&cache, "/", make_entry("v1", "W/\"1\""), 2);
+        insert_static_fast_cache(&cache, "/other", make_entry("other", "W/\"o\""), 2);
+        assert_eq!(cache.entry_count(), 2);
+
+        insert_static_fast_cache(&cache, "/", make_entry("v2", "W/\"2\""), 2);
+        assert_eq!(cache.entry_count(), 2);
+        assert!(cache.contains_key("/other"));
+
+        let stored = cache.get("/").expect("replaced entry");
+        assert_eq!(stored.identity.as_ref(), b"v2");
+        assert_eq!(stored.etag, "W/\"2\"");
+    }
+
+    #[test]
     fn test_insert_static_fast_cache_concurrent_never_exceeds_max() {
         let cache = Arc::new(StaticFastCache::new());
         let max_entries = 32usize;

--- a/crates/rari/src/server/cache/warmup.rs
+++ b/crates/rari/src/server/cache/warmup.rs
@@ -188,8 +188,9 @@ async fn warm_route(
             if matches!(enc, CompressionEncoding::Brotli) { Some(compressed) } else { None }
         };
 
-        state.static_fast_cache.insert(
-            path.to_string(),
+        response::insert_static_fast_cache(
+            &state.static_fast_cache,
+            path,
             Arc::new(response::PrebuiltResponse {
                 identity: body_bytes.clone(),
                 gzip: compressed_gzip.clone(),
@@ -200,6 +201,7 @@ async fn warm_route(
                 cache_control: cache_control.to_string(),
                 is_not_found: false,
             }),
+            state.response_cache.config.max_entries,
         );
 
         let cached_response = response::CachedResponse {

--- a/crates/rari/src/server/core/mod.rs
+++ b/crates/rari/src/server/core/mod.rs
@@ -239,7 +239,7 @@ impl Server {
                 &cache_registry,
             ),
             response_cache,
-            static_fast_cache: Arc::new(DashMap::new()),
+            static_fast_cache: Arc::new(response::StaticFastCache::new()),
             og_generator,
             project_root,
             image_optimizer: None,

--- a/crates/rari/src/server/core/types/mod.rs
+++ b/crates/rari/src/server/core/types/mod.rs
@@ -19,7 +19,7 @@ use crate::{
         cache::{
             CacheHandlerRegistry,
             handler::CacheHandler,
-            response::{PrebuiltResponse, ResponseCache},
+            response::{ResponseCache, StaticFastCache},
         },
         config::Config,
         image::ImageOptimizer,
@@ -43,7 +43,7 @@ pub struct ServerState {
     pub html_cache: Arc<DashMap<String, String>>,
     pub layout_html_cache: Arc<LayoutHtmlCache>,
     pub response_cache: Arc<ResponseCache>,
-    pub static_fast_cache: Arc<DashMap<String, Arc<PrebuiltResponse>>>,
+    pub static_fast_cache: Arc<StaticFastCache>,
     pub og_generator: Option<Arc<OgImageGenerator>>,
     pub project_root: PathBuf,
     pub image_optimizer: Option<Arc<ImageOptimizer>>,

--- a/crates/rari/src/server/routing/app.rs
+++ b/crates/rari/src/server/routing/app.rs
@@ -1279,8 +1279,6 @@ pub async fn handle_app_route(
             response::ResponseCache::generate_static_fast_cache_key(path, query_params_ref, None);
 
         if let Some(prebuilt) = state.static_fast_cache.get(&fast_key) {
-            let prebuilt = Arc::clone(prebuilt.value());
-
             if let Some(client_etag) = headers.get("if-none-match").and_then(|v| v.to_str().ok())
                 && client_etag == prebuilt.etag
             {

--- a/crates/rari/src/server/routing/app.rs
+++ b/crates/rari/src/server/routing/app.rs
@@ -1896,8 +1896,9 @@ pub async fn handle_app_route(
                         query_params_ref,
                         None,
                     );
-                    state.static_fast_cache.insert(
-                        fast_key,
+                    response::insert_static_fast_cache(
+                        &state.static_fast_cache,
+                        &fast_key,
                         Arc::new(response::PrebuiltResponse {
                             identity: body_bytes.clone(),
                             gzip: compressed_gzip.clone(),
@@ -1908,6 +1909,7 @@ pub async fn handle_app_route(
                             cache_control: cache_control_value.to_string(),
                             is_not_found: route_match.not_found.is_some(),
                         }),
+                        state.response_cache.config.max_entries,
                     );
                 }
 


### PR DESCRIPTION
Reuse response_cache max_entries and prefer evicting query-variant keys so warmed paths survive high-cardinality traffic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Static fast response caching now strictly enforces the configured max entry limit, including a `max_entries` of 0.
  * Eviction behavior is refined to better retain relevant entries, with improved count tracking.
  * Cache invalidation now removes the exact path plus related variants, keeping cache counts consistent.
  * “Fast path” route handling avoids unnecessary cloning for improved performance.
* **Tests**
  * Updated and expanded coverage for capacity/eviction behavior, replacement without count changes, and concurrent stress scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->