### PR TITLE
fix: evaluate generateStaticParams under react-server condition

### DIFF
--- a/packages/rari/src/router/build/evaluate-static-params.ts
+++ b/packages/rari/src/router/build/evaluate-static-params.ts
@@ -1,0 +1,66 @@
+import { spawn } from 'node:child_process'
+import process from 'node:process'
+import { pathToFileURL } from 'node:url'
+
+const RESOLVE_HOOK = `
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === "react-server-dom-rari/server") {
+    return nextResolve("rari/runtime/rsc-references", context);
+  }
+  return nextResolve(specifier, context);
+}
+`
+
+export async function evaluateGenerateStaticParams(compiledPath: string): Promise<unknown> {
+  const href = pathToFileURL(compiledPath).href
+  const resolveHookUrl = `data:text/javascript,${encodeURIComponent(RESOLVE_HOOK)}`
+  const script = `
+import { register } from "node:module";
+register(${JSON.stringify(resolveHookUrl)});
+const mod = await import(${JSON.stringify(href)});
+if (typeof mod.generateStaticParams !== "function") {
+  process.stdout.write("null");
+  process.exit(0);
+}
+const params = await mod.generateStaticParams();
+process.stdout.write(JSON.stringify(params ?? null));
+`
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ['--conditions=react-server', '--input-type=module', '--eval', script],
+      {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: process.env,
+      },
+    )
+
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk
+    })
+    child.on('error', reject)
+    child.on('close', code => {
+      if (code !== 0) {
+        reject(new Error(stderr.trim() || `generateStaticParams worker exited with code ${code}`))
+        return
+      }
+      try {
+        resolve(stdout === '' ? null : JSON.parse(stdout))
+      } catch (error) {
+        reject(
+          new Error(
+            `Failed to parse generateStaticParams result: ${error instanceof Error ? error.message : String(error)}`,
+          ),
+        )
+      }
+    })
+  })
+}

--- a/packages/rari/src/router/build/evaluate-static-params.ts
+++ b/packages/rari/src/router/build/evaluate-static-params.ts
@@ -2,28 +2,27 @@ import { spawn } from 'node:child_process'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
 
