### PR TITLE
feat(rari): add nonce-based CSP, timing-safe revalidation, and security hardening

### DIFF
--- a/crates/rari/src/rendering/layout/js/streaming_fizz.ts
+++ b/crates/rari/src/rendering/layout/js/streaming_fizz.ts
@@ -32,15 +32,31 @@ declare function rariCreateHtmlBoundaryTracker(): {
     }
   }
 
-  const RARI_STREAMING_COMPLETE_SCRIPT =
-    "<script>if(!window['~rari'])window['~rari']={};window['~rari'].streaming={complete:true}<\/script>"
+  function rariGetCurrentNonce(): string {
+    try {
+      const requestId = g['~rari']?.currentRequestId?.() ?? ''
+      if (!requestId) return ''
+      return Deno.core.ops.op_get_csp_nonce(requestId)
+    } catch {
+      return ''
+    }
+  }
+
+  function rariScriptOpen(nonce: string): string {
+    return nonce ? `<script nonce="${nonce}">` : '<script>'
+  }
+
+  function rariStreamingCompleteScript(nonce: string): string {
+    return `${rariScriptOpen(nonce)}if(!window['~rari'])window['~rari']={};window['~rari'].streaming={complete:true}<\/script>`
+  }
 
   function rariFormatFlightItem(
     item: Readonly<{ type: 'line'; line: string } | { type: 'binary'; b64: string }>,
+    nonce: string,
   ): string {
-    if (item.type === 'line') return rariFormatFlightScriptPush(`${item.line}\n`)
+    if (item.type === 'line') return rariFormatFlightScriptPush(`${item.line}\n`, nonce)
 
-    return rariFormatFlightBinaryPush(item.b64)
+    return rariFormatFlightBinaryPush(item.b64, nonce)
   }
 
   function rariStripLeadingDoctype(text: string): string {
@@ -114,14 +130,14 @@ declare function rariCreateHtmlBoundaryTracker(): {
     return session
   }
 
-  function rariFormatFlightScriptPush(payload: string | number): string {
+  function rariFormatFlightScriptPush(payload: string | number, nonce = ''): string {
     const escaped = JSON.stringify(payload).split('</').join('<\\/')
-    return `<script>(self.__rari_f=self.__rari_f||[]).push(${escaped})<\/script>`
+    return `${rariScriptOpen(nonce)}(self.__rari_f=self.__rari_f||[]).push(${escaped})<\/script>`
   }
 
-  function rariFormatFlightBinaryPush(b64: string): string {
+  function rariFormatFlightBinaryPush(b64: string, nonce = ''): string {
     const payload = JSON.stringify([2, b64]).split('</').join('<\\/')
-    return `<script>(self.__rari_f=self.__rari_f||[]).push(${payload})<\/script>`
+    return `${rariScriptOpen(nonce)}(self.__rari_f=self.__rari_f||[]).push(${payload})<\/script>`
   }
 
   function rariParseFlightRowId(line: string): number {
@@ -264,12 +280,12 @@ declare function rariCreateHtmlBoundaryTracker(): {
         }
       },
 
-      async collectAllRemainingText(): Promise<string> {
+      async collectAllRemainingText(nonce = ''): Promise<string> {
         let buf = ''
         for (;;) {
           const item = await this.drainNext()
           if (!item) break
-          buf += rariFormatFlightItem(item)
+          buf += rariFormatFlightItem(item, nonce)
         }
 
         return buf
@@ -413,6 +429,7 @@ declare function rariCreateHtmlBoundaryTracker(): {
     liveFlight: ReturnType<typeof rariCreateLiveFlightSource>,
     ensureSourceComplete?: () => Promise<void>,
     caughtErrors?: unknown[],
+    nonce = '',
   ) {
     const reader = fizzStream.getReader()
     const decoder = new TextDecoder()
@@ -426,7 +443,7 @@ declare function rariCreateHtmlBoundaryTracker(): {
     const takeFlightBootstrap = (): string => {
       if (flightBootstrapped) return ''
       flightBootstrapped = true
-      return rariFormatFlightScriptPush(0)
+      return rariFormatFlightScriptPush(0, nonce)
     }
 
     const takeErrorHtml = (): string => {
@@ -442,7 +459,7 @@ declare function rariCreateHtmlBoundaryTracker(): {
         const item = liveFlight.tryDrainNext()
         if (!item) break
         flightPumpCount++
-        out += rariFormatFlightItem(item)
+        out += rariFormatFlightItem(item, nonce)
       }
 
       return out
@@ -470,7 +487,7 @@ declare function rariCreateHtmlBoundaryTracker(): {
     const takeCompleteScript = (): string => {
       if (completeScriptSent) return ''
       completeScriptSent = true
-      return RARI_STREAMING_COMPLETE_SCRIPT
+      return rariStreamingCompleteScript(nonce)
     }
 
     const markFinalPackageSent = () => {
@@ -503,7 +520,7 @@ declare function rariCreateHtmlBoundaryTracker(): {
       // Collect flight before pumping so we don't await between "before" and
       // "tail" -- that yield lets HTTP flush a penultimate chunk alone.
       if (ensureSourceComplete) await ensureSourceComplete()
-      const flight = takeFlightBootstrap() + (await liveFlight.collectAllRemainingText())
+      const flight = takeFlightBootstrap() + (await liveFlight.collectAllRemainingText(nonce))
       if (before) session.trackHtmlBoundaries(before)
       const combined = before + flight + takeErrorHtml() + takeCompleteScript() + after
       if (!combined) return true
@@ -548,7 +565,7 @@ declare function rariCreateHtmlBoundaryTracker(): {
         rariStreamLog('mux.drainRemaining.start')
         if (!session.safeToInjectFlight()) session.resetHtmlState()
         if (ensureSourceComplete) await ensureSourceComplete()
-        const flight = takeFlightBootstrap() + (await liveFlight.collectAllRemainingText())
+        const flight = takeFlightBootstrap() + (await liveFlight.collectAllRemainingText(nonce))
         const complete = takeCompleteScript()
         const tail = takeErrorHtml() + flight + complete
         if (tail) {
@@ -599,6 +616,7 @@ declare function rariCreateHtmlBoundaryTracker(): {
     const { capturedElement, headContent, caughtErrors, streamId } = options
     if (!streamId) throw new Error('[rari] renderStreamingDocument requires streamId')
 
+    const nonce = rariGetCurrentNonce()
     const session = rariCreateFizzSession(streamId)
 
     const ReactServerRenderer = g['~reactServerRenderer']
@@ -648,19 +666,27 @@ declare function rariCreateHtmlBoundaryTracker(): {
     })) as ReadableStream & { allReady?: Promise<void> }
     rariStreamLog('fizz.stream.ready')
 
-    await rariPumpLiveMux(session, fizzStream, liveFlight, ensureSourceComplete, caughtErrors)
+    await rariPumpLiveMux(
+      session,
+      fizzStream,
+      liveFlight,
+      ensureSourceComplete,
+      caughtErrors,
+      nonce,
+    )
     rariStreamLog('render.done')
   }
 
   async function rariCollectFlightEmbedScripts(
     liveFlight: ReturnType<typeof rariCreateLiveFlightSource>,
+    nonce = '',
   ): Promise<string> {
-    let scripts = rariFormatFlightScriptPush(0)
+    let scripts = rariFormatFlightScriptPush(0, nonce)
     for (;;) {
       const item = await liveFlight.drainNext()
       if (!item) break
-      if (item.type === 'line') scripts += rariFormatFlightScriptPush(`${item.line}\n`)
-      else scripts += rariFormatFlightBinaryPush(item.b64)
+      if (item.type === 'line') scripts += rariFormatFlightScriptPush(`${item.line}\n`, nonce)
+      else scripts += rariFormatFlightBinaryPush(item.b64, nonce)
     }
 
     return scripts
@@ -676,6 +702,7 @@ declare function rariCreateHtmlBoundaryTracker(): {
   async function renderStaticDocument(options: RenderStaticDocumentOptions): Promise<string> {
     const { capturedElement, headContent, caughtErrors } = options
 
+    const nonce = rariGetCurrentNonce()
     const ReactServerRenderer = g['~reactServerRenderer']
     const ReactDOMServer = g['~reactServer']
     const R = g.React
@@ -724,8 +751,8 @@ declare function rariCreateHtmlBoundaryTracker(): {
     html = rariStripLeadingDoctype(html)
     if (!html.trimStart().toLowerCase().startsWith('<!doctype')) html = `<!DOCTYPE html>\n${html}`
 
-    const flightScripts = await rariCollectFlightEmbedScripts(liveFlight)
-    const completionScript = RARI_STREAMING_COMPLETE_SCRIPT
+    const flightScripts = await rariCollectFlightEmbedScripts(liveFlight, nonce)
+    const completionScript = rariStreamingCompleteScript(nonce)
 
     return rariInjectBeforeBodyClose(html, `${flightScripts}\n${completionScript}`)
   }

--- a/crates/rari/src/rendering/types.d.ts
+++ b/crates/rari/src/rendering/types.d.ts
@@ -78,6 +78,7 @@ declare global {
         function op_fizz_done(streamId: string): void
         function op_stream_promise_settled(streamId: string, ok: boolean, error: string): void
         function op_internal_log(message: string): void
+        function op_get_csp_nonce(requestId: string): string
       }
     }
   }

--- a/crates/rari/src/runtime/ext/rari/core/types.d.ts
+++ b/crates/rari/src/runtime/ext/rari/core/types.d.ts
@@ -254,6 +254,7 @@ declare global {
       namespace ops {
         function op_get_cookies(requestId?: string): string
         function op_get_request_headers(requestId?: string): string
+        function op_get_csp_nonce(requestId: string): string
         function op_set_cookie(
           options: Readonly<{
             name: string

--- a/crates/rari/src/runtime/ops.rs
+++ b/crates/rari/src/runtime/ops.rs
@@ -398,6 +398,7 @@ pub fn get_streaming_ops() -> Vec<OpDecl> {
         op_sanitize_html(),
         op_get_cookies(),
         op_get_request_headers(),
+        op_get_csp_nonce(),
         op_set_cookie(),
         op_delete_cookie(),
     ]
@@ -697,6 +698,18 @@ pub fn op_get_request_headers(state: Rc<RefCell<OpState>>, #[string] request_id:
     };
 
     serde_json::to_string(&ctx.request_headers).unwrap_or_else(|_| "{}".to_string())
+}
+
+#[allow(clippy::allow_attributes, clippy::needless_pass_by_value)]
+#[op2]
+#[string]
+pub fn op_get_csp_nonce(state: Rc<RefCell<OpState>>, #[string] request_id: String) -> String {
+    let op_state_ref = state.borrow();
+    let Some(ctx) = resolve_request_context(&op_state_ref, Some(request_id.as_str())) else {
+        return String::new();
+    };
+
+    ctx.csp_nonce.as_deref().unwrap_or("").to_string()
 }
 
 #[derive(serde::Deserialize)]

--- a/crates/rari/src/server/cache/revalidate.rs
+++ b/crates/rari/src/server/cache/revalidate.rs
@@ -13,6 +13,19 @@ use crate::{
     server::{ServerState, cache::response},
 };
 
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    let a = a.as_bytes();
+    let b = b.as_bytes();
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
 #[non_exhaustive]
@@ -154,7 +167,7 @@ pub async fn revalidate_by_path(
     match &request {
         RevalidateRequest::Path { path, secret } => {
             match secret {
-                Some(provided_secret) if provided_secret == &expected_secret => {}
+                Some(provided_secret) if constant_time_eq(provided_secret, &expected_secret) => {}
                 _ => {
                     return Ok(Json(RevalidateResponse {
                         revalidated: false,
@@ -183,7 +196,7 @@ pub async fn revalidate_by_path(
         }
         RevalidateRequest::Tag { tag, secret } => {
             match secret {
-                Some(provided_secret) if provided_secret == &expected_secret => {}
+                Some(provided_secret) if constant_time_eq(provided_secret, &expected_secret) => {}
                 _ => {
                     return Ok(Json(RevalidateResponse {
                         revalidated: false,

--- a/crates/rari/src/server/cache/revalidate.rs
+++ b/crates/rari/src/server/cache/revalidate.rs
@@ -16,12 +16,12 @@ use crate::{
 fn constant_time_eq(a: &str, b: &str) -> bool {
     let a = a.as_bytes();
     let b = b.as_bytes();
-    if a.len() != b.len() {
-        return false;
+    let mut diff = a.len() ^ b.len();
+    for i in 0..a.len() {
+        diff |= usize::from(a[i] ^ b[i % b.len().max(1)]);
     }
-    let mut diff = 0u8;
-    for (x, y) in a.iter().zip(b.iter()) {
-        diff |= x ^ y;
+    for i in 0..b.len() {
+        diff |= usize::from(a[i % a.len().max(1)] ^ b[i]);
     }
     diff == 0
 }

--- a/crates/rari/src/server/cache/revalidate.rs
+++ b/crates/rari/src/server/cache/revalidate.rs
@@ -17,11 +17,15 @@ fn constant_time_eq(a: &str, b: &str) -> bool {
     let a = a.as_bytes();
     let b = b.as_bytes();
     let mut diff = a.len() ^ b.len();
-    for i in 0..a.len() {
-        diff |= usize::from(a[i] ^ b[i % b.len().max(1)]);
+    if !b.is_empty() {
+        for i in 0..a.len() {
+            diff |= usize::from(a[i] ^ b[i % b.len()]);
+        }
     }
-    for i in 0..b.len() {
-        diff |= usize::from(a[i % a.len().max(1)] ^ b[i]);
+    if !a.is_empty() {
+        for i in 0..b.len() {
+            diff |= usize::from(a[i % a.len()] ^ b[i]);
+        }
     }
     diff == 0
 }

--- a/crates/rari/src/server/config.rs
+++ b/crates/rari/src/server/config.rs
@@ -13,6 +13,7 @@ use cow_utils::CowUtils;
 use http::HeaderValue;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::server::{
     cache::handler::MemoryConfig, image::ImageConfig,
@@ -192,6 +193,26 @@ pub struct CspConfig {
     pub connect_src: Vec<String>,
     pub default_src: Vec<String>,
     pub worker_src: Vec<String>,
+    #[serde(default = "csp_default_frame_ancestors")]
+    pub frame_ancestors: Vec<String>,
+    #[serde(default = "csp_default_base_uri")]
+    pub base_uri: Vec<String>,
+    #[serde(default = "csp_default_form_action")]
+    pub form_action: Vec<String>,
+    #[serde(default)]
+    pub use_nonces: bool,
+}
+
+fn csp_default_frame_ancestors() -> Vec<String> {
+    vec!["'self'".to_string()]
+}
+
+fn csp_default_base_uri() -> Vec<String> {
+    vec!["'self'".to_string()]
+}
+
+fn csp_default_form_action() -> Vec<String> {
+    vec!["'self'".to_string()]
 }
 
 impl Default for CspConfig {
@@ -204,6 +225,10 @@ impl Default for CspConfig {
             font_src: vec!["'self'".to_string(), "data:".to_string()],
             connect_src: vec!["'self'".to_string(), "ws:".to_string(), "wss:".to_string()],
             worker_src: vec!["'self'".to_string()],
+            frame_ancestors: csp_default_frame_ancestors(),
+            base_uri: csp_default_base_uri(),
+            form_action: csp_default_form_action(),
+            use_nonces: false,
         }
     }
 }
@@ -623,6 +648,30 @@ impl Config {
                             .filter_map(|v| v.as_str().map(ToString::to_string))
                             .collect();
                     }
+                    if let Some(frame_ancestors) =
+                        csp_data.get("frameAncestors").and_then(|v| v.as_array())
+                    {
+                        config.csp.frame_ancestors = frame_ancestors
+                            .iter()
+                            .filter_map(|v| v.as_str().map(ToString::to_string))
+                            .collect();
+                    }
+                    if let Some(base_uri) = csp_data.get("baseUri").and_then(|v| v.as_array()) {
+                        config.csp.base_uri = base_uri
+                            .iter()
+                            .filter_map(|v| v.as_str().map(ToString::to_string))
+                            .collect();
+                    }
+                    if let Some(form_action) = csp_data.get("formAction").and_then(|v| v.as_array())
+                    {
+                        config.csp.form_action = form_action
+                            .iter()
+                            .filter_map(|v| v.as_str().map(ToString::to_string))
+                            .collect();
+                    }
+                    if let Some(use_nonces) = csp_data.get("useNonces").and_then(Value::as_bool) {
+                        config.csp.use_nonces = use_nonces;
+                    }
                 }
 
                 if let Some(action_data) = config_data.get("action")
@@ -940,7 +989,13 @@ impl Config {
     pub fn csp_config(&self) -> CspConfig {
         let mut config = self.csp.clone();
 
-        if !config.script_src.contains(&"'unsafe-inline'".to_string()) {
+        if config.use_nonces {
+            config.script_src.retain(|s| s != "'unsafe-inline'");
+            config.script_src.push("'nonce-{{NONCE}}'".to_string());
+            if !config.script_src.contains(&"'strict-dynamic'".to_string()) {
+                config.script_src.push("'strict-dynamic'".to_string());
+            }
+        } else if !config.script_src.contains(&"'unsafe-inline'".to_string()) {
             config.script_src.push("'unsafe-inline'".to_string());
         }
 
@@ -985,6 +1040,18 @@ impl Config {
 
         if !config.worker_src.is_empty() {
             directives.push(format!("worker-src {}", config.worker_src.join(" ")));
+        }
+
+        if !config.frame_ancestors.is_empty() {
+            directives.push(format!("frame-ancestors {}", config.frame_ancestors.join(" ")));
+        }
+
+        if !config.base_uri.is_empty() {
+            directives.push(format!("base-uri {}", config.base_uri.join(" ")));
+        }
+
+        if !config.form_action.is_empty() {
+            directives.push(format!("form-action {}", config.form_action.join(" ")));
         }
 
         directives.join("; ")

--- a/crates/rari/src/server/core/mod.rs
+++ b/crates/rari/src/server/core/mod.rs
@@ -443,6 +443,16 @@ impl Server {
                     println!("  {} {}", "Origin:".bold(), origin.cyan());
                 }
             }
+        } else {
+            let host = &self.config.server.host;
+            if host == "0.0.0.0" || host == "::" {
+                tracing::warn!(
+                    host = %host,
+                    "Dev server is bound to all interfaces — /_rari/register and /_rari/hmr \
+                     endpoints accept unauthenticated code. Bind to 127.0.0.1 unless you \
+                     intentionally need LAN access."
+                );
+            }
         }
     }
 

--- a/crates/rari/src/server/core/utils/http.rs
+++ b/crates/rari/src/server/core/utils/http.rs
@@ -36,7 +36,8 @@ pub fn extract_headers(headers: &HeaderMap) -> FxHashMap<String, String> {
 pub fn filter_headers_for_components(
     headers: FxHashMap<String, String>,
 ) -> FxHashMap<String, String> {
-    const SENSITIVE_HEADERS: &[&str] = &["authorization", "cookie", "proxy-authorization"];
+    const SENSITIVE_HEADERS: &[&str] =
+        &["authorization", "cookie", "proxy-authorization", "x-rari-csp-nonce"];
 
     headers.into_iter().filter(|(name, _)| !SENSITIVE_HEADERS.contains(&name.as_str())).collect()
 }

--- a/crates/rari/src/server/middleware/request.rs
+++ b/crates/rari/src/server/middleware/request.rs
@@ -82,6 +82,8 @@ fn generate_nonce() -> String {
 }
 
 pub async fn security_headers_middleware(mut request: Request<Body>, next: Next) -> Response<Body> {
+    request.headers_mut().remove(X_RARI_CSP_NONCE);
+
     let use_nonces = Config::get().is_some_and(|c| c.csp.use_nonces);
     let nonce = if use_nonces {
         let n = generate_nonce();

--- a/crates/rari/src/server/middleware/request.rs
+++ b/crates/rari/src/server/middleware/request.rs
@@ -3,8 +3,13 @@ use axum::{
     http::{HeaderMap, HeaderValue, Request, Response, StatusCode, header::CACHE_CONTROL},
     middleware::Next,
 };
+use cow_utils::CowUtils;
 
 use crate::server::config::Config;
+
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct CspNonce(pub String);
 
 const ACCESS_CONTROL_ALLOW_ORIGIN: &str = "Access-Control-Allow-Origin";
 const ACCESS_CONTROL_ALLOW_METHODS: &str = "Access-Control-Allow-Methods";
@@ -70,23 +75,45 @@ fn add_cors_headers(headers: &mut HeaderMap) {
     }
 }
 
-pub async fn security_headers_middleware(request: Request<Body>, next: Next) -> Response<Body> {
+pub const X_RARI_CSP_NONCE: &str = "x-rari-csp-nonce";
+
+fn generate_nonce() -> String {
+    uuid::Uuid::new_v4().simple().to_string()
+}
+
+pub async fn security_headers_middleware(mut request: Request<Body>, next: Next) -> Response<Body> {
+    let use_nonces = Config::get().is_some_and(|c| c.csp.use_nonces);
+    let nonce = if use_nonces {
+        let n = generate_nonce();
+        if let Ok(v) = HeaderValue::from_str(&n) {
+            request.headers_mut().insert(X_RARI_CSP_NONCE, v);
+        }
+        Some(n)
+    } else {
+        None
+    };
+
     let mut response = next.run(request).await;
 
     let status = response.status();
     let headers = response.headers_mut();
 
-    add_security_headers(headers);
+    add_security_headers(headers, nonce.as_deref());
     apply_error_cache_control(headers, status);
 
     response
 }
 
-fn add_security_headers(headers: &mut HeaderMap) {
+fn add_security_headers(headers: &mut HeaderMap, nonce: Option<&str>) {
     let csp_policy = if let Some(config) = Config::get() {
         config.build_csp_policy()
     } else {
-        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:".to_string()
+        "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:; frame-ancestors 'self'; base-uri 'self'; form-action 'self'".to_string()
+    };
+
+    let csp_policy = match nonce {
+        Some(n) => csp_policy.cow_replace("{{NONCE}}", n).into_owned(),
+        None => csp_policy,
     };
 
     let security_headers = [

--- a/crates/rari/src/server/middleware/request_context.rs
+++ b/crates/rari/src/server/middleware/request_context.rs
@@ -17,7 +17,10 @@ use serde_json::Value;
 use tokio::sync::Mutex as TokioMutex;
 use uuid::Uuid;
 
-use crate::server::core::utils::{client::get_http_client, http};
+use crate::server::{
+    core::utils::{client::get_http_client, http},
+    middleware::request::X_RARI_CSP_NONCE,
+};
 
 #[derive(Clone, Debug)]
 #[non_exhaustive]
@@ -129,6 +132,7 @@ pub struct RequestContext {
     pub pending_cookies: Arc<DashMap<PendingCookieKey, PendingCookie>>,
     pub function_cache: Arc<DashMap<String, Value>>,
     pub action_form_state: Option<Value>,
+    pub csp_nonce: Option<String>,
 }
 
 impl RequestContext {
@@ -145,6 +149,7 @@ impl RequestContext {
             pending_cookies: Arc::new(DashMap::new()),
             function_cache: Arc::new(DashMap::new()),
             action_form_state: None,
+            csp_nonce: None,
         }
     }
 
@@ -155,8 +160,9 @@ impl RequestContext {
     }
 
     #[must_use]
-    pub fn with_http_headers(mut self, headers: FxHashMap<String, String>) -> Self {
+    pub fn with_http_headers(mut self, mut headers: FxHashMap<String, String>) -> Self {
         self.cookie_header = headers.get("cookie").cloned();
+        self.csp_nonce = headers.remove(X_RARI_CSP_NONCE);
         self.request_headers = http::filter_headers_for_components(headers);
         self
     }
@@ -170,6 +176,12 @@ impl RequestContext {
     #[must_use]
     pub fn with_action_form_state(mut self, form_state: Option<Value>) -> Self {
         self.action_form_state = form_state;
+        self
+    }
+
+    #[must_use]
+    pub fn with_csp_nonce(mut self, nonce: Option<String>) -> Self {
+        self.csp_nonce = nonce;
         self
     }
 

--- a/packages/rari/src/vite/index.ts
+++ b/packages/rari/src/vite/index.ts
@@ -198,6 +198,10 @@ export interface RariOptions {
     readonly connectSrc?: readonly string[]
     readonly defaultSrc?: readonly string[]
     readonly workerSrc?: readonly string[]
+    readonly frameAncestors?: readonly string[]
+    readonly baseUri?: readonly string[]
+    readonly formAction?: readonly string[]
+    readonly useNonces?: boolean
   }
   readonly cacheControl?: {
     readonly routes: Readonly<Record<string, string>>

--- a/packages/rari/src/vite/server/config.ts
+++ b/packages/rari/src/vite/server/config.ts
@@ -6,6 +6,10 @@ export interface ServerCSPConfig {
   readonly connectSrc?: readonly string[]
   readonly defaultSrc?: readonly string[]
   readonly workerSrc?: readonly string[]
+  readonly frameAncestors?: readonly string[]
+  readonly baseUri?: readonly string[]
+  readonly formAction?: readonly string[]
+  readonly useNonces?: boolean
 }
 
 export interface ServerCacheControlConfig {


### PR DESCRIPTION
Introduce opt-in per-request nonce generation for Content-Security-Policy with `strict-dynamic` trust propagation, replacing `unsafe-inline` when enabled. Harden the revalidation secret check against timing attacks with constant-time comparison. Add `frame-ancestors`, `base-uri`, and `form-action` CSP directives. Warn when dev server binds to all interfaces.

Wire nonce from Rust middleware → RequestContext → Deno op → streaming Fizz layer so all emitted <script> tags carry the nonce attribute. Sync new CSP config fields to the TS plugin options and JSON parser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable CSP directives: `frame-ancestors`, `base-uri`, and `form-action`.
  - Added optional CSP nonce support, including nonce-bearing streamed flight scripts and completion scripts.
  - Exposed new CSP nonce/directive options in the public Vite configuration.

- **Security**
  - Improved revalidation secret checking with constant-time comparison.
  - Redacts the CSP nonce header when forwarding component-related headers.
  - Added a development-mode warning when unauthenticated endpoints are publicly reachable.

- **Bug Fixes**
  - Ensured CSP nonces are applied consistently across both static and streaming page content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->