### PR TITLE
perf(vite): scope HMR re-registration to affected components

### DIFF
--- a/packages/rari/src/router/build/vite-plugin.ts
+++ b/packages/rari/src/router/build/vite-plugin.ts
@@ -5,6 +5,7 @@ import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { BACKSLASH_REGEX, QUOTE_REGEX, TSX_EXT_REGEX } from '@/shared/regex-constants'
+import { getRariServerUrl } from '@/shared/utils/server-port'
 import {
   isRecord,
   isStaticParamsArray,
@@ -183,7 +184,7 @@ function isAppRouteManifest(value: unknown): value is AppRouteManifest {
 
 async function notifyApiRouteInvalidation(filePath: string): Promise<void> {
   try {
-    const response = await fetch('http://localhost:3000/_rari/hmr', {
+    const response = await fetch(`${getRariServerUrl()}/_rari/hmr`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/rari/src/shared/utils/server-port.ts
+++ b/packages/rari/src/shared/utils/server-port.ts
@@ -2,12 +2,20 @@ import process from 'node:process'
 
 const DEFAULT_SERVER_PORT = 3000
 
+function parsePort(value: string | undefined): number | null {
+  if (value == null || value === '') return null
+  const port = Number(value)
+  return Number.isFinite(port) ? port : null
+}
+
+/**
+ * Resolves the Rust server port from the environment.
+ * Precedence: SERVER_PORT > PORT > RSC_PORT > 3000.
+ * Non-numeric values are skipped in favor of the next candidate.
+ */
 export function getRariServerPort(): number {
   const { SERVER_PORT, PORT, RSC_PORT } = process.env
-  if (SERVER_PORT != null && SERVER_PORT !== '') return Number(SERVER_PORT)
-  if (PORT != null && PORT !== '') return Number(PORT)
-  if (RSC_PORT != null && RSC_PORT !== '') return Number(RSC_PORT)
-  return DEFAULT_SERVER_PORT
+  return parsePort(SERVER_PORT) ?? parsePort(PORT) ?? parsePort(RSC_PORT) ?? DEFAULT_SERVER_PORT
 }
 
 export function getRariServerUrl(): string {

--- a/packages/rari/src/shared/utils/server-port.ts
+++ b/packages/rari/src/shared/utils/server-port.ts
@@ -1,0 +1,15 @@
+import process from 'node:process'
+
+const DEFAULT_SERVER_PORT = 3000
+
+export function getRariServerPort(): number {
+  const { SERVER_PORT, PORT, RSC_PORT } = process.env
+  if (SERVER_PORT != null && SERVER_PORT !== '') return Number(SERVER_PORT)
+  if (PORT != null && PORT !== '') return Number(PORT)
+  if (RSC_PORT != null && RSC_PORT !== '') return Number(RSC_PORT)
+  return DEFAULT_SERVER_PORT
+}
+
+export function getRariServerUrl(): string {
+  return `http://localhost:${getRariServerPort()}`
+}

--- a/packages/rari/src/vite/hmr/coordinator.ts
+++ b/packages/rari/src/vite/hmr/coordinator.ts
@@ -6,6 +6,7 @@ import { throwIfNotOk } from '@/shared/utils/http'
 import { getRariServerPort } from '@/shared/utils/server-port'
 import { isRecord } from '@/shared/utils/type-guards'
 import { HMRErrorHandler } from './error-handler'
+import { walkImporters } from './import-graph'
 
 export interface ComponentRebuildResult {
   componentId: string
@@ -288,27 +289,11 @@ export class HMRCoordinator {
   }
 
   private collectDependentPageComponents(changedFiles: readonly string[]): string[] {
-    const importGraph = this.serverComponentBuilder.getImportGraph()
-    const dependentPages = new Set<string>()
-    const visited = new Set<string>()
-
-    const findPageImporters = (filePath: string) => {
-      if (visited.has(filePath)) return
-      visited.add(filePath)
-
-      const importers = importGraph.get(filePath)
-      if (!importers) return
-
-      for (const importer of importers) {
-        const isAppFile = importer.includes('/app/') || importer.includes('\\app\\')
-        if (isAppFile && !changedFiles.includes(importer)) {
-          dependentPages.add(importer)
-        }
-        findPageImporters(importer)
-      }
-    }
-
-    for (const file of changedFiles) findPageImporters(file)
+    const dependentPages = walkImporters(
+      this.serverComponentBuilder.getImportGraph(),
+      changedFiles,
+      importer => importer.includes('/app/') || importer.includes('\\app\\'),
+    )
 
     return [...dependentPages]
   }

--- a/packages/rari/src/vite/hmr/coordinator.ts
+++ b/packages/rari/src/vite/hmr/coordinator.ts
@@ -3,7 +3,8 @@ import type { ServerComponentBuilder } from '../server/build'
 import path from 'node:path'
 import process from 'node:process'
 import { throwIfNotOk } from '@/shared/utils/http'
-import { isRecord, parseJsonRecord } from '@/shared/utils/type-guards'
+import { getRariServerPort } from '@/shared/utils/server-port'
+import { isRecord } from '@/shared/utils/type-guards'
 import { HMRErrorHandler } from './error-handler'
 
 export interface ComponentRebuildResult {
@@ -68,7 +69,7 @@ export class HMRCoordinator {
   constructor(
     // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- ServerComponentBuilder is a stateful builder with internal mutable caches
     builder: ServerComponentBuilder,
-    serverPort: number = 3000,
+    serverPort: number = getRariServerPort(),
   ) {
     this.serverComponentBuilder = builder
     this.rustServerUrl = `http://localhost:${serverPort}`
@@ -264,20 +265,19 @@ export class HMRCoordinator {
         )
       }
 
-      const result = parseJsonRecord(responseText)
-      if (!result) {
+      if (!isRecord(parsed)) {
         throw new Error(
           `Invalid server response (status ${response.status}): expected object, got ${typeof parsed}. ` +
             `Response body: ${responseText.substring(0, 200)}${responseText.length > 200 ? '...' : ''}`,
         )
       }
 
-      if (result.success !== true) {
+      if (parsed.success !== true) {
         const message =
-          typeof result.message === 'string' && result.message !== ''
-            ? result.message
-            : typeof result.error === 'string' && result.error !== ''
-              ? result.error
+          typeof parsed.message === 'string' && parsed.message !== ''
+            ? parsed.message
+            : typeof parsed.error === 'string' && parsed.error !== ''
+              ? parsed.error
               : 'Component reload failed'
         throw new Error(message)
       }

--- a/packages/rari/src/vite/hmr/import-graph.ts
+++ b/packages/rari/src/vite/hmr/import-graph.ts
@@ -1,0 +1,33 @@
+/**
+ * Collect every file that transitively imports one of the seed files, walking
+ * the reverse import graph (file -> set of files importing it). Seeds are
+ * traversed but excluded from the result; pass a predicate to keep only a
+ * subset of the discovered importers.
+ */
+export function walkImporters(
+  importGraph: ReadonlyMap<string, ReadonlySet<string>>,
+  seeds: readonly string[],
+  predicate?: (file: string) => boolean,
+): Set<string> {
+  const visited = new Set(seeds)
+  const collected = new Set<string>()
+  const queue = [...seeds]
+
+  while (queue.length > 0) {
+    const current = queue.pop()
+    if (current == null) break
+
+    const importers = importGraph.get(current)
+    if (!importers) continue
+
+    for (const importer of importers) {
+      if (visited.has(importer)) continue
+      visited.add(importer)
+      queue.push(importer)
+
+      if (predicate == null || predicate(importer)) collected.add(importer)
+    }
+  }
+
+  return collected
+}

--- a/packages/rari/src/vite/index.ts
+++ b/packages/rari/src/vite/index.ts
@@ -35,6 +35,7 @@ import {
   WINDOWS_PATH_REGEX,
 } from '@/shared/regex-constants'
 import { clearFileResolverCache, resolveImportToFilePath } from '@/shared/utils/file-resolver'
+import { getRariServerPort } from '@/shared/utils/server-port'
 import {
   aliasEntriesFromRecord,
   getErrnoCode,
@@ -696,17 +697,7 @@ if (import.meta.hot) {
   let rustServerReady = false
 
   async function checkRustServerHealth(): Promise<boolean> {
-    const serverPort =
-      process.env.SERVER_PORT != null && process.env.SERVER_PORT !== ''
-        ? Number(process.env.SERVER_PORT)
-        : Number(
-            process.env.PORT != null && process.env.PORT !== ''
-              ? process.env.PORT
-              : process.env.RSC_PORT != null && process.env.RSC_PORT !== ''
-                ? process.env.RSC_PORT
-                : 3000,
-          )
-    const baseUrl = `http://localhost:${serverPort}`
+    const baseUrl = `http://localhost:${getRariServerPort()}`
 
     try {
       const healthResponse = await fetch(`${baseUrl}/_rari/health`, {
@@ -721,6 +712,33 @@ if (import.meta.hot) {
     }
   }
 
+  let rustServerReadyWait: Promise<boolean> | null = null
+
+  async function waitForRustServerReady(timeoutMs: number): Promise<boolean> {
+    if (await checkRustServerHealth()) return true
+
+    rustServerReadyWait ??= (async () => {
+      try {
+        const deadline = Date.now() + timeoutMs
+        let interval = 50
+
+        while (Date.now() < deadline) {
+          await new Promise(resolve => {
+            setTimeout(resolve, Math.min(interval, deadline - Date.now()))
+          })
+          if (await checkRustServerHealth()) return true
+          interval = Math.min(interval * 2, 500)
+        }
+
+        return false
+      } finally {
+        rustServerReadyWait = null
+      }
+    })()
+
+    return rustServerReadyWait
+  }
+
   const mainPlugin: Plugin = {
     name: 'rari',
 
@@ -732,16 +750,7 @@ if (import.meta.hot) {
         (process.env.RARI_SERVER_URL != null && process.env.RARI_SERVER_URL !== '') ||
         (process.env.RARI_HOST != null && process.env.RARI_HOST !== '')
       ) {
-        const rariServerPort =
-          process.env.SERVER_PORT != null && process.env.SERVER_PORT !== ''
-            ? Number(process.env.SERVER_PORT)
-            : Number(
-                process.env.PORT != null && process.env.PORT !== ''
-                  ? process.env.PORT
-                  : process.env.RSC_PORT != null && process.env.RSC_PORT !== ''
-                    ? process.env.RSC_PORT
-                    : 3000,
-              )
+        const rariServerPort = getRariServerPort()
 
         let serverUrl: string
         if (process.env.RARI_SERVER_URL != null && process.env.RARI_SERVER_URL !== '') {
@@ -921,16 +930,7 @@ if (import.meta.hot) {
       config.server ??= {}
       config.server.proxy ??= {}
 
-      const serverPort =
-        process.env.SERVER_PORT != null && process.env.SERVER_PORT !== ''
-          ? Number(process.env.SERVER_PORT)
-          : Number(
-              process.env.PORT != null && process.env.PORT !== ''
-                ? process.env.PORT
-                : process.env.RSC_PORT != null && process.env.RSC_PORT !== ''
-                  ? process.env.RSC_PORT
-                  : 3000,
-            )
+      const serverPort = getRariServerPort()
 
       config.server.proxy['/api'] = {
         target: `http://localhost:${serverPort}`,
@@ -1305,19 +1305,7 @@ ${clientTransformedCode}`
 
           devServerComponentBuilder = builder
 
-          if (!hmrCoordinator) {
-            const serverPort =
-              process.env.SERVER_PORT != null && process.env.SERVER_PORT !== ''
-                ? Number(process.env.SERVER_PORT)
-                : Number(
-                    process.env.PORT != null && process.env.PORT !== ''
-                      ? process.env.PORT
-                      : process.env.RSC_PORT != null && process.env.RSC_PORT !== ''
-                        ? process.env.RSC_PORT
-                        : 3000,
-                  )
-            hmrCoordinator = new HMRCoordinator(builder, serverPort)
-          }
+          hmrCoordinator ??= new HMRCoordinator(builder, getRariServerPort())
 
           if (fs.existsSync(srcDir)) {
             const scanResult = scanDirectory(srcDir, builder, Object.values(resolvedAlias))
@@ -1333,47 +1321,39 @@ ${clientTransformedCode}`
 
           const components = await builder.getTransformedComponentsForDevelopment()
 
-          const serverPort =
-            process.env.SERVER_PORT != null && process.env.SERVER_PORT !== ''
-              ? Number(process.env.SERVER_PORT)
-              : Number(
-                  process.env.PORT != null && process.env.PORT !== ''
-                    ? process.env.PORT
-                    : process.env.RSC_PORT != null && process.env.RSC_PORT !== ''
-                      ? process.env.RSC_PORT
-                      : 3000,
+          const baseUrl = `http://localhost:${getRariServerPort()}`
+
+          await Promise.all(
+            components.map(async component => {
+              try {
+                const isAppRouterComponent = component.id.startsWith('app/')
+                if (isAppRouterComponent) return
+
+                if (component.isAction) return
+
+                const registerResponse = await fetch(`${baseUrl}/_rari/register`, {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                  },
+                  body: JSON.stringify({
+                    component_id: component.id,
+                    component_code: component.code,
+                  }),
+                })
+
+                if (!registerResponse.ok) {
+                  const errorText = await registerResponse.text()
+                  throw new Error(`HTTP ${registerResponse.status}: ${errorText}`)
+                }
+              } catch (error) {
+                console.error(
+                  `[rari] Runtime: Failed to register component ${component.id}:`,
+                  error instanceof Error ? error.message : String(error),
                 )
-          const baseUrl = `http://localhost:${serverPort}`
-
-          for (const component of components) {
-            try {
-              const isAppRouterComponent = component.id.startsWith('app/')
-              if (isAppRouterComponent) continue
-
-              if (component.isAction) continue
-
-              const registerResponse = await fetch(`${baseUrl}/_rari/register`, {
-                method: 'POST',
-                headers: {
-                  'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                  component_id: component.id,
-                  component_code: component.code,
-                }),
-              })
-
-              if (!registerResponse.ok) {
-                const errorText = await registerResponse.text()
-                throw new Error(`HTTP ${registerResponse.status}: ${errorText}`)
               }
-            } catch (error) {
-              console.error(
-                `[rari] Runtime: Failed to register component ${component.id}:`,
-                error instanceof Error ? error.message : String(error),
-              )
-            }
-          }
+            }),
+          )
         } catch (error) {
           console.error(
             '[rari] Runtime: Component discovery failed:',
@@ -1384,43 +1364,35 @@ ${clientTransformedCode}`
 
       const ensureClientComponentsRegistered = async () => {
         try {
-          const serverPort =
-            process.env.SERVER_PORT != null && process.env.SERVER_PORT !== ''
-              ? Number(process.env.SERVER_PORT)
-              : Number(
-                  process.env.PORT != null && process.env.PORT !== ''
-                    ? process.env.PORT
-                    : process.env.RSC_PORT != null && process.env.RSC_PORT !== ''
-                      ? process.env.RSC_PORT
-                      : 3000,
-                )
-          const baseUrl = `http://localhost:${serverPort}`
+          const baseUrl = `http://localhost:${getRariServerPort()}`
 
           const clientComponentFiles = getKnownClientComponentPaths()
 
-          for (const componentPath of clientComponentFiles) {
-            const relativePath = path.relative(process.cwd(), componentPath)
-            const componentName = path.basename(componentPath).replace(EXTENSION_REGEX, '')
+          await Promise.all(
+            [...clientComponentFiles].map(async componentPath => {
+              const relativePath = path.relative(process.cwd(), componentPath)
+              const componentName = path.basename(componentPath).replace(EXTENSION_REGEX, '')
 
-            try {
-              await fetch(`${baseUrl}/_rari/register-client`, {
-                method: 'POST',
-                headers: {
-                  'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                  component_id: componentName,
-                  file_path: relativePath,
-                  export_name: 'default',
-                }),
-              })
-            } catch (error) {
-              console.error(
-                `[rari] Runtime: Failed to pre-register client component ${componentName}:`,
-                error,
-              )
-            }
-          }
+              try {
+                await fetch(`${baseUrl}/_rari/register-client`, {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                  },
+                  body: JSON.stringify({
+                    component_id: componentName,
+                    file_path: relativePath,
+                    export_name: 'default',
+                  }),
+                })
+              } catch (error) {
+                console.error(
+                  `[rari] Runtime: Failed to pre-register client component ${componentName}:`,
+                  error,
+                )
+              }
+            }),
+          )
         } catch (error) {
           console.error('[rari] Runtime: Failed to pre-register client components:', error)
         }
@@ -1441,16 +1413,7 @@ ${clientTransformedCode}`
           return
         }
 
-        const serverPort =
-          process.env.SERVER_PORT != null && process.env.SERVER_PORT !== ''
-            ? Number(process.env.SERVER_PORT)
-            : Number(
-                process.env.PORT != null && process.env.PORT !== ''
-                  ? process.env.PORT
-                  : process.env.RSC_PORT != null && process.env.RSC_PORT !== ''
-                    ? process.env.RSC_PORT
-                    : 3000,
-              )
+        const serverPort = getRariServerPort()
         const mode = process.env.NODE_ENV === 'production' ? 'production' : 'development'
 
         const vitePort = server.config.server.port
@@ -1506,16 +1469,7 @@ ${clientTransformedCode}`
           else if (code) console.error(`rari server exited with code ${code}`)
         })
 
-        let serverReady = false
-        for (let i = 0; i < 20; i++) {
-          serverReady = await checkRustServerHealth()
-          if (serverReady) {
-            break
-          }
-          await new Promise(resolve => {
-            setTimeout(resolve, 500)
-          })
-        }
+        const serverReady = await waitForRustServerReady(10000)
 
         if (serverReady) {
           await discoverAndRegisterComponents()
@@ -1523,6 +1477,30 @@ ${clientTransformedCode}`
         } else {
           console.error('Server failed to become ready for component registration')
         }
+      }
+
+      const collectAffectedComponentFiles = (
+        importGraph: ReadonlyMap<string, ReadonlySet<string>>,
+        changedFile: string,
+      ): Set<string> => {
+        const affected = new Set<string>([changedFile])
+        const queue = [changedFile]
+
+        while (queue.length > 0) {
+          const current = queue.pop()
+          if (current == null) break
+
+          const importers = importGraph.get(current)
+          if (!importers) continue
+
+          for (const importer of importers) {
+            if (affected.has(importer)) continue
+            affected.add(importer)
+            queue.push(importer)
+          }
+        }
+
+        return affected
       }
 
       const handleServerComponentHMR = async (filePath: string) => {
@@ -1537,56 +1515,48 @@ ${clientTransformedCode}`
           const code = moduleAnalysisCache.getSource(filePath)
           builder.addServerComponent(filePath, code)
 
-          const components = await builder.getTransformedComponentsForDevelopment()
+          const affectedFiles = collectAffectedComponentFiles(builder.getImportGraph(), filePath)
+          const components = await builder.getTransformedComponentsForDevelopment(file =>
+            affectedFiles.has(file),
+          )
 
           if (components.length === 0) return
 
-          const serverPort =
-            process.env.SERVER_PORT != null && process.env.SERVER_PORT !== ''
-              ? Number(process.env.SERVER_PORT)
-              : Number(
-                  process.env.PORT != null && process.env.PORT !== ''
-                    ? process.env.PORT
-                    : process.env.RSC_PORT != null && process.env.RSC_PORT !== ''
-                      ? process.env.RSC_PORT
-                      : 3000,
+          const baseUrl = `http://localhost:${getRariServerPort()}`
+
+          await Promise.all(
+            components.map(async component => {
+              try {
+                const registerResponse = await fetch(`${baseUrl}/_rari/register`, {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                  },
+                  body: JSON.stringify({
+                    component_id: component.id,
+                    component_code: component.code,
+                  }),
+                })
+
+                if (!registerResponse.ok) {
+                  const errorText = await registerResponse.text()
+                  throw new Error(`HTTP ${registerResponse.status}: ${errorText}`)
+                }
+              } catch (error) {
+                console.error(
+                  '[rari] Failed to register component',
+                  `${component.id}:`,
+                  error instanceof Error ? error.message : String(error),
                 )
-          const baseUrl = `http://localhost:${serverPort}`
-
-          for (const component of components) {
-            try {
-              const registerResponse = await fetch(`${baseUrl}/_rari/register`, {
-                method: 'POST',
-                headers: {
-                  'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                  component_id: component.id,
-                  component_code: component.code,
-                }),
-              })
-
-              if (!registerResponse.ok) {
-                const errorText = await registerResponse.text()
-                throw new Error(`HTTP ${registerResponse.status}: ${errorText}`)
               }
-            } catch (error) {
-              console.error(
-                '[rari] Failed to register component',
-                `${component.id}:`,
-                error instanceof Error ? error.message : String(error),
-              )
-            }
-          }
+            }),
+          )
         } catch (error) {
           console.error(
             '[rari] Targeted HMR failed for',
             `${filePath}:`,
             error instanceof Error ? error.message : String(error),
           )
-          setTimeout(() => {
-            void discoverAndRegisterComponents()
-          }, 1000)
         }
       }
 
@@ -1609,43 +1579,20 @@ ${clientTransformedCode}`
             !req.url.includes('.')
           ) {
             if (!rustServerReady) {
-              let ready = await checkRustServerHealth()
+              const ready = await waitForRustServerReady(10000)
+
               if (!ready) {
-                const maxWait = 10000
-                const startWait = Date.now()
-                const checkInterval = 100
-
-                while (Date.now() - startWait < maxWait) {
-                  ready = await checkRustServerHealth()
-                  if (ready) break
-
-                  await new Promise(resolve => {
-                    setTimeout(resolve, checkInterval)
-                  })
+                console.error('[rari] Rust server not ready, cannot proxy RSC request')
+                if (!res.headersSent) {
+                  res.statusCode = 503
+                  res.end('Server not ready')
                 }
 
-                if (!ready) {
-                  console.error('[rari] Rust server not ready, cannot proxy RSC request')
-                  if (!res.headersSent) {
-                    res.statusCode = 503
-                    res.end('Server not ready')
-                  }
-
-                  return
-                }
+                return
               }
             }
 
-            const serverPort =
-              process.env.SERVER_PORT != null && process.env.SERVER_PORT !== ''
-                ? Number(process.env.SERVER_PORT)
-                : Number(
-                    process.env.PORT != null && process.env.PORT !== ''
-                      ? process.env.PORT
-                      : process.env.RSC_PORT != null && process.env.RSC_PORT !== ''
-                        ? process.env.RSC_PORT
-                        : 3000,
-                  )
+            const serverPort = getRariServerPort()
 
             const targetUrl = `http://localhost:${serverPort}${req.url}`
 
@@ -1712,19 +1659,17 @@ ${clientTransformedCode}`
             moduleAnalysisCache.invalidate(filePath)
           }
 
-          if (TSX_EXT_REGEX.test(filePath) && filePath.includes(srcDir)) {
-            if (isServerComponent(filePath)) {
-              server.ws.send({
-                type: 'custom',
-                event: 'rari:register-server-component',
-                data: { filePath },
-              })
-              await handleServerComponentHMR(filePath)
-            } else {
-              setTimeout(() => {
-                void discoverAndRegisterComponents()
-              }, 1000)
-            }
+          if (
+            TSX_EXT_REGEX.test(filePath) &&
+            filePath.includes(srcDir) &&
+            isServerComponent(filePath)
+          ) {
+            server.ws.send({
+              type: 'custom',
+              event: 'rari:register-server-component',
+              data: { filePath },
+            })
+            await handleServerComponentHMR(filePath)
           }
         })()
       })

--- a/packages/rari/src/vite/index.ts
+++ b/packages/rari/src/vite/index.ts
@@ -54,6 +54,7 @@ import {
 } from './analysis/module-cache'
 import { normalizeScanDirs } from './analysis/source-walker'
 import { HMRCoordinator } from './hmr/coordinator'
+import { walkImporters } from './hmr/import-graph'
 import {
   generateMdxRegistryModule,
   isMdxRegistryModuleId,
@@ -1479,30 +1480,6 @@ ${clientTransformedCode}`
         }
       }
 
-      const collectAffectedComponentFiles = (
-        importGraph: ReadonlyMap<string, ReadonlySet<string>>,
-        changedFile: string,
-      ): Set<string> => {
-        const affected = new Set<string>([changedFile])
-        const queue = [changedFile]
-
-        while (queue.length > 0) {
-          const current = queue.pop()
-          if (current == null) break
-
-          const importers = importGraph.get(current)
-          if (!importers) continue
-
-          for (const importer of importers) {
-            if (affected.has(importer)) continue
-            affected.add(importer)
-            queue.push(importer)
-          }
-        }
-
-        return affected
-      }
-
       const handleServerComponentHMR = async (filePath: string) => {
         try {
           if (!isServerComponent(filePath)) return
@@ -1515,7 +1492,8 @@ ${clientTransformedCode}`
           const code = moduleAnalysisCache.getSource(filePath)
           builder.addServerComponent(filePath, code)
 
-          const affectedFiles = collectAffectedComponentFiles(builder.getImportGraph(), filePath)
+          const affectedFiles = walkImporters(builder.getImportGraph(), [filePath])
+          affectedFiles.add(filePath)
           const components = await builder.getTransformedComponentsForDevelopment(file =>
             affectedFiles.has(file),
           )

--- a/packages/rari/src/vite/server/build.ts
+++ b/packages/rari/src/vite/server/build.ts
@@ -615,12 +615,14 @@ export class ServerComponentBuilder {
     return hasNodeImportsFromAnalysis(analysis)
   }
 
-  async getTransformedComponentsForDevelopment(): Promise<
-    Array<{ id: string; code: string; isAction: boolean }>
-  > {
+  async getTransformedComponentsForDevelopment(
+    filter?: (filePath: string) => boolean,
+  ): Promise<Array<{ id: string; code: string; isAction: boolean }>> {
     const components: Array<{ id: string; code: string; isAction: boolean }> = []
 
     for (const [filePath] of this.serverComponents) {
+      if (filter && !filter(filePath)) continue
+
       const relativePath = path.relative(this.projectRoot, filePath)
       const componentId = this.getComponentId(relativePath)
 
@@ -634,6 +636,8 @@ export class ServerComponentBuilder {
     }
 
     for (const [filePath] of this.serverActions) {
+      if (filter && !filter(filePath)) continue
+
       const relativePath = path.relative(this.projectRoot, filePath)
       const actionId = this.getComponentId(relativePath)
 


### PR DESCRIPTION
Re-register only the changed server component and its transitive importers instead of rebundling and re-POSTing the entire component graph on every edit. Replace fixed-interval health polling with a shared exponential backoff, deduplicate server port resolution into a shared helper (fixing a hardcoded localhost:3000 in the router HMR notify), parse the HMR reload response once, and drop the legacy full-rediscovery fallbacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Development servers now consistently respect configured port settings instead of assuming port 3000.
  - API updates and hot module replacement work correctly when the server runs on a custom port.
  - Improved server readiness handling reduces connection failures during startup.
  - Requests return a clear unavailable response when the development server cannot be reached.

- **Performance**
  - Hot updates now refresh only affected components, reducing unnecessary reloads and improving development speed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->