-const RESOLVE_HOOK = `
-export async function resolve(specifier, context, nextResolve) {
-  if (specifier === "react-server-dom-rari/server") {
-    return nextResolve("rari/runtime/rsc-references", context);
-  }
-  return nextResolve(specifier, context);
-}
-`
+const GENERATE_STATIC_PARAMS_TIMEOUT_MS = 60_000
 
 export async function evaluateGenerateStaticParams(compiledPath: string): Promise<unknown> {
   const href = pathToFileURL(compiledPath).href
-  const resolveHookUrl = `data:text/javascript,${encodeURIComponent(RESOLVE_HOOK)}`
   const script = `
-import { register } from "node:module";
-register(${JSON.stringify(resolveHookUrl)});
+import { registerHooks } from "node:module";
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier === "react-server-dom-rari/server") {
+      return nextResolve("rari/runtime/rsc-references", context);
+    }
+    return nextResolve(specifier, context);
+  },
+});
 const mod = await import(${JSON.stringify(href)});
 if (typeof mod.generateStaticParams !== "function") {
   process.stdout.write("null");
-  process.exit(0);
+} else {
+  const params = await mod.generateStaticParams();
+  process.stdout.write(JSON.stringify(params ?? null));
 }
-const params = await mod.generateStaticParams();
-process.stdout.write(JSON.stringify(params ?? null));
 `
 
   return new Promise((resolve, reject) => {
@@ -38,6 +37,23 @@ process.stdout.write(JSON.stringify(params ?? null));
 
     let stdout = ''
     let stderr = ''
+    let settled = false
+
+    const timeoutId = setTimeout(() => {
+      if (settled) return
+      settled = true
+      child.kill('SIGTERM')
+      reject(
+        new Error(
+          `generateStaticParams timed out after ${GENERATE_STATIC_PARAMS_TIMEOUT_MS}ms for ${compiledPath}`,
+        ),
+      )
+    }, GENERATE_STATIC_PARAMS_TIMEOUT_MS)
+
+    const clear = () => {
+      clearTimeout(timeoutId)
+    }
+
     child.stdout.setEncoding('utf8')
     child.stderr.setEncoding('utf8')
     child.stdout.on('data', (chunk: string) => {
@@ -46,8 +62,16 @@ process.stdout.write(JSON.stringify(params ?? null));
     child.stderr.on('data', (chunk: string) => {
       stderr += chunk
     })
-    child.on('error', reject)
+    child.on('error', error => {
+      if (settled) return
+      settled = true
+      clear()
+      reject(error)
+    })
     child.on('close', code => {
+      if (settled) return
+      settled = true
+      clear()
       if (code !== 0) {
         reject(new Error(stderr.trim() || `generateStaticParams worker exited with code ${code}`))
         return

--- a/packages/rari/src/router/build/evaluate-static-params.ts
+++ b/packages/rari/src/router/build/evaluate-static-params.ts
@@ -3,6 +3,7 @@ import process from 'node:process'
 import { pathToFileURL } from 'node:url'
 
 const GENERATE_STATIC_PARAMS_TIMEOUT_MS = 60_000
+const FORCE_KILL_GRACE_MS = 1_000
 
 export async function evaluateGenerateStaticParams(compiledPath: string): Promise<unknown> {
   const href = pathToFileURL(compiledPath).href
@@ -17,12 +18,12 @@ registerHooks({
   },
 });
 const mod = await import(${JSON.stringify(href)});
-if (typeof mod.generateStaticParams !== "function") {
-  process.stdout.write("null");
-} else {
-  const params = await mod.generateStaticParams();
-  process.stdout.write(JSON.stringify(params ?? null));
-}
+const result =
+  typeof mod.generateStaticParams !== "function"
+    ? null
+    : ((await mod.generateStaticParams()) ?? null);
+process.send(result);
+process.disconnect();
 `
 
   return new Promise((resolve, reject) => {
@@ -30,7 +31,7 @@ if (typeof mod.generateStaticParams !== "function") {
       process.execPath,
       ['--conditions=react-server', '--input-type=module', '--eval', script],
       {
-        stdio: ['ignore', 'pipe', 'pipe'],
+        stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
         env: process.env,
       },
     )
@@ -38,11 +39,27 @@ if (typeof mod.generateStaticParams !== "function") {
     let stdout = ''
     let stderr = ''
     let settled = false
+    let ipcReceived = false
+    let ipcValue: unknown
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+    let forceKillId: ReturnType<typeof setTimeout> | undefined
 
-    const timeoutId = setTimeout(() => {
+    const clearTimers = () => {
+      if (timeoutId !== undefined) clearTimeout(timeoutId)
+      if (forceKillId !== undefined) clearTimeout(forceKillId)
+      timeoutId = undefined
+      forceKillId = undefined
+    }
+
+    timeoutId = setTimeout(() => {
       if (settled) return
       settled = true
+      if (timeoutId !== undefined) clearTimeout(timeoutId)
+      timeoutId = undefined
       child.kill('SIGTERM')
+      forceKillId = setTimeout(() => {
+        child.kill('SIGKILL')
+      }, FORCE_KILL_GRACE_MS)
       reject(
         new Error(
           `generateStaticParams timed out after ${GENERATE_STATIC_PARAMS_TIMEOUT_MS}ms for ${compiledPath}`,
@@ -50,41 +67,45 @@ if (typeof mod.generateStaticParams !== "function") {
       )
     }, GENERATE_STATIC_PARAMS_TIMEOUT_MS)
 
-    const clear = () => {
-      clearTimeout(timeoutId)
-    }
-
-    child.stdout.setEncoding('utf8')
-    child.stderr.setEncoding('utf8')
-    child.stdout.on('data', (chunk: string) => {
+    child.stdout?.setEncoding('utf8')
+    child.stderr?.setEncoding('utf8')
+    child.stdout?.on('data', (chunk: string) => {
       stdout += chunk
     })
-    child.stderr.on('data', (chunk: string) => {
+    child.stderr?.on('data', (chunk: string) => {
       stderr += chunk
+    })
+    child.on('message', (value: unknown) => {
+      ipcReceived = true
+      ipcValue = value
     })
     child.on('error', error => {
       if (settled) return
       settled = true
-      clear()
+      clearTimers()
       reject(error)
     })
     child.on('close', code => {
+      clearTimers()
       if (settled) return
       settled = true
-      clear()
+
+      const diagnostics = [stderr.trim(), stdout.trim()].filter(Boolean).join('\n')
+
       if (code !== 0) {
-        reject(new Error(stderr.trim() || `generateStaticParams worker exited with code ${code}`))
+        reject(new Error(diagnostics || `generateStaticParams worker exited with code ${code}`))
         return
       }
-      try {
-        resolve(stdout === '' ? null : JSON.parse(stdout))
-      } catch (error) {
+      if (!ipcReceived) {
         reject(
           new Error(
-            `Failed to parse generateStaticParams result: ${error instanceof Error ? error.message : String(error)}`,
+            diagnostics ||
+              `generateStaticParams worker exited without an IPC result for ${compiledPath}`,
           ),
         )
+        return
       }
+      resolve(ipcValue)
     })
   })
 }

--- a/packages/rari/src/router/build/evaluate-static-params.ts
+++ b/packages/rari/src/router/build/evaluate-static-params.ts
@@ -22,8 +22,9 @@ const result =
   typeof mod.generateStaticParams !== "function"
     ? null
     : ((await mod.generateStaticParams()) ?? null);
-process.send(result);
-process.disconnect();
+process.send(result, () => {
+  process.disconnect();
+});
 `
 
   return new Promise((resolve, reject) => {

--- a/packages/rari/src/router/build/props-extractor.ts
+++ b/packages/rari/src/router/build/props-extractor.ts
@@ -1,4 +1,5 @@
 import { isRecord, isStaticParamsArray, warnInvalidStaticParams } from '@/shared/utils/type-guards'
+import { evaluateGenerateStaticParams } from './evaluate-static-params'
 
 export interface ServerSidePropsResult {
   props: Record<string, any>
@@ -320,14 +321,10 @@ export function mergeMetadata(
 /* v8 ignore start - requires dynamic imports, better tested in integration/e2e */
 export async function extractStaticParams(componentPath: string): Promise<StaticParamsResult> {
   try {
-    const module = await loadComponentModule(componentPath)
-
-    if (typeof module.generateStaticParams === 'function') {
-      const params = await module.generateStaticParams()
-      if (isStaticParamsArray(params)) return params
-      warnInvalidStaticParams(componentPath)
-    }
-
+    const params = await evaluateGenerateStaticParams(componentPath)
+    if (params == null) return []
+    if (isStaticParamsArray(params)) return params
+    warnInvalidStaticParams(componentPath)
     return []
   } catch (error) {
     console.error(`[rari] Router: Failed to extract static params from ${componentPath}:`, error)

--- a/packages/rari/src/router/build/vite-plugin.ts
+++ b/packages/rari/src/router/build/vite-plugin.ts
@@ -12,6 +12,7 @@ import {
   warnInvalidStaticParams,
 } from '@/shared/utils/type-guards'
 import { toRariPlugin } from '@/vite/plugin/types'
+import { evaluateGenerateStaticParams } from './evaluate-static-params'
 import { generateAppRouteManifest } from './routes'
 
 const METADATA_EXPORT_REGEX = /export\s+const\s+metadata\s*(?::\s*\w+\s*)?=\s*(\{[\s\S]*?\n\})/
@@ -489,19 +490,15 @@ export function rariRouter(options: RariRouterPluginOptions = {}): RariPlugin {
           const compiledPath = path.join(serverDir, `${componentId}.js`)
 
           try {
-            const module: unknown = await import(/* @vite-ignore */ compiledPath)
-            if (isRecord(module) && typeof module.generateStaticParams === 'function') {
-              // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- dynamically imported route module
-              const generateStaticParams = module.generateStaticParams as () => unknown
-              const params = await generateStaticParams()
-              if (isStaticParamsArray(params)) {
-                if (params.length > 0) {
-                  route.staticParams = params
-                  updated = true
-                }
-              } else {
-                warnInvalidStaticParams(componentId)
+            const params = await evaluateGenerateStaticParams(compiledPath)
+            if (params == null) continue
+            if (isStaticParamsArray(params)) {
+              if (params.length > 0) {
+                route.staticParams = params
+                updated = true
               }
+            } else {
+              warnInvalidStaticParams(componentId)
             }
           } catch (error) {
             console.warn(

--- a/packages/rari/src/router/build/vite-plugin.ts
+++ b/packages/rari/src/router/build/vite-plugin.ts
@@ -479,36 +479,57 @@ export function rariRouter(options: RariRouterPluginOptions = {}): RariPlugin {
         if (!manifestRecord || !isAppRouteManifest(manifestRecord)) return
 
         const manifest = manifestRecord
-        let updated = false
 
-        for (const route of manifest.routes) {
-          if (!route.isDynamic) continue
-
+        const dynamicRoutes = manifest.routes.flatMap(route => {
+          if (!route.isDynamic) return []
           const componentId = route.componentId
-          if (componentId == null || componentId === '') continue
+          if (componentId == null || componentId === '') return []
+          return [{ route, componentId }]
+        })
 
-          const compiledPath = path.join(serverDir, `${componentId}.js`)
+        const concurrency = Math.min(8, Math.max(1, dynamicRoutes.length))
+        const results = dynamicRoutes.map(() => false)
+        let index = 0
+        let active = 0
 
-          try {
-            const params = await evaluateGenerateStaticParams(compiledPath)
-            if (params == null) continue
-            if (isStaticParamsArray(params)) {
-              if (params.length > 0) {
-                route.staticParams = params
-                updated = true
-              }
-            } else {
-              warnInvalidStaticParams(componentId)
+        await new Promise<void>(resolveAll => {
+          const next = () => {
+            while (active < concurrency && index < dynamicRoutes.length) {
+              const taskIndex = index++
+              const { route, componentId } = dynamicRoutes[taskIndex]
+              const compiledPath = path.join(serverDir, `${componentId}.js`)
+
+              active++
+              void (async () => {
+                try {
+                  const params = await evaluateGenerateStaticParams(compiledPath)
+                  if (params == null) return
+                  if (isStaticParamsArray(params)) {
+                    route.staticParams = params
+                    results[taskIndex] = true
+                  } else {
+                    warnInvalidStaticParams(componentId)
+                  }
+                } catch (error) {
+                  console.warn(
+                    `[rari] Failed to evaluate generateStaticParams for ${componentId}:`,
+                    error,
+                  )
+                } finally {
+                  active--
+                  if (index >= dynamicRoutes.length && active === 0) resolveAll()
+                  else next()
+                }
+              })()
             }
-          } catch (error) {
-            console.warn(
-              `[rari] Failed to evaluate generateStaticParams for ${componentId}:`,
-              error,
-            )
-          }
-        }
 
-        if (updated) await fs.writeFile(routesPath, JSON.stringify(manifest), 'utf-8')
+            if (dynamicRoutes.length === 0) resolveAll()
+          }
+
+          next()
+        })
+
+        if (results.some(Boolean)) await fs.writeFile(routesPath, JSON.stringify(manifest), 'utf-8')
       } catch (error) {
         console.warn('[rari] Failed to enrich routes manifest with static params:', error)
       }


### PR DESCRIPTION
Avoid loading react-server-dom-webpack/server in the Vite process, which triggered CJS named-export errors and broke client builds when --conditions=react-server was set globally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dynamic route static-parameter generation by evaluating `generateStaticParams` in a more isolated and reliable way.
  - Added bounded-concurrency evaluation for faster, safer manifest enrichment.
  - Validates returned values and falls back to empty results when `generateStaticParams` is missing or invalid, with warnings instead of build failures.
  - Enhanced resilience and diagnostics when evaluation fails, including clearer timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->