### PR TITLE
fix(vite): replace regex client-import rewrites with lexer spans

### DIFF
--- a/packages/rari/src/vite/analysis/directives.ts
+++ b/packages/rari/src/vite/analysis/directives.ts
@@ -865,7 +865,15 @@ export function collectExportNames(source: string): string[] {
     }
 
     if (source.charCodeAt(pos) === CH_STAR) {
-      i = pos + 1
+      let afterStar = skipTrivia(source, pos + 1, len)
+      if (isKeywordAt(source, afterStar, 'as')) {
+        afterStar = skipTrivia(source, afterStar + 2, len)
+        const ns = readIdentifier(source, afterStar, len)
+        if (ns) exports.add(ns.name)
+        i = ns?.end ?? afterStar + 1
+      } else {
+        i = pos + 1
+      }
       continue
     }
 
@@ -918,7 +926,7 @@ export function collectExportNames(source: string): string[] {
     i++
   }
 
-  return exports.size > 0 ? [...exports] : ['default']
+  return [...exports]
 }
 
 function skipBalancedBraceList(source: string, start: number, len: number): number {

--- a/packages/rari/src/vite/analysis/directives.ts
+++ b/packages/rari/src/vite/analysis/directives.ts
@@ -429,21 +429,6 @@ export function analyzeModuleSource(source: string): ModuleAnalysis {
   while (i < len) {
     const ch = source.charCodeAt(i)
 
-    if (isWhitespaceCode(ch)) {
-      i++
-      continue
-    }
-
-    if (ch === CH_SLASH && source.charCodeAt(i + 1) === CH_SLASH) {
-      i = skipSingleLineComment(source, i, len)
-      continue
-    }
-
-    if (ch === CH_SLASH && source.charCodeAt(i + 1) === CH_STAR) {
-      i = skipMultiLineComment(source, i, len)
-      continue
-    }
-
     if (directivesPhase && (ch === CH_SINGLE_QUOTE || ch === CH_DOUBLE_QUOTE)) {
       const stringStart = i + 1
       const stringEnd = skipString(source, i, len, ch)
@@ -502,38 +487,14 @@ export function analyzeModuleSource(source: string): ModuleAnalysis {
       continue
     }
 
+    const skipped = skipNonCodeToken(source, i, len)
+    if (skipped !== -1) {
+      if (directivesPhase && !isTriviaOrCommentStart(source, i)) directivesPhase = false
+      i = skipped
+      continue
+    }
+
     directivesPhase = false
-
-    if (ch === CH_SINGLE_QUOTE || ch === CH_DOUBLE_QUOTE || ch === CH_BACKTICK) {
-      i = skipString(source, i, len, ch)
-      continue
-    }
-
-    if (
-      ch === CH_SLASH &&
-      source.charCodeAt(i + 1) !== CH_SLASH &&
-      source.charCodeAt(i + 1) !== CH_STAR
-    ) {
-      if (canPrecedeRegexWithKeywords(source, i)) {
-        i = skipRegex(source, i, len)
-        continue
-      }
-    }
-
-    if (ch === CH_LT) {
-      const nextCh = source.charCodeAt(i + 1)
-      if (
-        nextCh === CH_SLASH ||
-        nextCh === CH_DOT ||
-        nextCh === CH_GT ||
-        isIdentifierStartCode(nextCh)
-      ) {
-        i = skipJSX(source, i, len)
-        continue
-      }
-      i++
-      continue
-    }
 
     if (isKeywordAt(source, i, 'import')) {
       const collected = collectImportSourcesAt(source, i, len)
@@ -856,50 +817,9 @@ export function scanImportStatements(source: string): ScannedImport[] {
   const len = source.length
 
   while (i < len) {
-    const ch = source.charCodeAt(i)
-
-    if (isWhitespaceCode(ch)) {
-      i++
-      continue
-    }
-
-    if (ch === CH_SLASH && source.charCodeAt(i + 1) === CH_SLASH) {
-      i = skipSingleLineComment(source, i, len)
-      continue
-    }
-
-    if (ch === CH_SLASH && source.charCodeAt(i + 1) === CH_STAR) {
-      i = skipMultiLineComment(source, i, len)
-      continue
-    }
-
-    if (ch === CH_SINGLE_QUOTE || ch === CH_DOUBLE_QUOTE || ch === CH_BACKTICK) {
-      i = skipString(source, i, len, ch)
-      continue
-    }
-
-    if (
-      ch === CH_SLASH &&
-      source.charCodeAt(i + 1) !== CH_SLASH &&
-      source.charCodeAt(i + 1) !== CH_STAR &&
-      canPrecedeRegexWithKeywords(source, i)
-    ) {
-      i = skipRegex(source, i, len)
-      continue
-    }
-
-    if (ch === CH_LT) {
-      const nextCh = source.charCodeAt(i + 1)
-      if (
-        nextCh === CH_SLASH ||
-        nextCh === CH_DOT ||
-        nextCh === CH_GT ||
-        isIdentifierStartCode(nextCh)
-      ) {
-        i = skipJSX(source, i, len)
-        continue
-      }
-      i++
+    const skipped = skipNonCodeToken(source, i, len)
+    if (skipped !== -1) {
+      i = skipped
       continue
     }
 
@@ -1142,6 +1062,59 @@ function skipRegex(source: string, i: number, len: number): number {
   return i
 }
 
+/**
+ * If `source[i]` starts whitespace, a comment, string, regex literal, or JSX,
+ * return the offset past that token. Returns -1 when the position is code.
+ */
+function skipNonCodeToken(source: string, i: number, len: number): number {
+  if (i >= len) return -1
+
+  const ch = source.charCodeAt(i)
+
+  if (isWhitespaceCode(ch)) return i + 1
+
+  if (ch === CH_SLASH && source.charCodeAt(i + 1) === CH_SLASH)
+    return skipSingleLineComment(source, i, len)
+
+  if (ch === CH_SLASH && source.charCodeAt(i + 1) === CH_STAR)
+    return skipMultiLineComment(source, i, len)
+
+  if (ch === CH_SINGLE_QUOTE || ch === CH_DOUBLE_QUOTE || ch === CH_BACKTICK)
+    return skipString(source, i, len, ch)
+
+  if (
+    ch === CH_SLASH &&
+    source.charCodeAt(i + 1) !== CH_SLASH &&
+    source.charCodeAt(i + 1) !== CH_STAR &&
+    canPrecedeRegexWithKeywords(source, i)
+  ) {
+    return skipRegex(source, i, len)
+  }
+
+  if (ch === CH_LT) {
+    const nextCh = source.charCodeAt(i + 1)
+    if (
+      nextCh === CH_SLASH ||
+      nextCh === CH_DOT ||
+      nextCh === CH_GT ||
+      isIdentifierStartCode(nextCh)
+    ) {
+      return skipJSX(source, i, len)
+    }
+  }
+
+  return -1
+}
+
+function isTriviaOrCommentStart(source: string, i: number): boolean {
+  const ch = source.charCodeAt(i)
+  if (isWhitespaceCode(ch)) return true
+  return (
+    ch === CH_SLASH &&
+    (source.charCodeAt(i + 1) === CH_SLASH || source.charCodeAt(i + 1) === CH_STAR)
+  )
+}
+
 export interface ExportDefaultValueLocation {
   /** Start of the `export` keyword. */
   readonly exportStart: number
@@ -1168,50 +1141,9 @@ export function locateExportDefaultValue(source: string): ExportDefaultValueLoca
   let i = 0
 
   while (i < len) {
-    const ch = source.charCodeAt(i)
-
-    if (isWhitespaceCode(ch)) {
-      i++
-      continue
-    }
-
-    if (ch === CH_SLASH && source.charCodeAt(i + 1) === CH_SLASH) {
-      i = skipSingleLineComment(source, i, len)
-      continue
-    }
-
-    if (ch === CH_SLASH && source.charCodeAt(i + 1) === CH_STAR) {
-      i = skipMultiLineComment(source, i, len)
-      continue
-    }
-
-    if (ch === CH_SINGLE_QUOTE || ch === CH_DOUBLE_QUOTE || ch === CH_BACKTICK) {
-      i = skipString(source, i, len, ch)
-      continue
-    }
-
-    if (
-      ch === CH_SLASH &&
-      source.charCodeAt(i + 1) !== CH_SLASH &&
-      source.charCodeAt(i + 1) !== CH_STAR &&
-      canPrecedeRegexWithKeywords(source, i)
-    ) {
-      i = skipRegex(source, i, len)
-      continue
-    }
-
-    if (ch === CH_LT) {
-      const nextCh = source.charCodeAt(i + 1)
-      if (
-        nextCh === CH_SLASH ||
-        nextCh === CH_DOT ||
-        nextCh === CH_GT ||
-        isIdentifierStartCode(nextCh)
-      ) {
-        i = skipJSX(source, i, len)
-        continue
-      }
-      i++
+    const skipped = skipNonCodeToken(source, i, len)
+    if (skipped !== -1) {
+      i = skipped
       continue
     }
 
@@ -1259,17 +1191,61 @@ export function locateExportDefaultValue(source: string): ExportDefaultValueLoca
   return null
 }
 
+function isExpressionContinuationAt(source: string, i: number, len: number): boolean {
+  if (i >= len) return false
+
+  const ch = source.charCodeAt(i)
+  const next = i + 1 < len ? source.charCodeAt(i + 1) : -1
+
+  if (ch === CH_DOT) return true
+  if (ch === CH_QUESTION && next === CH_DOT) return true
+  if (ch === CH_OPEN_PAREN || ch === CH_OPEN_BRACKET || ch === CH_BACKTICK) return true
+  if (ch === CH_EQUALS && next === CH_GT) return true
+
+  if (
+    ch === CH_PLUS ||
+    ch === CH_MINUS ||
+    ch === CH_STAR ||
+    ch === CH_SLASH ||
+    ch === CH_PERCENT ||
+    ch === CH_AMP ||
+    ch === CH_PIPE ||
+    ch === CH_CARET ||
+    ch === CH_LT ||
+    ch === CH_GT ||
+    ch === CH_EQUALS ||
+    ch === CH_EXCL ||
+    ch === CH_QUESTION ||
+    ch === CH_COLON ||
+    ch === CH_COMMA ||
+    ch === CH_TILDE
+  ) {
+    return true
+  }
+
+  return (
+    isKeywordAt(source, i, 'instanceof') ||
+    isKeywordAt(source, i, 'in') ||
+    isKeywordAt(source, i, 'of') ||
+    isKeywordAt(source, i, 'as')
+  )
+}
+
+const NON_TERMINATING_EXPR_KEYWORDS = new Set(['typeof', 'void', 'delete', 'await', 'yield', 'new'])
+
 function scanExportDefaultValueEnd(source: string, start: number, len: number): number {
   let i = start
   let paren = 0
   let brace = 0
   let bracket = 0
+  let lastCanTerminate = false
 
   while (i < len) {
     const ch = source.charCodeAt(i)
 
     if (ch === CH_SINGLE_QUOTE || ch === CH_DOUBLE_QUOTE || ch === CH_BACKTICK) {
       i = skipString(source, i, len, ch)
+      lastCanTerminate = true
       continue
     }
 
@@ -1290,6 +1266,7 @@ function scanExportDefaultValueEnd(source: string, start: number, len: number): 
       canPrecedeRegexWithKeywords(source, i)
     ) {
       i = skipRegex(source, i, len)
+      lastCanTerminate = true
       continue
     }
 
@@ -1302,27 +1279,32 @@ function scanExportDefaultValueEnd(source: string, start: number, len: number): 
         isIdentifierStartCode(nextCh)
       ) {
         i = skipJSX(source, i, len)
+        lastCanTerminate = true
         continue
       }
     }
 
     if (ch === CH_OPEN_PAREN) {
       paren++
+      lastCanTerminate = false
       i++
       continue
     }
     if (ch === CH_CLOSE_PAREN) {
       paren = Math.max(0, paren - 1)
+      lastCanTerminate = true
       i++
       continue
     }
     if (ch === CH_OPEN_BRACE) {
       brace++
+      lastCanTerminate = false
       i++
       continue
     }
     if (ch === CH_CLOSE_BRACE) {
       brace = Math.max(0, brace - 1)
+      lastCanTerminate = true
       i++
       // Declaration bodies (`function () {}`, `class {}`) end when the outer
       // brace closes at depth 0.
@@ -1331,22 +1313,87 @@ function scanExportDefaultValueEnd(source: string, start: number, len: number): 
     }
     if (ch === CH_OPEN_BRACKET) {
       bracket++
+      lastCanTerminate = false
       i++
       continue
     }
     if (ch === CH_CLOSE_BRACKET) {
       bracket = Math.max(0, bracket - 1)
+      lastCanTerminate = true
       i++
       continue
     }
 
     if (paren === 0 && brace === 0 && bracket === 0) {
       if (ch === CH_SEMICOLON) return i
+
       if (isLineTerminatorCode(ch)) {
-        // ASI: end the statement unless the next non-trivia token continues
-        // the expression (rare for `export default`; treat newline as end).
+        const afterNl = skipTrivia(source, i + 1, len)
+        if (!lastCanTerminate || isExpressionContinuationAt(source, afterNl, len)) {
+          i++
+          continue
+        }
         return i
       }
+    }
+
+    if (isIdentifierStartCode(ch)) {
+      const id = readIdentifier(source, i, len)
+      if (id) {
+        lastCanTerminate = !NON_TERMINATING_EXPR_KEYWORDS.has(id.name)
+        i = id.end
+        continue
+      }
+    }
+
+    if (ch >= CH_0 && ch <= CH_9) {
+      lastCanTerminate = true
+      i++
+      while (i < len) {
+        const d = source.charCodeAt(i)
+        if (
+          (d >= CH_0 && d <= CH_9) ||
+          d === CH_DOT ||
+          d === 110 /* n */ ||
+          d === 101 /* e */ ||
+          d === 69 /* E */
+        ) {
+          i++
+          continue
+        }
+        break
+      }
+      continue
+    }
+
+    if (ch === CH_EQUALS && source.charCodeAt(i + 1) === CH_GT) {
+      lastCanTerminate = false
+      i += 2
+      continue
+    }
+
+    if (
+      ch === CH_DOT ||
+      ch === CH_COMMA ||
+      ch === CH_COLON ||
+      ch === CH_QUESTION ||
+      ch === CH_EQUALS ||
+      ch === CH_PLUS ||
+      ch === CH_MINUS ||
+      ch === CH_STAR ||
+      ch === CH_SLASH ||
+      ch === CH_PERCENT ||
+      ch === CH_AMP ||
+      ch === CH_PIPE ||
+      ch === CH_CARET ||
+      ch === CH_EXCL ||
+      ch === CH_TILDE ||
+      ch === CH_LT ||
+      ch === CH_GT
+    ) {
+      lastCanTerminate = false
+      i++
+      continue
     }
 
     i++

--- a/packages/rari/src/vite/analysis/directives.ts
+++ b/packages/rari/src/vite/analysis/directives.ts
@@ -633,6 +633,293 @@ export function analyzeModuleSource(source: string): ModuleAnalysis {
   }
 }
 
+export interface ScannedImportSpecifier {
+  readonly imported: string
+  readonly local: string
+  readonly typeOnly: boolean
+}
+
+export interface ScannedImport {
+  /** Offset of the `import` keyword. */
+  readonly start: number
+  /** Offset past the statement (includes a trailing semicolon when present). */
+  readonly end: number
+  readonly source: string
+  readonly typeOnly: boolean
+  readonly sideEffectOnly: boolean
+  readonly defaultBinding: string | null
+  readonly namespaceBinding: string | null
+  readonly named: readonly ScannedImportSpecifier[]
+}
+
+function readIdentifier(
+  source: string,
+  i: number,
+  len: number,
+): { name: string; end: number } | null {
+  if (i >= len || !isIdentifierStartCode(source.charCodeAt(i))) return null
+
+  let j = i + 1
+  while (j < len && isIdentifierPartCode(source.charCodeAt(j))) j++
+
+  return { name: source.slice(i, j), end: j }
+}
+
+function consumeTrailingSemicolon(source: string, end: number, len: number): number {
+  let pos = end
+  while (pos < len) {
+    const ch = source.charCodeAt(pos)
+    if (ch === CH_SPACE || ch === CH_TAB) {
+      pos++
+      continue
+    }
+    if (ch === CH_SEMICOLON) return pos + 1
+    break
+  }
+
+  return end
+}
+
+interface NamedSpecifierParse {
+  readonly named: ScannedImportSpecifier[]
+  readonly end: number
+}
+
+function parseNamedImportSpecifiers(
+  source: string,
+  openBrace: number,
+  len: number,
+): NamedSpecifierParse | null {
+  const named: ScannedImportSpecifier[] = []
+  let pos = openBrace + 1
+
+  for (;;) {
+    pos = skipTrivia(source, pos, len)
+    if (pos >= len) return null
+
+    if (source.charCodeAt(pos) === CH_CLOSE_BRACE) return { named, end: pos + 1 }
+
+    // Inline type specifier: `type` followed by another specifier name is a
+    // modifier. A binding literally named `type` still parses as a name below.
+    let specTypeOnly = false
+    if (isKeywordAt(source, pos, 'type')) {
+      const after = skipTrivia(source, pos + 4, len)
+      const afterCh = source.charCodeAt(after)
+      const startsSpecifier =
+        afterCh === CH_SINGLE_QUOTE ||
+        afterCh === CH_DOUBLE_QUOTE ||
+        readIdentifier(source, after, len) !== null
+      if (startsSpecifier && !isKeywordAt(source, after, 'as')) {
+        specTypeOnly = true
+        pos = after
+      }
+    }
+
+    let imported: string
+    const importedCh = source.charCodeAt(pos)
+    if (importedCh === CH_SINGLE_QUOTE || importedCh === CH_DOUBLE_QUOTE) {
+      const strEnd = skipString(source, pos, len, importedCh)
+      imported = source.slice(pos + 1, strEnd - 1)
+      pos = strEnd
+    } else {
+      const ident = readIdentifier(source, pos, len)
+      if (!ident) return null
+      imported = ident.name
+      pos = ident.end
+    }
+
+    pos = skipTrivia(source, pos, len)
+
+    let local = imported
+    if (isKeywordAt(source, pos, 'as')) {
+      pos = skipTrivia(source, pos + 2, len)
+      const alias = readIdentifier(source, pos, len)
+      if (!alias) return null
+      local = alias.name
+      pos = skipTrivia(source, alias.end, len)
+    }
+
+    named.push({ imported, local, typeOnly: specTypeOnly })
+
+    const ch = source.charCodeAt(pos)
+    if (ch === CH_COMMA) {
+      pos++
+      continue
+    }
+    if (ch === CH_CLOSE_BRACE) return { named, end: pos + 1 }
+
+    return null
+  }
+}
+
+function parseImportStatementAt(source: string, start: number, len: number): ScannedImport | null {
+  let pos = skipTrivia(source, start + 6, len)
+  if (pos >= len) return null
+
+  const ch = source.charCodeAt(pos)
+  // Dynamic import or import.meta — not a static statement.
+  if (ch === CH_OPEN_PAREN || ch === CH_DOT) return null
+
+  if (ch === CH_SINGLE_QUOTE || ch === CH_DOUBLE_QUOTE) {
+    const spec = readImportModuleSpecifier(source, pos, len)
+    if (!spec) return null
+
+    return {
+      start,
+      end: consumeTrailingSemicolon(source, spec.end, len),
+      source: spec.source,
+      typeOnly: false,
+      sideEffectOnly: true,
+      defaultBinding: null,
+      namespaceBinding: null,
+      named: [],
+    }
+  }
+
+  let typeOnly = false
+  // `import type ...` is type-only unless `type` is itself the default
+  // binding (`import type from './x'` or `import type, { x } from './x'`).
+  if (isKeywordAt(source, pos, 'type')) {
+    const after = skipTrivia(source, pos + 4, len)
+    if (!isKeywordAt(source, after, 'from') && source.charCodeAt(after) !== CH_COMMA) {
+      typeOnly = true
+      pos = after
+    }
+  }
+
+  let defaultBinding: string | null = null
+  let namespaceBinding: string | null = null
+  let named: ScannedImportSpecifier[] = []
+
+  let clauseCh = source.charCodeAt(pos)
+
+  if (clauseCh !== CH_OPEN_BRACE && clauseCh !== CH_STAR) {
+    const ident = readIdentifier(source, pos, len)
+    if (!ident) return null
+
+    defaultBinding = ident.name
+    pos = skipTrivia(source, ident.end, len)
+
+    if (source.charCodeAt(pos) === CH_COMMA) {
+      pos = skipTrivia(source, pos + 1, len)
+      clauseCh = source.charCodeAt(pos)
+    } else {
+      clauseCh = -1
+    }
+  }
+
+  if (clauseCh === CH_STAR) {
+    pos = skipTrivia(source, pos + 1, len)
+    if (!isKeywordAt(source, pos, 'as')) return null
+
+    pos = skipTrivia(source, pos + 2, len)
+    const ns = readIdentifier(source, pos, len)
+    if (!ns) return null
+
+    namespaceBinding = ns.name
+    pos = ns.end
+  } else if (clauseCh === CH_OPEN_BRACE) {
+    const parsed = parseNamedImportSpecifiers(source, pos, len)
+    if (!parsed) return null
+
+    named = parsed.named
+    pos = parsed.end
+  }
+
+  pos = skipTrivia(source, pos, len)
+  if (!isKeywordAt(source, pos, 'from')) return null
+
+  const spec = readImportModuleSpecifier(source, pos + 4, len)
+  if (!spec) return null
+
+  return {
+    start,
+    end: consumeTrailingSemicolon(source, spec.end, len),
+    source: spec.source,
+    typeOnly,
+    sideEffectOnly: false,
+    defaultBinding,
+    namespaceBinding,
+    named,
+  }
+}
+
+/**
+ * Scan static import statements with byte spans and full specifier structure
+ * (default, namespace, named with aliases, type-only, side-effect, multi-line).
+ * Same lexer discipline as analyzeModuleSource: comments, strings, regex
+ * literals, and JSX are skipped, so imports inside them never match.
+ */
+export function scanImportStatements(source: string): ScannedImport[] {
+  const imports: ScannedImport[] = []
+  let i = 0
+  const len = source.length
+
+  while (i < len) {
+    const ch = source.charCodeAt(i)
+
+    if (isWhitespaceCode(ch)) {
+      i++
+      continue
+    }
+
+    if (ch === CH_SLASH && source.charCodeAt(i + 1) === CH_SLASH) {
+      i = skipSingleLineComment(source, i, len)
+      continue
+    }
+
+    if (ch === CH_SLASH && source.charCodeAt(i + 1) === CH_STAR) {
+      i = skipMultiLineComment(source, i, len)
+      continue
+    }
+
+    if (ch === CH_SINGLE_QUOTE || ch === CH_DOUBLE_QUOTE || ch === CH_BACKTICK) {
+      i = skipString(source, i, len, ch)
+      continue
+    }
+
+    if (
+      ch === CH_SLASH &&
+      source.charCodeAt(i + 1) !== CH_SLASH &&
+      source.charCodeAt(i + 1) !== CH_STAR &&
+      canPrecedeRegexWithKeywords(source, i)
+    ) {
+      i = skipRegex(source, i, len)
+      continue
+    }
+
+    if (ch === CH_LT) {
+      const nextCh = source.charCodeAt(i + 1)
+      if (
+        nextCh === CH_SLASH ||
+        nextCh === CH_DOT ||
+        nextCh === CH_GT ||
+        isIdentifierStartCode(nextCh)
+      ) {
+        i = skipJSX(source, i, len)
+        continue
+      }
+      i++
+      continue
+    }
+
+    if (isKeywordAt(source, i, 'import')) {
+      const parsed = parseImportStatementAt(source, i, len)
+      if (parsed) {
+        imports.push(parsed)
+        i = parsed.end
+        continue
+      }
+      i += 6
+      continue
+    }
+
+    i++
+  }
+
+  return imports
+}
+
 export function getDirectives(source: string): DirectiveResult {
   return analyzeModuleSource(source).directives
 }
@@ -853,4 +1140,233 @@ function skipRegex(source: string, i: number, len: number): number {
   }
 
   return i
+}
+
+export interface ExportDefaultValueLocation {
+  /** Start of the `export` keyword. */
+  readonly exportStart: number
+  /** Start of the exported value / declaration after `default`. */
+  readonly valueStart: number
+  /** End of the exported value (before an optional trailing semicolon). */
+  readonly valueEnd: number
+  /** End of the statement including a trailing semicolon when present. */
+  readonly statementEnd: number
+  /**
+   * Local binding name when the export is a named function/class declaration;
+   * null for expression exports that need a temporary binding.
+   */
+  readonly bindingName: string | null
+}
+
+/**
+ * Locate the first `export default …` statement with a correctly spanned
+ * expression body (brace/paren/bracket depth, strings, comments, JSX, regex).
+ * Avoids the classic `[^;]+` trap that truncates arrow-function bodies.
+ */
+export function locateExportDefaultValue(source: string): ExportDefaultValueLocation | null {
+  const len = source.length
+  let i = 0
+
+  while (i < len) {
+    const ch = source.charCodeAt(i)
+
+    if (isWhitespaceCode(ch)) {
+      i++
+      continue
+    }
+
+    if (ch === CH_SLASH && source.charCodeAt(i + 1) === CH_SLASH) {
+      i = skipSingleLineComment(source, i, len)
+      continue
+    }
+
+    if (ch === CH_SLASH && source.charCodeAt(i + 1) === CH_STAR) {
+      i = skipMultiLineComment(source, i, len)
+      continue
+    }
+
+    if (ch === CH_SINGLE_QUOTE || ch === CH_DOUBLE_QUOTE || ch === CH_BACKTICK) {
+      i = skipString(source, i, len, ch)
+      continue
+    }
+
+    if (
+      ch === CH_SLASH &&
+      source.charCodeAt(i + 1) !== CH_SLASH &&
+      source.charCodeAt(i + 1) !== CH_STAR &&
+      canPrecedeRegexWithKeywords(source, i)
+    ) {
+      i = skipRegex(source, i, len)
+      continue
+    }
+
+    if (ch === CH_LT) {
+      const nextCh = source.charCodeAt(i + 1)
+      if (
+        nextCh === CH_SLASH ||
+        nextCh === CH_DOT ||
+        nextCh === CH_GT ||
+        isIdentifierStartCode(nextCh)
+      ) {
+        i = skipJSX(source, i, len)
+        continue
+      }
+      i++
+      continue
+    }
+
+    if (isKeywordAt(source, i, 'export')) {
+      const afterExport = skipTrivia(source, i + 6, len)
+      if (!isKeywordAt(source, afterExport, 'default')) {
+        i++
+        continue
+      }
+
+      const valueStart = skipTrivia(source, afterExport + 7, len)
+      let pos = valueStart
+      let bindingName: string | null = null
+
+      if (isKeywordAt(source, pos, 'async')) {
+        const afterAsync = skipTrivia(source, pos + 5, len)
+        if (isKeywordAt(source, afterAsync, 'function')) pos = afterAsync
+      }
+
+      if (isKeywordAt(source, pos, 'function') || isKeywordAt(source, pos, 'class')) {
+        const keywordLen = isKeywordAt(source, pos, 'function') ? 8 : 5
+        let afterKeyword = skipTrivia(source, pos + keywordLen, len)
+        if (source.charCodeAt(afterKeyword) === CH_STAR) {
+          afterKeyword = skipTrivia(source, afterKeyword + 1, len)
+        }
+        const name = readIdentifier(source, afterKeyword, len)
+        if (name) bindingName = name.name
+      }
+
+      const valueEnd = scanExportDefaultValueEnd(source, valueStart, len)
+      const statementEnd = consumeTrailingSemicolon(source, valueEnd, len)
+
+      return {
+        exportStart: i,
+        valueStart,
+        valueEnd,
+        statementEnd,
+        bindingName,
+      }
+    }
+
+    i++
+  }
+
+  return null
+}
+
+function scanExportDefaultValueEnd(source: string, start: number, len: number): number {
+  let i = start
+  let paren = 0
+  let brace = 0
+  let bracket = 0
+
+  while (i < len) {
+    const ch = source.charCodeAt(i)
+
+    if (ch === CH_SINGLE_QUOTE || ch === CH_DOUBLE_QUOTE || ch === CH_BACKTICK) {
+      i = skipString(source, i, len, ch)
+      continue
+    }
+
+    if (ch === CH_SLASH && source.charCodeAt(i + 1) === CH_SLASH) {
+      i = skipSingleLineComment(source, i, len)
+      continue
+    }
+
+    if (ch === CH_SLASH && source.charCodeAt(i + 1) === CH_STAR) {
+      i = skipMultiLineComment(source, i, len)
+      continue
+    }
+
+    if (
+      ch === CH_SLASH &&
+      source.charCodeAt(i + 1) !== CH_SLASH &&
+      source.charCodeAt(i + 1) !== CH_STAR &&
+      canPrecedeRegexWithKeywords(source, i)
+    ) {
+      i = skipRegex(source, i, len)
+      continue
+    }
+
+    if (ch === CH_LT && paren === 0 && brace === 0 && bracket === 0) {
+      const nextCh = source.charCodeAt(i + 1)
+      if (
+        nextCh === CH_SLASH ||
+        nextCh === CH_DOT ||
+        nextCh === CH_GT ||
+        isIdentifierStartCode(nextCh)
+      ) {
+        i = skipJSX(source, i, len)
+        continue
+      }
+    }
+
+    if (ch === CH_OPEN_PAREN) {
+      paren++
+      i++
+      continue
+    }
+    if (ch === CH_CLOSE_PAREN) {
+      paren = Math.max(0, paren - 1)
+      i++
+      continue
+    }
+    if (ch === CH_OPEN_BRACE) {
+      brace++
+      i++
+      continue
+    }
+    if (ch === CH_CLOSE_BRACE) {
+      brace = Math.max(0, brace - 1)
+      i++
+      // Declaration bodies (`function () {}`, `class {}`) end when the outer
+      // brace closes at depth 0.
+      if (paren === 0 && brace === 0 && bracket === 0) return i
+      continue
+    }
+    if (ch === CH_OPEN_BRACKET) {
+      bracket++
+      i++
+      continue
+    }
+    if (ch === CH_CLOSE_BRACKET) {
+      bracket = Math.max(0, bracket - 1)
+      i++
+      continue
+    }
+
+    if (paren === 0 && brace === 0 && bracket === 0) {
+      if (ch === CH_SEMICOLON) return i
+      if (isLineTerminatorCode(ch)) {
+        // ASI: end the statement unless the next non-trivia token continues
+        // the expression (rare for `export default`; treat newline as end).
+        return i
+      }
+    }
+
+    i++
+  }
+
+  return i
+}
+
+/**
+ * Rewrite `export default <expr>` to
+ * `const <tempVar> = <expr>;\nexport default <tempVar>` so the binding can be
+ * passed to registerServerReference. Named function/class defaults are left
+ * alone (caller should register the declaration name directly).
+ */
+export function rewriteExportDefaultAsBinding(source: string, tempVarName: string): string | null {
+  const located = locateExportDefaultValue(source)
+  if (located == null || located.bindingName != null) return null
+
+  const value = source.slice(located.valueStart, located.valueEnd).trimEnd()
+  const rewritten = `const ${tempVarName} = ${value};\nexport default ${tempVarName}${source.slice(located.statementEnd)}`
+
+  return source.slice(0, located.exportStart) + rewritten
 }

--- a/packages/rari/src/vite/analysis/directives.ts
+++ b/packages/rari/src/vite/analysis/directives.ts
@@ -840,6 +840,120 @@ export function scanImportStatements(source: string): ScannedImport[] {
   return imports
 }
 
+export function collectExportNames(source: string): string[] {
+  const exports = new Set<string>()
+  let i = 0
+  const len = source.length
+
+  while (i < len) {
+    const skipped = skipNonCodeToken(source, i, len)
+    if (skipped !== -1) {
+      i = skipped
+      continue
+    }
+
+    if (!isKeywordAt(source, i, 'export')) {
+      i++
+      continue
+    }
+
+    let pos = skipTrivia(source, i + 6, len)
+
+    if (isKeywordAt(source, pos, 'type') || isKeywordAt(source, pos, 'interface')) {
+      i = pos + 1
+      continue
+    }
+
+    if (source.charCodeAt(pos) === CH_STAR) {
+      i = pos + 1
+      continue
+    }
+
+    if (isKeywordAt(source, pos, 'default')) {
+      exports.add('default')
+      i = pos + 7
+      continue
+    }
+
+    if (source.charCodeAt(pos) === CH_OPEN_BRACE) {
+      const close = skipBalancedBraceList(source, pos, len)
+      const list = source.slice(pos + 1, close - 1)
+      for (const part of list.split(',')) {
+        const trimmed = part.trim()
+        if (!trimmed || trimmed.startsWith('type ') || trimmed.startsWith('typeof ')) continue
+        const asParts = trimmed.split(/\s+as\s+/)
+        const exportedName = (asParts.at(-1) ?? '').trim()
+        if (exportedName !== '' && exportedName !== 'type') exports.add(exportedName)
+      }
+      i = close
+      continue
+    }
+
+    if (isKeywordAt(source, pos, 'async')) {
+      pos = skipTrivia(source, pos + 5, len)
+    }
+
+    if (
+      isKeywordAt(source, pos, 'function') ||
+      isKeywordAt(source, pos, 'class') ||
+      isKeywordAt(source, pos, 'const') ||
+      isKeywordAt(source, pos, 'let') ||
+      isKeywordAt(source, pos, 'var')
+    ) {
+      const keywordLen = isKeywordAt(source, pos, 'function')
+        ? 8
+        : isKeywordAt(source, pos, 'class')
+          ? 5
+          : isKeywordAt(source, pos, 'const')
+            ? 5
+            : 3
+      let after = skipTrivia(source, pos + keywordLen, len)
+      if (source.charCodeAt(after) === CH_STAR) after = skipTrivia(source, after + 1, len)
+      const name = readIdentifier(source, after, len)
+      if (name) exports.add(name.name)
+      i = name?.end ?? after + 1
+      continue
+    }
+
+    i++
+  }
+
+  return exports.size > 0 ? [...exports] : ['default']
+}
+
+function skipBalancedBraceList(source: string, start: number, len: number): number {
+  let i = start
+  let depth = 0
+  while (i < len) {
+    const ch = source.charCodeAt(i)
+    if (ch === CH_SINGLE_QUOTE || ch === CH_DOUBLE_QUOTE || ch === CH_BACKTICK) {
+      i = skipString(source, i, len, ch)
+      continue
+    }
+    if (ch === CH_SLASH && source.charCodeAt(i + 1) === CH_SLASH) {
+      i = skipSingleLineComment(source, i, len)
+      continue
+    }
+    if (ch === CH_SLASH && source.charCodeAt(i + 1) === CH_STAR) {
+      i = skipMultiLineComment(source, i, len)
+      continue
+    }
+    if (ch === CH_OPEN_BRACE) {
+      depth++
+      i++
+      continue
+    }
+    if (ch === CH_CLOSE_BRACE) {
+      depth--
+      i++
+      if (depth === 0) return i
+      continue
+    }
+    i++
+  }
+  return i
+}
+
 export function getDirectives(source: string): DirectiveResult {
   return analyzeModuleSource(source).directives
 }
@@ -1018,6 +1132,64 @@ function canPrecedeRegexWithKeywords(source: string, pos: number): boolean {
   return false
 }
 
+const JSX_PRECEDE_KEYWORDS = new Set([
+  'return',
+  'throw',
+  'case',
+  'default',
+  'else',
+  'do',
+  'typeof',
+  'void',
+  'yield',
+  'await',
+  'delete',
+])
+
+function canPrecedeJSX(source: string, pos: number): boolean {
+  const prevCharCode = getPreviousNonTriviaCharCode(source, pos)
+  if (prevCharCode === -1) return true
+
+  if (isIdentifierPartCode(prevCharCode) || (prevCharCode >= CH_0 && prevCharCode <= CH_9)) {
+    const prevToken = getPreviousToken(source, pos)
+    return prevToken != null && prevToken !== '' && JSX_PRECEDE_KEYWORDS.has(prevToken)
+  }
+
+  if (
+    prevCharCode === CH_CLOSE_PAREN ||
+    prevCharCode === CH_CLOSE_BRACKET ||
+    prevCharCode === CH_CLOSE_BRACE
+  ) {
+    return false
+  }
+
+  return true
+}
+
+/**
+ * Try to skip a JSX tag/element at `i`. Returns the offset past a completed
+ * tag (ending in `>`), or -1 when `<` is not JSX (comparison, generics, etc.).
+ */
+function trySkipJSX(source: string, i: number, len: number): number {
+  if (!canPrecedeJSX(source, i)) return -1
+
+  const nextCh = source.charCodeAt(i + 1)
+  if (
+    nextCh !== CH_SLASH &&
+    nextCh !== CH_DOT &&
+    nextCh !== CH_GT &&
+    !isIdentifierStartCode(nextCh)
+  ) {
+    return -1
+  }
+
+  let end = skipJSX(source, i, len)
+  // skipJSX may stop after a closing tag name before consuming `>`.
+  if (end < len && source.charCodeAt(end) === CH_GT) end++
+  if (end > i && source.charCodeAt(end - 1) === CH_GT) return end
+  return -1
+}
+
 function skipRegex(source: string, i: number, len: number): number {
   i++
   let inCharClass = false
@@ -1092,15 +1264,8 @@ export function skipNonCodeToken(source: string, i: number, len: number): number
   }
 
   if (ch === CH_LT) {
-    const nextCh = source.charCodeAt(i + 1)
-    if (
-      nextCh === CH_SLASH ||
-      nextCh === CH_DOT ||
-      nextCh === CH_GT ||
-      isIdentifierStartCode(nextCh)
-    ) {
-      return skipJSX(source, i, len)
-    }
+    const jsxEnd = trySkipJSX(source, i, len)
+    if (jsxEnd !== -1) return jsxEnd
   }
 
   return -1
@@ -1271,14 +1436,9 @@ function scanExportDefaultValueEnd(source: string, start: number, len: number): 
     }
 
     if (ch === CH_LT && paren === 0 && brace === 0 && bracket === 0) {
-      const nextCh = source.charCodeAt(i + 1)
-      if (
-        nextCh === CH_SLASH ||
-        nextCh === CH_DOT ||
-        nextCh === CH_GT ||
-        isIdentifierStartCode(nextCh)
-      ) {
-        i = skipJSX(source, i, len)
+      const jsxEnd = trySkipJSX(source, i, len)
+      if (jsxEnd !== -1) {
+        i = jsxEnd
         lastCanTerminate = true
         continue
       }

--- a/packages/rari/src/vite/analysis/directives.ts
+++ b/packages/rari/src/vite/analysis/directives.ts
@@ -1066,7 +1066,7 @@ function skipRegex(source: string, i: number, len: number): number {
  * If `source[i]` starts whitespace, a comment, string, regex literal, or JSX,
  * return the offset past that token. Returns -1 when the position is code.
  */
-function skipNonCodeToken(source: string, i: number, len: number): number {
+export function skipNonCodeToken(source: string, i: number, len: number): number {
   if (i >= len) return -1
 
   const ch = source.charCodeAt(i)

--- a/packages/rari/src/vite/index.ts
+++ b/packages/rari/src/vite/index.ts
@@ -74,6 +74,7 @@ import {
 } from './server/build'
 import { buildClientReferenceReplacementFromImport } from './transform/client-import'
 import { parseHtmlEntryImports } from './transform/html-entry'
+import { transformInlineServerActions } from './transform/inline-server-action'
 import { transformDefineMdxComponents } from './transform/mdx-components'
 import { getUseCacheTransform } from './transform/use-cache'
 
@@ -513,19 +514,35 @@ export function rari(options: RariOptions = {}): RariPlugin[] {
   }
 
   function transformServerModule(code: string, id: string, analysis: ModuleAnalysis): string {
-    if (!analysis.topLevelUseServer) return code
-
-    const exportedNames = parseExportedNames(code, analysis)
-    if (exportedNames.length === 0) return code
-
     const projectRoot =
       options.projectRoot != null && options.projectRoot !== ''
         ? options.projectRoot
         : process.cwd()
     const moduleId = getComponentId(id, projectRoot)
+
+    const inlineTransformed = transformInlineServerActions(code, moduleId)
+    let newCode = inlineTransformed?.code ?? code
+
+    if (!analysis.topLevelUseServer) {
+      if (inlineTransformed == null) return code
+      newCode += `
+
+if (import.meta.hot) {
+  import.meta.hot.accept(() => {
+  });
+}`
+      return newCode
+    }
+
+    const exportedNames = parseExportedNames(newCode, analysis)
+    if (exportedNames.length === 0 && inlineTransformed == null) return code
+
     const idJson = JSON.stringify(moduleId)
-    let newCode = code
-    newCode += '\n\nimport {registerServerReference} from "react-server-dom-rari/server";\n'
+    if (!newCode.includes('registerServerReference')) {
+      newCode += '\n\nimport {registerServerReference} from "react-server-dom-rari/server";\n'
+    } else {
+      newCode += '\n'
+    }
 
     for (const name of exportedNames) {
       if (name === 'default') {
@@ -546,6 +563,9 @@ export function rari(options: RariOptions = {}): RariPlugin[] {
             newCode += `}\n`
           }
         }
+      } else if (inlineTransformed?.actionNames.includes(name)) {
+        // Already registered by the inline-action hoist.
+        continue
       } else {
         newCode += `\n// Register server reference for ${name}\n`
         newCode += `if (typeof ${name} === "function") {\n`
@@ -1114,6 +1134,7 @@ ${clientTransformedCode}`
       let needsReactImport = false
       const importingFileIsClient = id.includes('entry-client')
       const replacements: Array<{ start: number; end: number; replacement: string }> = []
+      const clientRefHelpers = new Set<string>()
 
       for (const imp of scanImportStatements(code)) {
         if (imp.typeOnly || imp.sideEffectOnly) continue
@@ -1143,12 +1164,14 @@ ${clientTransformedCode}`
           imp,
           resolvedImportPath,
         )
-        if (clientRefReplacement === '') continue
+        if (clientRefReplacement.code === '') continue
+
+        for (const helper of clientRefReplacement.helpers) clientRefHelpers.add(helper)
 
         replacements.push({
           start: imp.start,
           end: imp.end,
-          replacement: clientRefReplacement,
+          replacement: clientRefReplacement.code,
         })
         hasServerImports = true
         needsReactImport = true
@@ -1156,6 +1179,11 @@ ${clientTransformedCode}`
 
       for (const { start, end, replacement } of [...replacements].sort((a, b) => b.start - a.start))
         modifiedCode = modifiedCode.slice(0, start) + replacement + modifiedCode.slice(end)
+
+      if (clientRefHelpers.size > 0) {
+        const helperList = [...clientRefHelpers].join(', ')
+        modifiedCode = `import { ${helperList} } from "react-server-dom-rari/server";\n${modifiedCode}`
+      }
 
       if (hasServerImports) {
         const hasReactImport =

--- a/packages/rari/src/vite/index.ts
+++ b/packages/rari/src/vite/index.ts
@@ -46,6 +46,7 @@ import {
 } from '@/shared/utils/type-guards'
 import { getComponentId } from './analysis/component-ids'
 import {
+  collectExportNames,
   hasDefaultExport,
   rewriteExportDefaultAsBinding,
   scanImportStatements,
@@ -96,11 +97,7 @@ const IMPORT_SPECIFIER_REGEX = /import\s+(\{[^}]+\})\s+from\s+["']\.\.?\/([^"']+
 const IMPORT_NAMESPACE_REGEX = /import\s+(\*\s+as\s+\w+)\s+from\s+["']\.\.?\/([^"']+)["'];?/g
 const IMPORT_DEFAULT_REGEX = /import\s+(\w+)\s+from\s+["']\.\.?\/([^"']+)["'];?/g
 const IMPORT_SIDE_EFFECT_REGEX = /import\s+["']\.\.?\/([^"']+)["'];?/g
-const NAMED_EXPORT_REGEX = /export\s*\{([^}]+)\}/g
-const AS_SPLIT_REGEX = /\s+as\s+/
-const EXPORT_DEFAULT_FUNCTION_OR_CLASS_REGEX = /export\s+default\s+(?:function|class)\s+\w+/
 const EXPORT_DEFAULT_FUNCTION_DECL_REGEX = /export\s+default\s+(?:async\s+)?function\s+(\w+)/
-const EXPORT_DECLARATION_REGEX = /export\s+(?:async\s+)?(?:const|let|var|function|class)\s+(\w+)/g
 const USE_CLIENT_DIRECTIVE_REGEX = /^['"]use client['"];?\s*$/gm
 const IMPORT_REGEX = /import\s+["']([^"']+)["']/g
 const LOCAL_IMPORT_SOURCE_REGEX = /^[./@~#]/
@@ -500,27 +497,9 @@ export function rari(options: RariOptions = {}): RariPlugin[] {
 
   function parseExportedNames(code: string, analysis?: ModuleAnalysis): string[] {
     try {
-      const exportedNames: string[] = []
-      const namedExportMatch = code.matchAll(NAMED_EXPORT_REGEX)
-      for (const match of namedExportMatch) {
-        const exports = match[1].split(',')
-        for (const exp of exports) {
-          const trimmed = exp.trim()
-          const parts = trimmed.split(AS_SPLIT_REGEX)
-          const exportedName = parts.at(-1)?.trim()
-          if (exportedName != null && exportedName !== '') exportedNames.push(exportedName)
-        }
-      }
-
-      if (EXPORT_DEFAULT_FUNCTION_OR_CLASS_REGEX.test(code)) exportedNames.push('default')
-      else if (analysis?.hasDefaultExport ?? hasDefaultExport(code)) exportedNames.push('default')
-
-      const declarationExports = code.matchAll(EXPORT_DECLARATION_REGEX)
-      for (const match of declarationExports) {
-        if (match[1]) exportedNames.push(match[1])
-      }
-
-      return [...new Set(exportedNames)]
+      const exportedNames = new Set(collectExportNames(code))
+      if (analysis?.hasDefaultExport ?? hasDefaultExport(code)) exportedNames.add('default')
+      return [...exportedNames]
     } catch {
       return []
     }
@@ -576,8 +555,8 @@ if (import.meta.hot) {
             newCode += `}\n`
           }
         }
-      } else if (inlineTransformed?.actionNames.includes(name)) {
-        // Already registered by the inline-action hoist.
+      } else if (inlineTransformed?.rewrittenExportNames.includes(name)) {
+        // Already registered by the inline-action hoist under this export name.
         continue
       } else {
         newCode += `\n// Register server reference for ${name}\n`

--- a/packages/rari/src/vite/index.ts
+++ b/packages/rari/src/vite/index.ts
@@ -72,7 +72,10 @@ import {
   scanDirectory,
   ServerComponentBuilder,
 } from './server/build'
-import { buildClientReferenceReplacementFromImport } from './transform/client-import'
+import {
+  buildClientReferenceReplacementFromImport,
+  ensureNamedImportFromModule,
+} from './transform/client-import'
 import { parseHtmlEntryImports } from './transform/html-entry'
 import {
   hasRegisterServerReferenceImport,
@@ -101,6 +104,13 @@ const EXPORT_DECLARATION_REGEX = /export\s+(?:async\s+)?(?:const|let|var|functio
 const USE_CLIENT_DIRECTIVE_REGEX = /^['"]use client['"];?\s*$/gm
 const IMPORT_REGEX = /import\s+["']([^"']+)["']/g
 const LOCAL_IMPORT_SOURCE_REGEX = /^[./@~#]/
+
+function matchesAliasImport(source: string, aliases: Readonly<Record<string, string>>): boolean {
+  for (const alias of Object.keys(aliases)) {
+    if (source === alias || source.startsWith(`${alias}/`)) return true
+  }
+  return false
+}
 
 const REACT_IMPORT_REGEX = /import\s+\{[^}]*\}\s+from\s+['"]react['"]/
 const REACT_IMPORT_WITH_DEFAULT_REGEX = /import\s+[^,\s]+\s*,\s*\{[^}]*\}\s+from\s+['"]react['"]/
@@ -1070,7 +1080,12 @@ if (import.meta.hot) {
         addTrackedClientComponent(id)
 
         for (const importPath of moduleAnalysis.importSources) {
-          if (!LOCAL_IMPORT_SOURCE_REGEX.test(importPath)) continue
+          if (
+            !LOCAL_IMPORT_SOURCE_REGEX.test(importPath) &&
+            !matchesAliasImport(importPath, resolvedAlias)
+          ) {
+            continue
+          }
 
           const resolvedImportPath = resolveImportToFilePath(importPath, id, resolvedAlias)
 
@@ -1141,7 +1156,12 @@ ${clientTransformedCode}`
 
       for (const imp of scanImportStatements(code)) {
         if (imp.typeOnly || imp.sideEffectOnly) continue
-        if (!LOCAL_IMPORT_SOURCE_REGEX.test(imp.source)) continue
+        if (
+          !LOCAL_IMPORT_SOURCE_REGEX.test(imp.source) &&
+          !matchesAliasImport(imp.source, resolvedAlias)
+        ) {
+          continue
+        }
 
         const resolvedImportPath = resolveImportToFilePath(imp.source, id, resolvedAlias)
 
@@ -1184,8 +1204,9 @@ ${clientTransformedCode}`
         modifiedCode = modifiedCode.slice(0, start) + replacement + modifiedCode.slice(end)
 
       if (clientRefHelpers.size > 0) {
-        const helperList = [...clientRefHelpers].join(', ')
-        modifiedCode = `import { ${helperList} } from "react-server-dom-rari/server";\n${modifiedCode}`
+        modifiedCode = ensureNamedImportFromModule(modifiedCode, 'react-server-dom-rari/server', [
+          ...clientRefHelpers,
+        ])
       }
 
       if (hasServerImports) {

--- a/packages/rari/src/vite/index.ts
+++ b/packages/rari/src/vite/index.ts
@@ -45,7 +45,11 @@ import {
   parseJsonRecord,
 } from '@/shared/utils/type-guards'
 import { getComponentId } from './analysis/component-ids'
-import { hasDefaultExport } from './analysis/directives'
+import {
+  hasDefaultExport,
+  rewriteExportDefaultAsBinding,
+  scanImportStatements,
+} from './analysis/directives'
 import {
   collectClientComponentPaths,
   invalidateModuleCachePath,
@@ -68,10 +72,7 @@ import {
   scanDirectory,
   ServerComponentBuilder,
 } from './server/build'
-import {
-  buildNamespaceClientReferenceReplacement,
-  NAMESPACE_IMPORT_LINE_REGEX,
-} from './transform/client-import'
+import { buildClientReferenceReplacementFromImport } from './transform/client-import'
 import { parseHtmlEntryImports } from './transform/html-entry'
 import { transformDefineMdxComponents } from './transform/mdx-components'
 import { getUseCacheTransform } from './transform/use-cache'
@@ -92,12 +93,10 @@ const NAMED_EXPORT_REGEX = /export\s*\{([^}]+)\}/g
 const AS_SPLIT_REGEX = /\s+as\s+/
 const EXPORT_DEFAULT_FUNCTION_OR_CLASS_REGEX = /export\s+default\s+(?:function|class)\s+\w+/
 const EXPORT_DEFAULT_FUNCTION_DECL_REGEX = /export\s+default\s+(?:async\s+)?function\s+(\w+)/
-const EXPORT_DEFAULT_VALUE_REGEX = /export\s+default\s+([^;]+)/
 const EXPORT_DECLARATION_REGEX = /export\s+(?:async\s+)?(?:const|let|var|function|class)\s+(\w+)/g
 const USE_CLIENT_DIRECTIVE_REGEX = /^['"]use client['"];?\s*$/gm
 const IMPORT_REGEX = /import\s+["']([^"']+)["']/g
-const IMPORT_LINE_REGEX =
-  /^\s*import\s+(?:(\w+)(?:\s*,\s*\{\s*(?:(\w+(?:\s*,\s*\w+)*)\s*)?\})?|\{\s*(\w+(?:\s*,\s*\w+)*)\s*\})\s+from\s+['"]([./@][^'"]+)['"].*$/
+const LOCAL_IMPORT_SOURCE_REGEX = /^[./@]/
 
 const REACT_IMPORT_REGEX = /import\s+\{[^}]*\}\s+from\s+['"]react['"]/
 const REACT_IMPORT_WITH_DEFAULT_REGEX = /import\s+[^,\s]+\s*,\s*\{[^}]*\}\s+from\s+['"]react['"]/
@@ -108,59 +107,6 @@ const RSC_CLIENT_IMPORT_REGEX =
 const JSX_TEST_REGEX = /\bJSX\b/
 const IMPORT_SPECIFIERS_REGEX = /\{([^}]*)\}/
 const USE_CLIENT_DIRECTIVE_LINE_REGEX = /^['"]use client['"];?\s*\n/
-
-interface ClientReferenceSpecifier {
-  readonly bindingName: string
-  readonly exportName: string
-}
-
-function parseClientImportSpecifiers(
-  line: string,
-  importedDefault?: string,
-): ClientReferenceSpecifier[] {
-  const specifiers: ClientReferenceSpecifier[] = []
-
-  if (importedDefault != null && importedDefault !== '')
-    specifiers.push({ bindingName: importedDefault, exportName: 'default' })
-
-  const namedBlock = /\{([^}]+)\}/.exec(line)?.[1]
-  if (namedBlock != null && namedBlock !== '') {
-    for (const part of namedBlock.split(',')) {
-      const trimmed = part.trim()
-      if (!trimmed) continue
-
-      const asParts = trimmed.split(/\s+as\s+/i)
-      if (asParts.length === 2 && asParts[0] && asParts[1]) {
-        specifiers.push({
-          bindingName: asParts[1].trim(),
-          exportName: asParts[0].trim(),
-        })
-      } else {
-        specifiers.push({ bindingName: trimmed, exportName: trimmed })
-      }
-    }
-  }
-
-  return specifiers
-}
-
-function buildClientReferenceReplacement(
-  specifiers: readonly ClientReferenceSpecifier[],
-  resolvedImportPath: string,
-): string {
-  return `import { registerClientReference } from "react-server-dom-rari/server";
-${specifiers
-  .map(
-    ({ bindingName, exportName }) => `const ${bindingName} = registerClientReference(
-  function() {
-    throw new Error("Attempted to call ${bindingName} from the server but it's on the client. It can only be rendered as a Component or passed to props of a Client Component.");
-  },
-  ${JSON.stringify(resolvedImportPath)},
-  ${JSON.stringify(exportName)}
-);`,
-  )
-  .join('\n')}`
-}
 
 export interface RouterPluginOptions {
   readonly appDir?: string
@@ -590,14 +536,10 @@ export function rari(options: RariOptions = {}): RariPlugin[] {
           newCode += `\n// Register server reference for default export\n`
           newCode += `registerServerReference(${functionName}, ${idJson}, ${JSON.stringify(name)});\n`
         } else {
-          const match = EXPORT_DEFAULT_VALUE_REGEX.exec(code)
-          if (match) {
-            const exportedValue = match[1].trim()
-            const tempVarName = '__default_export__'
-            newCode = newCode.replace(
-              EXPORT_DEFAULT_VALUE_REGEX,
-              `const ${tempVarName} = ${exportedValue};\nexport default ${tempVarName}`,
-            )
+          const tempVarName = '__default_export__'
+          const rewritten = rewriteExportDefaultAsBinding(newCode, tempVarName)
+          if (rewritten != null) {
+            newCode = rewritten
             newCode += `\n// Register server reference for default export\n`
             newCode += `if (typeof ${tempVarName} === "function") {\n`
             newCode += `  registerServerReference(${tempVarName}, ${idJson}, ${JSON.stringify(name)});\n`
@@ -1104,15 +1046,8 @@ if (import.meta.hot) {
         setComponentType(id, 'client')
         addTrackedClientComponent(id)
 
-        const lines = code.split('\n')
-
-        for (const line of lines) {
-          const namespaceMatch = line.match(NAMESPACE_IMPORT_LINE_REGEX)
-          const importMatch = namespaceMatch ? null : IMPORT_LINE_REGEX.exec(line)
-          if (!namespaceMatch && !importMatch) continue
-
-          const importPath = namespaceMatch?.[2] ?? importMatch![4]
-          if (!importPath) continue
+        for (const importPath of moduleAnalysis.importSources) {
+          if (!LOCAL_IMPORT_SOURCE_REGEX.test(importPath)) continue
 
           const resolvedImportPath = resolveImportToFilePath(importPath, id, resolvedAlias)
 
@@ -1174,20 +1109,17 @@ ${clientTransformedCode}`
 
       setComponentType(id, 'unknown')
 
-      const lines = code.split('\n')
       let modifiedCode = code
       let hasServerImports = false
       let needsReactImport = false
       const importingFileIsClient = id.includes('entry-client')
+      const replacements: Array<{ start: number; end: number; replacement: string }> = []
 
-      for (const line of lines) {
-        const namespaceMatch = line.match(NAMESPACE_IMPORT_LINE_REGEX)
-        const importMatch = namespaceMatch ? null : IMPORT_LINE_REGEX.exec(line)
-        if (!namespaceMatch && !importMatch) continue
+      for (const imp of scanImportStatements(code)) {
+        if (imp.typeOnly || imp.sideEffectOnly) continue
+        if (!LOCAL_IMPORT_SOURCE_REGEX.test(imp.source)) continue
 
-        const importedDefault = importMatch?.[1]
-        const importPath = namespaceMatch?.[2] ?? importMatch![4]
-        const resolvedImportPath = resolveImportToFilePath(importPath, id, resolvedAlias)
+        const resolvedImportPath = resolveImportToFilePath(imp.source, id, resolvedAlias)
 
         const isClientComponent =
           getComponentType(resolvedImportPath) === 'client' ||
@@ -1199,36 +1131,31 @@ ${clientTransformedCode}`
           addTrackedClientComponent(resolvedImportPath)
         }
 
-        if (isClientComponent && (environment.name === 'rsc' || environment.name === 'ssr')) {
-          if (!importingFileIsClient) {
-            const originalImport = line
-
-            if (namespaceMatch) {
-              const clientRefReplacement = buildNamespaceClientReferenceReplacement(
-                namespaceMatch[1],
-                resolvedImportPath,
-              )
-
-              modifiedCode = modifiedCode.replace(originalImport, clientRefReplacement)
-              hasServerImports = true
-              needsReactImport = true
-              continue
-            }
-
-            const specifiers = parseClientImportSpecifiers(line, importedDefault)
-            if (specifiers.length === 0) continue
-
-            const clientRefReplacement = buildClientReferenceReplacement(
-              specifiers,
-              resolvedImportPath,
-            )
-
-            modifiedCode = modifiedCode.replace(originalImport, clientRefReplacement)
-            hasServerImports = true
-            needsReactImport = true
-          }
+        if (
+          !isClientComponent ||
+          importingFileIsClient ||
+          (environment.name !== 'rsc' && environment.name !== 'ssr')
+        ) {
+          continue
         }
+
+        const clientRefReplacement = buildClientReferenceReplacementFromImport(
+          imp,
+          resolvedImportPath,
+        )
+        if (clientRefReplacement === '') continue
+
+        replacements.push({
+          start: imp.start,
+          end: imp.end,
+          replacement: clientRefReplacement,
+        })
+        hasServerImports = true
+        needsReactImport = true
       }
+
+      for (const { start, end, replacement } of [...replacements].sort((a, b) => b.start - a.start))
+        modifiedCode = modifiedCode.slice(0, start) + replacement + modifiedCode.slice(end)
 
       if (hasServerImports) {
         const hasReactImport =

--- a/packages/rari/src/vite/index.ts
+++ b/packages/rari/src/vite/index.ts
@@ -74,7 +74,10 @@ import {
 } from './server/build'
 import { buildClientReferenceReplacementFromImport } from './transform/client-import'
 import { parseHtmlEntryImports } from './transform/html-entry'
-import { transformInlineServerActions } from './transform/inline-server-action'
+import {
+  hasRegisterServerReferenceImport,
+  transformInlineServerActions,
+} from './transform/inline-server-action'
 import { transformDefineMdxComponents } from './transform/mdx-components'
 import { getUseCacheTransform } from './transform/use-cache'
 
@@ -97,7 +100,7 @@ const EXPORT_DEFAULT_FUNCTION_DECL_REGEX = /export\s+default\s+(?:async\s+)?func
 const EXPORT_DECLARATION_REGEX = /export\s+(?:async\s+)?(?:const|let|var|function|class)\s+(\w+)/g
 const USE_CLIENT_DIRECTIVE_REGEX = /^['"]use client['"];?\s*$/gm
 const IMPORT_REGEX = /import\s+["']([^"']+)["']/g
-const LOCAL_IMPORT_SOURCE_REGEX = /^[./@]/
+const LOCAL_IMPORT_SOURCE_REGEX = /^[./@~#]/
 
 const REACT_IMPORT_REGEX = /import\s+\{[^}]*\}\s+from\s+['"]react['"]/
 const REACT_IMPORT_WITH_DEFAULT_REGEX = /import\s+[^,\s]+\s*,\s*\{[^}]*\}\s+from\s+['"]react['"]/
@@ -538,7 +541,7 @@ if (import.meta.hot) {
     if (exportedNames.length === 0 && inlineTransformed == null) return code
 
     const idJson = JSON.stringify(moduleId)
-    if (!newCode.includes('registerServerReference')) {
+    if (!hasRegisterServerReferenceImport(newCode)) {
       newCode += '\n\nimport {registerServerReference} from "react-server-dom-rari/server";\n'
     } else {
       newCode += '\n'
@@ -546,7 +549,7 @@ if (import.meta.hot) {
 
     for (const name of exportedNames) {
       if (name === 'default') {
-        const functionDeclMatch = EXPORT_DEFAULT_FUNCTION_DECL_REGEX.exec(code)
+        const functionDeclMatch = EXPORT_DEFAULT_FUNCTION_DECL_REGEX.exec(newCode)
 
         if (functionDeclMatch) {
           const functionName = functionDeclMatch[1]

--- a/packages/rari/src/vite/server/build.ts
+++ b/packages/rari/src/vite/server/build.ts
@@ -48,15 +48,24 @@ import {
 } from '../analysis/module-cache'
 import { collectSourceFilePaths, normalizeScanDirs } from '../analysis/source-walker'
 import { resolveMdxRegistryEntries } from '../mdx/registry'
+import {
+  buildClientReferenceStubModule,
+  collectExportNames,
+} from '../transform/client-reference-stub'
+import {
+  buildGlobalClientComponentWrapper,
+  buildGlobalClientNamespaceWrapper,
+} from '../transform/component-global'
 import { parseHtmlEntryImports } from '../transform/html-entry'
+import { transformInlineServerActions } from '../transform/inline-server-action'
 import { getUseCacheTransform } from '../transform/use-cache'
 
-const COMPONENT_IMPORT_REGEX = /import\s+(\w+)\s+from\s+['"]([^'"]+)['"]/g
 const PROXY_FILE_REGEX = /^proxy\.(?:tsx?|jsx?|mts|mjs)$/
 const COMPONENTS_PATH_REGEX = /\/components\/(\w+)(?:\.tsx?|\.jsx?)?$/
-const COMPONENTS_PATH_ALT_REGEX = /[/\\]components[/\\](\w+)(?:\.tsx?|\.jsx?)?$/
+const COMPONENTS_PATH_ALT_REGEX = /[/\\]components[/\\]\w+(?:\.tsx?|\.jsx?)?$/
 const SPECIAL_FILE_REGEX = /^(?:robots|sitemap|feed)\.(?:tsx?|jsx?)$/
 const RSC_REFERENCES_IMPORT = 'react-server-dom-rari/server'
+const LOCAL_IMPORT_SOURCE_REGEX = /^[./@]/
 const NODE_PROTOCOL_REGEX = /^node:/
 export const RARI_CSS_MODULES_PATTERN = '[hash]_[local]'
 
@@ -652,137 +661,128 @@ export class ServerComponentBuilder {
     return components
   }
 
-  private transformComponentImportsToGlobal(code: string): string {
-    const replacements: Array<{ original: string; replacement: string }> = []
+  /**
+   * Resolve a page import to a client component under src/components when
+   * present. Returns the registry key used by ~clientComponents.
+   */
+  private resolveComponentsDirClientImport(
+    importPath: string,
+  ): { registryKey: string; absolutePath: string } | null {
+    if (
+      !importPath.startsWith('.') &&
+      !importPath.startsWith('@') &&
+      !importPath.startsWith('~') &&
+      !importPath.startsWith('#')
+    ) {
+      return null
+    }
 
-    for (const match of code.matchAll(COMPONENT_IMPORT_REGEX)) {
-      const [fullMatch, importName, importPath] = match
+    if (importPath.startsWith('.')) {
+      if (!importPath.includes('/components/')) return null
 
-      if (
-        !importPath.startsWith('.') &&
-        !importPath.startsWith('@') &&
-        !importPath.startsWith('~') &&
-        !importPath.startsWith('#')
-      )
-        continue
+      const componentMatch = COMPONENTS_PATH_REGEX.exec(importPath)
+      if (!componentMatch) return null
 
-      let resolvedPath: string | null = null
+      const componentName = componentMatch[1]
+      const possiblePaths = [
+        path.resolve(this.projectRoot, 'src', 'components', `${componentName}.tsx`),
+        path.resolve(this.projectRoot, 'src', 'components', `${componentName}.ts`),
+        path.resolve(this.projectRoot, 'src', 'components', `${componentName}.jsx`),
+        path.resolve(this.projectRoot, 'src', 'components', `${componentName}.js`),
+      ]
 
-      if (importPath.startsWith('.')) {
-        if (importPath.includes('/components/')) {
-          const componentMatch = COMPONENTS_PATH_REGEX.exec(importPath)
-          if (componentMatch) {
-            const componentName = componentMatch[1]
-
-            const possiblePaths = [
-              path.resolve(this.projectRoot, 'src', 'components', `${componentName}.tsx`),
-              path.resolve(this.projectRoot, 'src', 'components', `${componentName}.ts`),
-              path.resolve(this.projectRoot, 'src', 'components', `${componentName}.jsx`),
-              path.resolve(this.projectRoot, 'src', 'components', `${componentName}.js`),
-            ]
-
-            let isClient = false
-            for (const possiblePath of possiblePaths) {
-              if (fs.existsSync(possiblePath) && this.isClientComponent(possiblePath)) {
-                isClient = true
-                break
-              }
-            }
-
-            if (!isClient) continue
-
-            const replacement = `// Component reference: ${componentName}
-const ${importName} = (props) => {
-  let Component = globalThis['~clientComponents']?.['components/${componentName}']?.component
-    || globalThis['components/${componentName}'];
-
-  if (Component && typeof Component === 'object' && Component.default) {
-    Component = Component.default;
-  }
-
-  if (!Component) {
-    throw new Error('Component components/${componentName} not loaded');
-  }
-
-  if (typeof Component !== 'function') {
-    throw new Error('Component components/${componentName} is not a function, got: ' + typeof Component);
-  }
-
-  return Component(props);
-}`
-            replacements.push({ original: fullMatch, replacement })
+      for (const possiblePath of possiblePaths) {
+        if (fs.existsSync(possiblePath) && this.isClientComponent(possiblePath)) {
+          return {
+            registryKey: `components/${componentName}`,
+            absolutePath: possiblePath,
           }
-        }
-        continue
-      }
-
-      const aliases = this.options.alias
-      for (const [alias, replacement] of Object.entries(aliases)) {
-        if (importPath.startsWith(`${alias}/`) || importPath === alias) {
-          const relativePath = importPath.slice(alias.length).replace(/^\/+/, '')
-          resolvedPath = path.join(replacement, relativePath)
-          break
         }
       }
 
-      if (resolvedPath != null && resolvedPath !== '') {
-        const componentMatch = COMPONENTS_PATH_ALT_REGEX.exec(resolvedPath)
-        if (componentMatch) {
-          const componentName = componentMatch[1]
+      return null
+    }
 
-          const absolutePath = path.isAbsolute(resolvedPath)
-            ? resolvedPath
-            : path.resolve(this.projectRoot, resolvedPath)
+    let resolvedPath: string | null = null
+    for (const [alias, replacement] of Object.entries(this.options.alias)) {
+      if (importPath.startsWith(`${alias}/`) || importPath === alias) {
+        const relativePath = importPath.slice(alias.length).replace(/^\/+/, '')
+        resolvedPath = path.join(replacement, relativePath)
+        break
+      }
+    }
 
-          const possiblePaths = [
-            absolutePath,
-            `${absolutePath}.tsx`,
-            `${absolutePath}.ts`,
-            `${absolutePath}.jsx`,
-            `${absolutePath}.js`,
-          ]
+    if (resolvedPath == null || resolvedPath === '') return null
 
-          let isClient = false
-          let actualPath = absolutePath
-          for (const possiblePath of possiblePaths) {
-            if (fs.existsSync(possiblePath)) {
-              actualPath = possiblePath
-              if (this.isClientComponent(possiblePath)) isClient = true
-              break
-            }
-          }
+    const componentMatch = COMPONENTS_PATH_ALT_REGEX.exec(resolvedPath)
+    if (!componentMatch) return null
 
-          if (!isClient) continue
+    const absolutePath = path.isAbsolute(resolvedPath)
+      ? resolvedPath
+      : path.resolve(this.projectRoot, resolvedPath)
 
-          const componentId = this.getComponentReferenceId(actualPath)
+    const possiblePaths = [
+      absolutePath,
+      `${absolutePath}.tsx`,
+      `${absolutePath}.ts`,
+      `${absolutePath}.jsx`,
+      `${absolutePath}.js`,
+    ]
 
-          const replacement = `// Component reference: ${componentName}
-const ${importName} = (props) => {
-  let Component = globalThis['~clientComponents']?.['${componentId}']?.component
-    || globalThis['${componentId}'];
-
-  if (Component && typeof Component === 'object' && Component.default) {
-    Component = Component.default;
-  }
-
-  if (!Component) {
-    throw new Error('Component ${componentId} not loaded');
-  }
-
-  if (typeof Component !== 'function') {
-    throw new Error('Component ${componentId} is not a function, got: ' + typeof Component);
-  }
-
-  return Component(props);
-}`
-          replacements.push({ original: fullMatch, replacement })
+    for (const possiblePath of possiblePaths) {
+      if (fs.existsSync(possiblePath) && this.isClientComponent(possiblePath)) {
+        return {
+          registryKey: this.getComponentReferenceId(possiblePath),
+          absolutePath: possiblePath,
         }
       }
     }
 
+    return null
+  }
+
+  private transformComponentImportsToGlobal(code: string): string {
+    const replacements: Array<{ start: number; end: number; replacement: string }> = []
+
+    for (const imp of scanImportStatements(code)) {
+      if (imp.typeOnly || imp.sideEffectOnly) continue
+
+      const resolved = this.resolveComponentsDirClientImport(imp.source)
+      if (resolved == null) continue
+
+      const parts: string[] = []
+
+      if (imp.namespaceBinding != null) {
+        parts.push(buildGlobalClientNamespaceWrapper(imp.namespaceBinding, resolved.registryKey))
+      }
+
+      if (imp.defaultBinding != null) {
+        parts.push(
+          buildGlobalClientComponentWrapper(imp.defaultBinding, resolved.registryKey, 'default'),
+        )
+      }
+
+      for (const spec of imp.named) {
+        if (spec.typeOnly) continue
+        parts.push(
+          buildGlobalClientComponentWrapper(spec.local, resolved.registryKey, spec.imported),
+        )
+      }
+
+      if (parts.length === 0) continue
+
+      replacements.push({
+        start: imp.start,
+        end: imp.end,
+        replacement: parts.join('\n'),
+      })
+    }
+
+    if (replacements.length === 0) return code
+
     let transformedCode = code
-    for (const { original, replacement } of replacements)
-      transformedCode = transformedCode.replace(original, replacement)
+    for (const { start, end, replacement } of [...replacements].sort((a, b) => b.start - a.start))
+      transformedCode = transformedCode.slice(0, start) + replacement + transformedCode.slice(end)
 
     return transformedCode
   }
@@ -973,9 +973,7 @@ const ${importName} = (props) => {
             ).replace(BACKSLASH_REGEX, '/')
 
             return {
-              code: `import { registerClientReference } from ${JSON.stringify(RSC_REFERENCES_IMPORT)};
-export default registerClientReference(null, ${JSON.stringify(componentId)}, "default");
-`,
+              code: this.generateClientReferenceStub(filePath, componentId),
               moduleType: 'js',
             }
           }
@@ -1259,7 +1257,10 @@ export default registerClientReference(null, ${JSON.stringify(componentId)}, "de
 
   private async buildComponentCodeOnly(inputPath: string): Promise<string> {
     const originalCode = await fs.promises.readFile(inputPath, 'utf-8')
-    const clientTransformedCode = this.transformClientImports(originalCode, inputPath)
+    const withInlineActions =
+      transformInlineServerActions(originalCode, this.getComponentId(inputPath))?.code ??
+      originalCode
+    const clientTransformedCode = this.transformClientImports(withInlineActions, inputPath)
     const isPage = this.isPageComponent(inputPath)
     const transformedCode = isPage
       ? this.transformComponentImportsToGlobal(clientTransformedCode)
@@ -1704,14 +1705,18 @@ export default registerClientReference(null, ${JSON.stringify(componentId)}, "de
   }
 
   private extractExportNames(code: string): string[] {
-    const exports: string[] = []
-    if (/export\s+default\b/.test(code)) exports.push('default')
-    const namedExportRegex = /export\s+(?:async\s+)?(?:function|const|let|var|class)\s+(\w+)/g
-    for (const m of code.matchAll(namedExportRegex)) {
-      exports.push(m[1])
+    return collectExportNames(code)
+  }
+
+  private generateClientReferenceStub(filePath: string, componentId: string): string {
+    let exports = ['default']
+    try {
+      exports = collectExportNames(fs.readFileSync(filePath, 'utf-8'))
+    } catch {
+      // Fall back to default-only when the source is unreadable.
     }
 
-    return exports.length > 0 ? exports : ['default']
+    return buildClientReferenceStubModule(componentId, exports)
   }
 
   private isServerActionFile(filePath: string): boolean {
@@ -1905,7 +1910,10 @@ export default registerClientReference(null, ${JSON.stringify(componentId)}, "de
     outputPath: string,
   ): Promise<BuiltComponent> {
     const originalCode = await fs.promises.readFile(inputPath, 'utf-8')
-    const clientTransformedCode = this.transformClientImports(originalCode, inputPath)
+    const withInlineActions =
+      transformInlineServerActions(originalCode, this.getComponentId(inputPath))?.code ??
+      originalCode
+    const clientTransformedCode = this.transformClientImports(withInlineActions, inputPath)
     const isPage = this.isPageComponent(inputPath)
     const transformedCode = isPage
       ? this.transformComponentImportsToGlobal(clientTransformedCode)
@@ -2002,7 +2010,7 @@ export default registerClientReference(null, ${JSON.stringify(componentId)}, "de
 
       if (externalClientComponents.includes(imp.source)) {
         isClientComponent = true
-      } else {
+      } else if (LOCAL_IMPORT_SOURCE_REGEX.test(imp.source)) {
         const resolvedPath = this.resolveImportPath(imp.source, inputPath)
         if (this.isClientComponent(resolvedPath)) {
           isClientComponent = true

--- a/packages/rari/src/vite/server/build.ts
+++ b/packages/rari/src/vite/server/build.ts
@@ -2011,7 +2011,12 @@ export class ServerComponentBuilder {
 
       if (externalClientComponents.includes(imp.source)) {
         isClientComponent = true
-      } else if (LOCAL_IMPORT_SOURCE_REGEX.test(imp.source)) {
+      } else if (
+        LOCAL_IMPORT_SOURCE_REGEX.test(imp.source) ||
+        Object.keys(this.options.alias).some(
+          alias => imp.source === alias || imp.source.startsWith(`${alias}/`),
+        )
+      ) {
         const resolvedPath = this.resolveImportPath(imp.source, inputPath)
         if (this.isClientComponent(resolvedPath)) {
           isClientComponent = true

--- a/packages/rari/src/vite/server/build.ts
+++ b/packages/rari/src/vite/server/build.ts
@@ -65,7 +65,7 @@ const COMPONENTS_PATH_REGEX = /\/components\/(\w+)(?:\.tsx?|\.jsx?)?$/
 const COMPONENTS_PATH_ALT_REGEX = /[/\\]components[/\\]\w+(?:\.tsx?|\.jsx?)?$/
 const SPECIAL_FILE_REGEX = /^(?:robots|sitemap|feed)\.(?:tsx?|jsx?)$/
 const RSC_REFERENCES_IMPORT = 'react-server-dom-rari/server'
-const LOCAL_IMPORT_SOURCE_REGEX = /^[./@]/
+const LOCAL_IMPORT_SOURCE_REGEX = /^[./@~#]/
 const NODE_PROTOCOL_REGEX = /^node:/
 export const RARI_CSS_MODULES_PATTERN = '[hash]_[local]'
 

--- a/packages/rari/src/vite/server/build.ts
+++ b/packages/rari/src/vite/server/build.ts
@@ -48,6 +48,7 @@ import {
 } from '../analysis/module-cache'
 import { collectSourceFilePaths, normalizeScanDirs } from '../analysis/source-walker'
 import { resolveMdxRegistryEntries } from '../mdx/registry'
+import { ensureNamedImportFromModule } from '../transform/client-import'
 import {
   buildClientReferenceStubModule,
   collectExportNames,
@@ -2064,7 +2065,7 @@ export class ServerComponentBuilder {
       ...(needsProxyImport ? ['createClientModuleProxy'] : []),
     ]
 
-    return `import { ${referenceImports.join(', ')} } from ${JSON.stringify(RSC_REFERENCES_IMPORT)};\n\n${transformedCode}`
+    return ensureNamedImportFromModule(transformedCode, RSC_REFERENCES_IMPORT, referenceImports)
   }
 
   private resolveImportPath(importPath: string, importerPath: string): string {

--- a/packages/rari/src/vite/server/build.ts
+++ b/packages/rari/src/vite/server/build.ts
@@ -37,7 +37,7 @@ import {
   getProjectRelativePath as getSharedProjectRelativePath,
   hashString as sharedHashString,
 } from '../analysis/component-ids'
-import { analyzeModuleSource } from '../analysis/directives'
+import { analyzeModuleSource, scanImportStatements } from '../analysis/directives'
 import {
   filterExternalDependencies,
   filterRelativeImportSources,
@@ -52,7 +52,6 @@ import { parseHtmlEntryImports } from '../transform/html-entry'
 import { getUseCacheTransform } from '../transform/use-cache'
 
 const COMPONENT_IMPORT_REGEX = /import\s+(\w+)\s+from\s+['"]([^'"]+)['"]/g
-const CLIENT_IMPORT_REGEX = /import\s+(?:(\w+)|\{([^}]+)\})\s+from\s+['"]([^'"]+)['"];?\s*$/gm
 const PROXY_FILE_REGEX = /^proxy\.(?:tsx?|jsx?|mts|mjs)$/
 const COMPONENTS_PATH_REGEX = /\/components\/(\w+)(?:\.tsx?|\.jsx?)?$/
 const COMPONENTS_PATH_ALT_REGEX = /[/\\]components[/\\](\w+)(?:\.tsx?|\.jsx?)?$/
@@ -1987,79 +1986,77 @@ export default registerClientReference(null, ${JSON.stringify(componentId)}, "de
   }
 
   private transformClientImports(code: string, inputPath: string): string {
-    let transformedCode = code
-
-    let match
-
-    const replacements: Array<{ original: string; replacement: string }> = []
-    let hasClientComponents = false
-
     const externalClientComponents = EXTERNAL_CLIENT_COMPONENT_MANIFESTS.map(
       entry => entry.componentId,
     )
 
-    CLIENT_IMPORT_REGEX.lastIndex = 0
-    for (;;) {
-      match = CLIENT_IMPORT_REGEX.exec(code)
-      if (match === null) break
+    const replacements: Array<{ start: number; end: number; replacement: string }> = []
+    let needsRegisterImport = false
+    let needsProxyImport = false
 
-      const [fullMatch, defaultImport, namedImports, importPath] = match
+    for (const imp of scanImportStatements(code)) {
+      if (imp.typeOnly || imp.sideEffectOnly) continue
 
       let isClientComponent = false
-      let componentId = importPath
+      let componentId = imp.source
 
-      if (externalClientComponents.includes(importPath)) {
+      if (externalClientComponents.includes(imp.source)) {
         isClientComponent = true
       } else {
-        const resolvedPath = this.resolveImportPath(importPath, inputPath)
+        const resolvedPath = this.resolveImportPath(imp.source, inputPath)
         if (this.isClientComponent(resolvedPath)) {
           isClientComponent = true
           componentId = path.relative(this.projectRoot, resolvedPath).replace(BACKSLASH_REGEX, '/')
         }
       }
 
-      if (isClientComponent) {
-        hasClientComponents = true
+      if (!isClientComponent) continue
 
-        let replacement = ''
+      const parts: string[] = []
 
-        if (defaultImport) {
-          replacement = `const ${defaultImport} = registerClientReference(
+      if (imp.namespaceBinding != null) {
+        needsProxyImport = true
+        parts.push(
+          `const ${imp.namespaceBinding} = createClientModuleProxy(${JSON.stringify(componentId)});`,
+        )
+      }
+
+      if (imp.defaultBinding != null) {
+        needsRegisterImport = true
+        parts.push(`const ${imp.defaultBinding} = registerClientReference(
   null,
   ${JSON.stringify(componentId)},
   "default"
-);`
-        } else if (namedImports) {
-          const imports = namedImports.split(',').map(imp => imp.trim())
-          const registrations = imports
-            .map(imp => {
-              const [importName, alias] = imp.includes(' as ')
-                ? imp.split(' as ').map(s => s.trim())
-                : [imp, imp]
+);`)
+      }
 
-              return `const ${alias} = registerClientReference(
+      for (const spec of imp.named) {
+        if (spec.typeOnly) continue
+        needsRegisterImport = true
+        parts.push(`const ${spec.local} = registerClientReference(
   null,
   ${JSON.stringify(componentId)},
-  ${JSON.stringify(importName)}
-);`
-            })
-            .join('\n')
-
-          replacement = registrations
-        }
-
-        replacements.push({ original: fullMatch, replacement })
+  ${JSON.stringify(spec.imported)}
+);`)
       }
+
+      if (parts.length === 0) continue
+
+      replacements.push({ start: imp.start, end: imp.end, replacement: parts.join('\n') })
     }
 
-    if (hasClientComponents) {
-      transformedCode = `import { registerClientReference } from ${JSON.stringify(RSC_REFERENCES_IMPORT)};\n\n${transformedCode}`
-    }
+    if (replacements.length === 0) return code
 
-    for (const { original, replacement } of replacements)
-      transformedCode = transformedCode.replace(original, replacement)
+    let transformedCode = code
+    for (const { start, end, replacement } of [...replacements].sort((a, b) => b.start - a.start))
+      transformedCode = transformedCode.slice(0, start) + replacement + transformedCode.slice(end)
 
-    return transformedCode
+    const referenceImports = [
+      ...(needsRegisterImport ? ['registerClientReference'] : []),
+      ...(needsProxyImport ? ['createClientModuleProxy'] : []),
+    ]
+
+    return `import { ${referenceImports.join(', ')} } from ${JSON.stringify(RSC_REFERENCES_IMPORT)};\n\n${transformedCode}`
   }
 
   private resolveImportPath(importPath: string, importerPath: string): string {

--- a/packages/rari/src/vite/transform/client-import.ts
+++ b/packages/rari/src/vite/transform/client-import.ts
@@ -1,10 +1,41 @@
 import type { ScannedImport } from '../analysis/directives'
+import { scanImportStatements } from '../analysis/directives'
 
 export interface ClientReferenceReplacement {
   /** Binding statements only (no helper import). Empty when there are no runtime bindings. */
   readonly code: string
   /** Helper names required by `code` (`registerClientReference` / `createClientModuleProxy`). */
   readonly helpers: readonly string[]
+}
+
+export function ensureNamedImportFromModule(
+  code: string,
+  moduleSource: string,
+  names: readonly string[],
+): string {
+  if (names.length === 0) return code
+
+  const existing = scanImportStatements(code).find(
+    imp => imp.source === moduleSource && !imp.typeOnly && !imp.sideEffectOnly,
+  )
+
+  const bindings = new Map<string, string>()
+  if (existing != null) {
+    for (const spec of existing.named) {
+      if (!spec.typeOnly) bindings.set(spec.imported, spec.local)
+    }
+  }
+  for (const name of names) {
+    if (!bindings.has(name)) bindings.set(name, name)
+  }
+
+  const namedList = [...bindings.entries()].map(([imported, local]) =>
+    imported === local ? imported : `${imported} as ${local}`,
+  )
+  const stmt = `import { ${namedList.join(', ')} } from ${JSON.stringify(moduleSource)};`
+
+  if (existing == null) return `${stmt}\n\n${code}`
+  return code.slice(0, existing.start) + stmt + code.slice(existing.end)
 }
 
 function buildNamespaceClientReferenceBinding(

--- a/packages/rari/src/vite/transform/client-import.ts
+++ b/packages/rari/src/vite/transform/client-import.ts
@@ -1,5 +1,12 @@
 import type { ScannedImport } from '../analysis/directives'
 
+export interface ClientReferenceReplacement {
+  /** Binding statements only (no helper import). Empty when there are no runtime bindings. */
+  readonly code: string
+  /** Helper names required by `code` (`registerClientReference` / `createClientModuleProxy`). */
+  readonly helpers: readonly string[]
+}
+
 function buildNamespaceClientReferenceBinding(
   bindingName: string,
   resolvedImportPath: string,
@@ -24,7 +31,7 @@ function buildRegisterClientReferenceBinding(
 export function buildClientReferenceReplacementFromImport(
   imp: ScannedImport,
   resolvedImportPath: string,
-): string {
+): ClientReferenceReplacement {
   const parts: string[] = []
   const helpers = new Set<string>()
 
@@ -46,8 +53,7 @@ export function buildClientReferenceReplacementFromImport(
     parts.push(buildRegisterClientReferenceBinding(spec.local, resolvedImportPath, spec.imported))
   }
 
-  if (parts.length === 0) return ''
+  if (parts.length === 0) return { code: '', helpers: [] }
 
-  const helperList = [...helpers].join(', ')
-  return `import { ${helperList} } from "react-server-dom-rari/server";\n${parts.join('\n')}`
+  return { code: parts.join('\n'), helpers: [...helpers] }
 }

--- a/packages/rari/src/vite/transform/client-import.ts
+++ b/packages/rari/src/vite/transform/client-import.ts
@@ -32,7 +32,18 @@ export function ensureNamedImportFromModule(
   const namedList = [...bindings.entries()].map(([imported, local]) =>
     imported === local ? imported : `${imported} as ${local}`,
   )
-  const stmt = `import { ${namedList.join(', ')} } from ${JSON.stringify(moduleSource)};`
+
+  if (existing?.namespaceBinding != null) {
+    const missing = names.filter(
+      name => !existing.named.some(spec => !spec.typeOnly && spec.imported === name),
+    )
+    if (missing.length === 0) return code
+    const namedStmt = `import { ${[...new Set(missing)].join(', ')} } from ${JSON.stringify(moduleSource)};`
+    return `${namedStmt}\n${code}`
+  }
+
+  const defaultPart = existing?.defaultBinding != null ? `${existing.defaultBinding}, ` : ''
+  const stmt = `import ${defaultPart}{ ${namedList.join(', ')} } from ${JSON.stringify(moduleSource)};`
 
   if (existing == null) return `${stmt}\n\n${code}`
   return code.slice(0, existing.start) + stmt + code.slice(existing.end)

--- a/packages/rari/src/vite/transform/client-import.ts
+++ b/packages/rari/src/vite/transform/client-import.ts
@@ -33,7 +33,7 @@ export function ensureNamedImportFromModule(
     imported === local ? imported : `${imported} as ${local}`,
   )
 
-  if (existing?.namespaceBinding != null) {
+  if (existing?.namespaceBinding != null || existing?.named.some(spec => spec.typeOnly)) {
     const missing = names.filter(
       name => !existing.named.some(spec => !spec.typeOnly && spec.imported === name),
     )

--- a/packages/rari/src/vite/transform/client-import.ts
+++ b/packages/rari/src/vite/transform/client-import.ts
@@ -1,10 +1,53 @@
-export const NAMESPACE_IMPORT_LINE_REGEX =
-  /^\s*import\s+\*\s+as\s+(\w+)\s+from\s+['"]([./@][^'"]+)['"].*$/
+import type { ScannedImport } from '../analysis/directives'
 
-export function buildNamespaceClientReferenceReplacement(
+function buildNamespaceClientReferenceBinding(
   bindingName: string,
   resolvedImportPath: string,
 ): string {
-  return `import { createClientModuleProxy } from "react-server-dom-rari/server";
-const ${bindingName} = createClientModuleProxy(${JSON.stringify(resolvedImportPath)});`
+  return `const ${bindingName} = createClientModuleProxy(${JSON.stringify(resolvedImportPath)});`
+}
+
+function buildRegisterClientReferenceBinding(
+  bindingName: string,
+  resolvedImportPath: string,
+  exportName: string,
+): string {
+  return `const ${bindingName} = registerClientReference(
+  function() {
+    throw new Error("Attempted to call ${bindingName} from the server but it's on the client. It can only be rendered as a Component or passed to props of a Client Component.");
+  },
+  ${JSON.stringify(resolvedImportPath)},
+  ${JSON.stringify(exportName)}
+);`
+}
+
+export function buildClientReferenceReplacementFromImport(
+  imp: ScannedImport,
+  resolvedImportPath: string,
+): string {
+  const parts: string[] = []
+  const helpers = new Set<string>()
+
+  if (imp.namespaceBinding != null) {
+    helpers.add('createClientModuleProxy')
+    parts.push(buildNamespaceClientReferenceBinding(imp.namespaceBinding, resolvedImportPath))
+  }
+
+  if (imp.defaultBinding != null) {
+    helpers.add('registerClientReference')
+    parts.push(
+      buildRegisterClientReferenceBinding(imp.defaultBinding, resolvedImportPath, 'default'),
+    )
+  }
+
+  for (const spec of imp.named) {
+    if (spec.typeOnly) continue
+    helpers.add('registerClientReference')
+    parts.push(buildRegisterClientReferenceBinding(spec.local, resolvedImportPath, spec.imported))
+  }
+
+  if (parts.length === 0) return ''
+
+  const helperList = [...helpers].join(', ')
+  return `import { ${helperList} } from "react-server-dom-rari/server";\n${parts.join('\n')}`
 }

--- a/packages/rari/src/vite/transform/client-reference-stub.ts
+++ b/packages/rari/src/vite/transform/client-reference-stub.ts
@@ -1,0 +1,60 @@
+const RSC_REFERENCES_IMPORT = 'react-server-dom-rari/server'
+
+/**
+ * Emit a `\0client-ref:` stub module that exposes every export from the
+ * underlying client file as a registerClientReference binding — not just
+ * default. Named imports that fall through to this safety net must resolve.
+ */
+export function buildClientReferenceStubModule(
+  componentId: string,
+  exportNames: readonly string[],
+): string {
+  const names = exportNames.length > 0 ? exportNames : ['default']
+  const lines = [
+    `import { registerClientReference } from ${JSON.stringify(RSC_REFERENCES_IMPORT)};`,
+  ]
+
+  for (const name of names) {
+    if (name === 'default') {
+      lines.push(
+        `export default registerClientReference(null, ${JSON.stringify(componentId)}, "default");`,
+      )
+    } else {
+      lines.push(
+        `export const ${name} = registerClientReference(null, ${JSON.stringify(componentId)}, ${JSON.stringify(name)});`,
+      )
+    }
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
+/**
+ * Collect export names from source for client-ref stubs and server-action
+ * proxies. Covers declarations and `export { a as b }` lists.
+ */
+export function collectExportNames(code: string): string[] {
+  const exports = new Set<string>()
+
+  if (/export\s+default\b/.test(code)) exports.add('default')
+
+  for (const m of code.matchAll(
+    /export\s+(?:async\s+)?(?:function|const|let|var|class)\s+(\w+)/g,
+  )) {
+    exports.add(m[1])
+  }
+
+  for (const m of code.matchAll(/export\s*\{([^}]+)\}/g)) {
+    for (const part of m[1].split(',')) {
+      const trimmed = part.trim()
+      if (!trimmed || trimmed.startsWith('type ')) continue
+
+      const asParts = trimmed.split(/\s+as\s+/)
+      const exportedName = (asParts.at(-1) ?? '').trim()
+      if (exportedName === '') continue
+      exports.add(exportedName)
+    }
+  }
+
+  return exports.size > 0 ? [...exports] : ['default']
+}

--- a/packages/rari/src/vite/transform/client-reference-stub.ts
+++ b/packages/rari/src/vite/transform/client-reference-stub.ts
@@ -1,3 +1,7 @@
+import { collectExportNames } from '../analysis/directives'
+
+export { collectExportNames }
+
 const RSC_REFERENCES_IMPORT = 'react-server-dom-rari/server'
 
 /**
@@ -27,34 +31,4 @@ export function buildClientReferenceStubModule(
   }
 
   return `${lines.join('\n')}\n`
-}
-
-/**
- * Collect export names from source for client-ref stubs and server-action
- * proxies. Covers declarations and `export { a as b }` lists.
- */
-export function collectExportNames(code: string): string[] {
-  const exports = new Set<string>()
-
-  if (/export\s+default\b/.test(code)) exports.add('default')
-
-  for (const m of code.matchAll(
-    /export\s+(?:async\s+)?(?:function|const|let|var|class)\s+(\w+)/g,
-  )) {
-    exports.add(m[1])
-  }
-
-  for (const m of code.matchAll(/export\s*\{([^}]+)\}/g)) {
-    for (const part of m[1].split(',')) {
-      const trimmed = part.trim()
-      if (!trimmed || trimmed.startsWith('type ')) continue
-
-      const asParts = trimmed.split(/\s+as\s+/)
-      const exportedName = (asParts.at(-1) ?? '').trim()
-      if (exportedName === '') continue
-      exports.add(exportedName)
-    }
-  }
-
-  return exports.size > 0 ? [...exports] : ['default']
 }

--- a/packages/rari/src/vite/transform/component-global.ts
+++ b/packages/rari/src/vite/transform/component-global.ts
@@ -1,0 +1,42 @@
+export function buildGlobalClientComponentWrapper(
+  bindingName: string,
+  registryKey: string,
+  exportName: string,
+): string {
+  const exportAccess =
+    exportName === 'default'
+      ? `if (Component && typeof Component === 'object' && Component.default) {
+    Component = Component.default;
+  }`
+      : `if (Component && typeof Component === 'object') {
+    Component = Component[${JSON.stringify(exportName)}] ?? Component.default?.[${JSON.stringify(exportName)}];
+  }`
+
+  return `// Component reference: ${registryKey}#${exportName}
+const ${bindingName} = (props) => {
+  let Component = globalThis['~clientComponents']?.[${JSON.stringify(registryKey)}]?.component
+    || globalThis[${JSON.stringify(registryKey)}];
+
+  ${exportAccess}
+
+  if (!Component) {
+    throw new Error('Component ${registryKey}#${exportName} not loaded');
+  }
+
+  if (typeof Component !== 'function') {
+    throw new Error('Component ${registryKey}#${exportName} is not a function, got: ' + typeof Component);
+  }
+
+  return Component(props);
+}`
+}
+
+export function buildGlobalClientNamespaceWrapper(
+  bindingName: string,
+  registryKey: string,
+): string {
+  return `// Component namespace reference: ${registryKey}
+const ${bindingName} = globalThis['~clientComponents']?.[${JSON.stringify(registryKey)}]?.component
+  || globalThis[${JSON.stringify(registryKey)}]
+  || {};`
+}

--- a/packages/rari/src/vite/transform/inline-server-action.ts
+++ b/packages/rari/src/vite/transform/inline-server-action.ts
@@ -125,6 +125,8 @@ const JS_KEYWORDS = new Set([
 export interface InlineServerActionTransformResult {
   readonly code: string
   readonly actionNames: readonly string[]
+  /** Export names already registered by the inline-action rewrite (skip in transformServerModule). */
+  readonly rewrittenExportNames: readonly string[]
 }
 
 interface LocatedAction {
@@ -190,19 +192,12 @@ function skipBalanced(source: string, start: number, open: number, close: number
   let depth = 0
   const len = source.length
   while (i < len) {
+    const skipped = skipNonCodeToken(source, i, len)
+    if (skipped !== -1) {
+      i = skipped
+      continue
+    }
     const ch = source.charCodeAt(i)
-    if (ch === 39 || ch === 34 || ch === 96) {
-      i = skipString(source, i, ch)
-      continue
-    }
-    if (ch === 47 && source.charCodeAt(i + 1) === 47) {
-      i = skipWhitespaceAndComments(source, i)
-      continue
-    }
-    if (ch === 47 && source.charCodeAt(i + 1) === 42) {
-      i = skipWhitespaceAndComments(source, i)
-      continue
-    }
     if (ch === open) depth++
     else if (ch === close) {
       depth--
@@ -594,6 +589,7 @@ export function transformInlineServerActions(
 
   const moduleBindings = collectModuleBindings(code)
   const actionNames: string[] = []
+  const rewrittenExportNames: string[] = []
   let result = code
   const hoisted: string[] = []
   let needsRegisterImport = false
@@ -612,27 +608,36 @@ export function transformInlineServerActions(
     const params = [...freeVars, action.paramsRaw.trim()].filter(p => p !== '').join(', ')
     const asyncKw = action.isAsync ? 'async ' : ''
 
-    hoisted.unshift(
-      `${asyncKw}function ${hoistedName}(${params}) {\n${body}\n}`,
-      `registerServerReference(${hoistedName}, ${JSON.stringify(moduleId)}, ${JSON.stringify(hoistedName)});`,
-    )
-    needsRegisterImport = true
-
     const bindExpr =
       freeVars.length > 0 ? `${hoistedName}.bind(null, ${freeVars.join(', ')})` : hoistedName
 
     const { start: replaceStart, exportKind } = resolveActionReplaceRange(result, action.start)
 
     let replacement = bindExpr
+    let rewrittenExport: string | null = null
+
     if (exportKind === 'default') {
-      replacement = `export default ${bindExpr}`
+      rewrittenExport = 'default'
+      replacement = `export default registerServerReference(${bindExpr}, ${JSON.stringify(moduleId)}, "default")`
     } else if (action.kind === 'declaration' && action.name != null) {
       if (exportKind === 'named') {
-        replacement = `export const ${action.name} = ${bindExpr}`
+        rewrittenExport = action.name
+        replacement = `export const ${action.name} = registerServerReference(${bindExpr}, ${JSON.stringify(moduleId)}, ${JSON.stringify(action.name)})`
       } else {
         replacement = `const ${action.name} = ${bindExpr}`
       }
     }
+
+    if (rewrittenExport == null) {
+      hoisted.unshift(
+        `${asyncKw}function ${hoistedName}(${params}) {\n${body}\n}`,
+        `registerServerReference(${hoistedName}, ${JSON.stringify(moduleId)}, ${JSON.stringify(hoistedName)});`,
+      )
+    } else {
+      hoisted.unshift(`${asyncKw}function ${hoistedName}(${params}) {\n${body}\n}`)
+      rewrittenExportNames.unshift(rewrittenExport)
+    }
+    needsRegisterImport = true
 
     result = result.slice(0, replaceStart) + replacement + result.slice(action.end)
   }
@@ -647,5 +652,6 @@ export function transformInlineServerActions(
   return {
     code: `${prefix}${result}\n\n${hoisted.join('\n')}\n`,
     actionNames,
+    rewrittenExportNames,
   }
 }

--- a/packages/rari/src/vite/transform/inline-server-action.ts
+++ b/packages/rari/src/vite/transform/inline-server-action.ts
@@ -624,10 +624,10 @@ export function transformInlineServerActions(
     const { start: replaceStart, exportKind } = resolveActionReplaceRange(result, action.start)
 
     let replacement = bindExpr
-    if (action.kind === 'declaration' && action.name != null) {
-      if (exportKind === 'default') {
-        replacement = bindExpr
-      } else if (exportKind === 'named') {
+    if (exportKind === 'default') {
+      replacement = `export default ${bindExpr}`
+    } else if (action.kind === 'declaration' && action.name != null) {
+      if (exportKind === 'named') {
         replacement = `export const ${action.name} = ${bindExpr}`
       } else {
         replacement = `const ${action.name} = ${bindExpr}`

--- a/packages/rari/src/vite/transform/inline-server-action.ts
+++ b/packages/rari/src/vite/transform/inline-server-action.ts
@@ -1,5 +1,15 @@
+import { skipNonCodeToken } from '../analysis/directives'
+
 const USE_SERVER = 'use server'
 const REGISTER_IMPORT = 'react-server-dom-rari/server'
+
+/** True when `code` already imports `registerServerReference` as a named binding. */
+export const REGISTER_SERVER_REFERENCE_IMPORT_RE =
+  /(?:^|[\n\r;])\s*import\s*\{[^}]*\bregisterServerReference\b[^}]*\}\s*from\s*["'][^"'\n]+["']/
+
+export function hasRegisterServerReferenceImport(code: string): boolean {
+  return REGISTER_SERVER_REFERENCE_IMPORT_RE.test(code)
+}
 
 const KNOWN_GLOBALS = new Set([
   'undefined',
@@ -140,7 +150,7 @@ function skipWhitespaceAndComments(source: string, i: number): number {
   const len = source.length
   while (i < len) {
     const ch = source.charCodeAt(i)
-    if (ch === 32 || ch === 9 || ch === 10 || ch === 13 || ch === 0xFEFF) {
+    if (ch === 32 || ch === 9 || ch === 10 || ch === 13 || ch === 65279) {
       i++
       continue
     }
@@ -358,15 +368,90 @@ function collectFreeVars(
   ])
 
   const used = new Set<string>()
-  for (const m of body.matchAll(/\b([a-z_$][\w$]*)\b/gi)) {
-    const name = m[1]
-    if (bound.has(name)) continue
-    const idx = m.index
-    if (idx > 0 && body[idx - 1] === '.') continue
-    used.add(name)
+  let i = 0
+  const len = body.length
+
+  while (i < len) {
+    const skipped = skipNonCodeToken(body, i, len)
+    if (skipped !== -1) {
+      i = skipped
+      continue
+    }
+
+    if (!isIdentStart(body.charCodeAt(i))) {
+      i++
+      continue
+    }
+
+    const ident = readIdent(body, i)
+    if (ident == null) {
+      i++
+      continue
+    }
+
+    // Member access: skip `obj.prop` / `obj?.prop` property names.
+    if (i > 0 && body.charCodeAt(i - 1) === 46) {
+      i = ident.end
+      continue
+    }
+
+    // Object-literal keys in `key: value` pairs (not ternary / labels alone).
+    if (isObjectLiteralKey(body, i, ident.end)) {
+      i = ident.end
+      continue
+    }
+
+    if (!bound.has(ident.name)) used.add(ident.name)
+    i = ident.end
   }
 
   return [...used]
+}
+
+function skipWsBack(source: string, i: number): number {
+  while (i > 0) {
+    const ch = source.charCodeAt(i - 1)
+    if (ch === 32 || ch === 9 || ch === 10 || ch === 13 || ch === 65279) i--
+    else break
+  }
+  return i
+}
+
+function keywordEndsAt(source: string, end: number, keyword: string): number | null {
+  const start = end - keyword.length
+  if (start < 0) return null
+  if (!isKeywordAt(source, start, keyword)) return null
+  return start
+}
+
+/** Object key when prev significant is `{` or `,` and next significant is `:`. */
+function isObjectLiteralKey(body: string, identStart: number, identEnd: number): boolean {
+  const after = skipWhitespaceAndComments(body, identEnd)
+  if (body.charCodeAt(after) !== 58) return false
+
+  const before = skipWsBack(body, identStart)
+  if (before === 0) return false
+  const prev = body.charCodeAt(before - 1)
+  return prev === 123 || prev === 44
+}
+
+function resolveActionReplaceRange(
+  source: string,
+  actionStart: number,
+): { start: number; exportKind: 'default' | 'named' | null } {
+  let cursor = skipWsBack(source, actionStart)
+
+  const defaultStart = keywordEndsAt(source, cursor, 'default')
+  if (defaultStart != null) {
+    cursor = skipWsBack(source, defaultStart)
+    const exportStart = keywordEndsAt(source, cursor, 'export')
+    if (exportStart != null) return { start: exportStart, exportKind: 'default' }
+  }
+
+  const exportStart = keywordEndsAt(source, cursor, 'export')
+  if (exportStart != null) return { start: exportStart, exportKind: 'named' }
+
+  return { start: actionStart, exportKind: null }
 }
 
 function locateInlineUseServerActions(source: string): LocatedAction[] {
@@ -536,12 +621,20 @@ export function transformInlineServerActions(
     const bindExpr =
       freeVars.length > 0 ? `${hoistedName}.bind(null, ${freeVars.join(', ')})` : hoistedName
 
+    const { start: replaceStart, exportKind } = resolveActionReplaceRange(result, action.start)
+
     let replacement = bindExpr
     if (action.kind === 'declaration' && action.name != null) {
-      replacement = `const ${action.name} = ${bindExpr}`
+      if (exportKind === 'default') {
+        replacement = bindExpr
+      } else if (exportKind === 'named') {
+        replacement = `export const ${action.name} = ${bindExpr}`
+      } else {
+        replacement = `const ${action.name} = ${bindExpr}`
+      }
     }
 
-    result = result.slice(0, action.start) + replacement + result.slice(action.end)
+    result = result.slice(0, replaceStart) + replacement + result.slice(action.end)
   }
 
   const registerImport = needsRegisterImport
@@ -549,11 +642,7 @@ export function transformInlineServerActions(
     : ''
 
   const prefix =
-    needsRegisterImport && !result.includes('registerServerReference')
-      ? registerImport
-      : needsRegisterImport && !/import\s*\{[^}]*registerServerReference/.test(result)
-        ? registerImport
-        : ''
+    needsRegisterImport && !hasRegisterServerReferenceImport(result) ? registerImport : ''
 
   return {
     code: `${prefix}${result}\n\n${hoisted.join('\n')}\n`,

--- a/packages/rari/src/vite/transform/inline-server-action.ts
+++ b/packages/rari/src/vite/transform/inline-server-action.ts
@@ -433,20 +433,47 @@ function isObjectLiteralKey(body: string, identStart: number, identEnd: number):
 function resolveActionReplaceRange(
   source: string,
   actionStart: number,
-): { start: number; exportKind: 'default' | 'named' | null } {
+): {
+  start: number
+  exportKind: 'default' | 'named' | null
+  bindingName: string | null
+} {
   let cursor = skipWsBack(source, actionStart)
 
   const defaultStart = keywordEndsAt(source, cursor, 'default')
   if (defaultStart != null) {
     cursor = skipWsBack(source, defaultStart)
     const exportStart = keywordEndsAt(source, cursor, 'export')
-    if (exportStart != null) return { start: exportStart, exportKind: 'default' }
+    if (exportStart != null) return { start: exportStart, exportKind: 'default', bindingName: null }
+  }
+
+  if (cursor > 0 && source.charCodeAt(cursor - 1) === 61 /* = */) {
+    const beforeEq = skipWsBack(source, cursor - 1)
+    const nameEnd = beforeEq
+    let nameStart = nameEnd
+    while (nameStart > 0 && isIdentPart(source.charCodeAt(nameStart - 1))) nameStart--
+    if (nameStart < nameEnd && isIdentStart(source.charCodeAt(nameStart))) {
+      const bindingName = source.slice(nameStart, nameEnd)
+      const beforeName = skipWsBack(source, nameStart)
+      const declStart =
+        keywordEndsAt(source, beforeName, 'const') ??
+        keywordEndsAt(source, beforeName, 'let') ??
+        keywordEndsAt(source, beforeName, 'var')
+      if (declStart != null) {
+        const beforeDecl = skipWsBack(source, declStart)
+        const exportStart = keywordEndsAt(source, beforeDecl, 'export')
+        if (exportStart != null) {
+          return { start: actionStart, exportKind: 'named', bindingName }
+        }
+        return { start: actionStart, exportKind: null, bindingName }
+      }
+    }
   }
 
   const exportStart = keywordEndsAt(source, cursor, 'export')
-  if (exportStart != null) return { start: exportStart, exportKind: 'named' }
+  if (exportStart != null) return { start: exportStart, exportKind: 'named', bindingName: null }
 
-  return { start: actionStart, exportKind: null }
+  return { start: actionStart, exportKind: null, bindingName: null }
 }
 
 function locateInlineUseServerActions(source: string): LocatedAction[] {
@@ -611,22 +638,32 @@ export function transformInlineServerActions(
     const bindExpr =
       freeVars.length > 0 ? `${hoistedName}.bind(null, ${freeVars.join(', ')})` : hoistedName
 
-    const { start: replaceStart, exportKind } = resolveActionReplaceRange(result, action.start)
+    const {
+      start: replaceStart,
+      exportKind,
+      bindingName,
+    } = resolveActionReplaceRange(result, action.start)
 
     let replacement = bindExpr
     let rewrittenExport: string | null = null
 
     if (exportKind === 'default') {
+      // Cover declaration and arrow/default forms; register under "default" once.
       rewrittenExport = 'default'
       replacement = `export default registerServerReference(${bindExpr}, ${JSON.stringify(moduleId)}, "default")`
+    } else if (exportKind === 'named' && action.name != null) {
+      // export async function name() { 'use server' ... }
+      rewrittenExport = action.name
+      replacement = `export const ${action.name} = registerServerReference(${bindExpr}, ${JSON.stringify(moduleId)}, ${JSON.stringify(action.name)})`
+    } else if (exportKind === 'named' && bindingName != null) {
+      // export const bindingName = async () => { 'use server' ... }
+      // Preserve surrounding binding; register under the exported name once.
+      rewrittenExport = bindingName
+      replacement = `registerServerReference(${bindExpr}, ${JSON.stringify(moduleId)}, ${JSON.stringify(bindingName)})`
     } else if (action.kind === 'declaration' && action.name != null) {
-      if (exportKind === 'named') {
-        rewrittenExport = action.name
-        replacement = `export const ${action.name} = registerServerReference(${bindExpr}, ${JSON.stringify(moduleId)}, ${JSON.stringify(action.name)})`
-      } else {
-        replacement = `const ${action.name} = ${bindExpr}`
-      }
+      replacement = `const ${action.name} = ${bindExpr}`
     }
+    // else: non-exported arrow/expression — preserve surrounding binding (replacement = bindExpr)
 
     if (rewrittenExport == null) {
       hoisted.unshift(

--- a/packages/rari/src/vite/transform/inline-server-action.ts
+++ b/packages/rari/src/vite/transform/inline-server-action.ts
@@ -1,0 +1,562 @@
+const USE_SERVER = 'use server'
+const REGISTER_IMPORT = 'react-server-dom-rari/server'
+
+const KNOWN_GLOBALS = new Set([
+  'undefined',
+  'NaN',
+  'Infinity',
+  'arguments',
+  'Object',
+  'Array',
+  'String',
+  'Number',
+  'Boolean',
+  'Symbol',
+  'BigInt',
+  'Math',
+  'Date',
+  'JSON',
+  'Promise',
+  'Error',
+  'TypeError',
+  'RangeError',
+  'Map',
+  'Set',
+  'WeakMap',
+  'WeakSet',
+  'RegExp',
+  'Proxy',
+  'Reflect',
+  'Function',
+  'console',
+  'fetch',
+  'process',
+  'Buffer',
+  'globalThis',
+  'global',
+  'window',
+  'document',
+  'navigator',
+  'location',
+  'crypto',
+  'TextEncoder',
+  'TextDecoder',
+  'URL',
+  'URLSearchParams',
+  'FormData',
+  'Headers',
+  'Request',
+  'Response',
+  'AbortController',
+  'AbortSignal',
+  'setTimeout',
+  'clearTimeout',
+  'setInterval',
+  'clearInterval',
+  'queueMicrotask',
+  'structuredClone',
+  'atob',
+  'btoa',
+  'React',
+  'jsx',
+  'jsxs',
+  'Fragment',
+])
+
+const JS_KEYWORDS = new Set([
+  'await',
+  'return',
+  'throw',
+  'if',
+  'else',
+  'for',
+  'while',
+  'do',
+  'switch',
+  'case',
+  'break',
+  'continue',
+  'new',
+  'typeof',
+  'instanceof',
+  'void',
+  'delete',
+  'yield',
+  'class',
+  'extends',
+  'super',
+  'this',
+  'try',
+  'catch',
+  'finally',
+  'with',
+  'debugger',
+  'default',
+  'of',
+  'in',
+  'from',
+  'as',
+  'import',
+  'export',
+  'async',
+  'function',
+  'const',
+  'let',
+  'var',
+  'true',
+  'false',
+  'null',
+  'static',
+  'get',
+  'set',
+  'typeof',
+])
+
+export interface InlineServerActionTransformResult {
+  readonly code: string
+  readonly actionNames: readonly string[]
+}
+
+interface LocatedAction {
+  readonly start: number
+  readonly end: number
+  readonly bodyOpen: number
+  readonly bodyClose: number
+  readonly paramsRaw: string
+  readonly isAsync: boolean
+  readonly name: string | null
+  readonly kind: 'declaration' | 'expression' | 'arrow'
+}
+
+function isIdentStart(ch: number): boolean {
+  return (ch >= 97 && ch <= 122) || (ch >= 65 && ch <= 90) || ch === 95 || ch === 36
+}
+
+function isIdentPart(ch: number): boolean {
+  return isIdentStart(ch) || (ch >= 48 && ch <= 57)
+}
+
+function skipWhitespaceAndComments(source: string, i: number): number {
+  const len = source.length
+  while (i < len) {
+    const ch = source.charCodeAt(i)
+    if (ch === 32 || ch === 9 || ch === 10 || ch === 13 || ch === 0xFEFF) {
+      i++
+      continue
+    }
+    if (ch === 47 && source.charCodeAt(i + 1) === 47) {
+      i += 2
+      while (i < len && source.charCodeAt(i) !== 10 && source.charCodeAt(i) !== 13) i++
+      continue
+    }
+    if (ch === 47 && source.charCodeAt(i + 1) === 42) {
+      i += 2
+      while (i < len - 1 && (source.charCodeAt(i) !== 42 || source.charCodeAt(i + 1) !== 47)) i++
+      i += 2
+      continue
+    }
+    break
+  }
+  return i
+}
+
+function skipString(source: string, i: number, quote: number): number {
+  i++
+  const len = source.length
+  while (i < len) {
+    const ch = source.charCodeAt(i)
+    if (ch === 92) {
+      i += 2
+      continue
+    }
+    if (ch === quote) return i + 1
+    i++
+  }
+  return i
+}
+
+function skipBalanced(source: string, start: number, open: number, close: number): number {
+  let i = start
+  let depth = 0
+  const len = source.length
+  while (i < len) {
+    const ch = source.charCodeAt(i)
+    if (ch === 39 || ch === 34 || ch === 96) {
+      i = skipString(source, i, ch)
+      continue
+    }
+    if (ch === 47 && source.charCodeAt(i + 1) === 47) {
+      i = skipWhitespaceAndComments(source, i)
+      continue
+    }
+    if (ch === 47 && source.charCodeAt(i + 1) === 42) {
+      i = skipWhitespaceAndComments(source, i)
+      continue
+    }
+    if (ch === open) depth++
+    else if (ch === close) {
+      depth--
+      if (depth === 0) return i + 1
+    }
+    i++
+  }
+  return i
+}
+
+function regionEquals(source: string, offset: number, target: string): boolean {
+  for (let k = 0; k < target.length; k++) {
+    if (source.charCodeAt(offset + k) !== target.charCodeAt(k)) return false
+  }
+  return true
+}
+
+function hasUseServerPrologue(source: string, bodyOpen: number, bodyClose: number): boolean {
+  let i = skipWhitespaceAndComments(source, bodyOpen + 1)
+  if (i >= bodyClose) return false
+
+  const ch = source.charCodeAt(i)
+  if (ch !== 39 && ch !== 34) return false
+
+  const contentStart = i + 1
+  const afterString = skipString(source, i, ch)
+  const contentEnd = afterString - 1
+  if (contentEnd - contentStart !== USE_SERVER.length) return false
+  if (!regionEquals(source, contentStart, USE_SERVER)) return false
+
+  i = afterString
+  while (i < bodyClose) {
+    const next = source.charCodeAt(i)
+    if (next === 32 || next === 9) {
+      i++
+      continue
+    }
+    if (next === 59 || next === 10 || next === 13) return true
+    if (next === 47 && source.charCodeAt(i + 1) === 47) return true
+    if (next === 47 && source.charCodeAt(i + 1) === 42) return true
+    return false
+  }
+
+  return true
+}
+
+function stripUseServerPrologue(source: string, bodyOpen: number, bodyClose: number): string {
+  let i = skipWhitespaceAndComments(source, bodyOpen + 1)
+  const ch = source.charCodeAt(i)
+  if (ch !== 39 && ch !== 34) return source.slice(bodyOpen + 1, bodyClose)
+
+  const afterString = skipString(source, i, ch)
+  i = skipWhitespaceAndComments(source, afterString)
+  if (source.charCodeAt(i) === 59) i++
+  i = skipWhitespaceAndComments(source, i)
+  return source.slice(i, bodyClose)
+}
+
+function readIdent(source: string, i: number): { name: string; end: number } | null {
+  if (!isIdentStart(source.charCodeAt(i))) return null
+  let j = i + 1
+  while (j < source.length && isIdentPart(source.charCodeAt(j))) j++
+  return { name: source.slice(i, j), end: j }
+}
+
+function isKeywordAt(source: string, i: number, keyword: string): boolean {
+  if (!regionEquals(source, i, keyword)) return false
+  const before = i > 0 ? source.charCodeAt(i - 1) : -1
+  const after = i + keyword.length < source.length ? source.charCodeAt(i + keyword.length) : -1
+  if (before !== -1 && isIdentPart(before)) return false
+  if (after !== -1 && isIdentPart(after)) return false
+  return true
+}
+
+function collectParamNames(paramsRaw: string): Set<string> {
+  const names = new Set<string>()
+  let i = 0
+  const len = paramsRaw.length
+  while (i < len) {
+    i = skipWhitespaceAndComments(paramsRaw, i)
+    if (i >= len) break
+    const ch = paramsRaw.charCodeAt(i)
+    if (ch === 123 || ch === 91) {
+      const end = skipBalanced(paramsRaw, i, ch, ch === 123 ? 125 : 93)
+      for (const m of paramsRaw.slice(i, end).matchAll(/[a-z_$][\w$]*/gi)) {
+        if (m[0] !== 'as') names.add(m[0])
+      }
+      i = end
+      continue
+    }
+    if (ch === 46 && paramsRaw.charCodeAt(i + 1) === 46 && paramsRaw.charCodeAt(i + 2) === 46) {
+      i += 3
+      i = skipWhitespaceAndComments(paramsRaw, i)
+      const ident = readIdent(paramsRaw, i)
+      if (ident) {
+        names.add(ident.name)
+        i = ident.end
+      }
+      continue
+    }
+    const ident = readIdent(paramsRaw, i)
+    if (ident) {
+      names.add(ident.name)
+      i = ident.end
+      continue
+    }
+    i++
+  }
+  return names
+}
+
+function collectLocalDeclarations(body: string): Set<string> {
+  const names = new Set<string>()
+  for (const m of body.matchAll(
+    /\b(?:const|let|var|function|class|async\s+function)\s+([A-Za-z_$][\w$]*)/g,
+  )) {
+    names.add(m[1])
+  }
+  return names
+}
+
+function collectModuleBindings(source: string): Set<string> {
+  const names = new Set<string>()
+  for (const m of source.matchAll(
+    /\b(?:import|export)\s+(?:type\s+)?(?:\{([^}]+)\}|(\*\s+as\s+[A-Za-z_$][\w$]*)|([A-Za-z_$][\w$]*))/g,
+  )) {
+    if (m[1]) {
+      for (const part of m[1].split(',')) {
+        const trimmed = part.trim()
+        if (!trimmed || trimmed.startsWith('type ')) continue
+        const asParts = trimmed.split(/\s+as\s+/)
+        const local = (asParts.at(-1) ?? '').trim()
+        if (local) names.add(local)
+      }
+    }
+    if (m[2]) {
+      const ns = /as\s+([A-Za-z_$][\w$]*)/.exec(m[2])
+      if (ns) names.add(ns[1])
+    }
+    if (m[3] && m[3] !== 'type' && m[3] !== 'async' && m[3] !== 'function' && m[3] !== 'class') {
+      names.add(m[3])
+    }
+  }
+  for (const m of source.matchAll(
+    /(?:^|\n)\s*(?:export\s+)?(?:async\s+)?(?:function|class|const|let|var)\s+([A-Za-z_$][\w$]*)/g,
+  )) {
+    names.add(m[1])
+  }
+  return names
+}
+
+function collectFreeVars(
+  body: string,
+  paramsRaw: string,
+  moduleBindings: ReadonlySet<string>,
+): string[] {
+  const bound = new Set<string>([
+    ...collectParamNames(paramsRaw),
+    ...collectLocalDeclarations(body),
+    ...moduleBindings,
+    ...KNOWN_GLOBALS,
+    ...JS_KEYWORDS,
+  ])
+
+  const used = new Set<string>()
+  for (const m of body.matchAll(/\b([a-z_$][\w$]*)\b/gi)) {
+    const name = m[1]
+    if (bound.has(name)) continue
+    const idx = m.index
+    if (idx > 0 && body[idx - 1] === '.') continue
+    used.add(name)
+  }
+
+  return [...used]
+}
+
+function locateInlineUseServerActions(source: string): LocatedAction[] {
+  const actions: LocatedAction[] = []
+  const len = source.length
+  let i = 0
+
+  while (i < len) {
+    const ch = source.charCodeAt(i)
+
+    if (ch === 39 || ch === 34 || ch === 96) {
+      i = skipString(source, i, ch)
+      continue
+    }
+    if (ch === 47 && (source.charCodeAt(i + 1) === 47 || source.charCodeAt(i + 1) === 42)) {
+      i = skipWhitespaceAndComments(source, i)
+      continue
+    }
+
+    if (isKeywordAt(source, i, 'async') || isKeywordAt(source, i, 'function')) {
+      const start = i
+      let pos = i
+      let isAsync = false
+      if (isKeywordAt(source, pos, 'async')) {
+        isAsync = true
+        pos = skipWhitespaceAndComments(source, pos + 5)
+      }
+
+      if (isKeywordAt(source, pos, 'function')) {
+        pos = skipWhitespaceAndComments(source, pos + 8)
+        if (source.charCodeAt(pos) === 42) pos = skipWhitespaceAndComments(source, pos + 1)
+
+        let name: string | null = null
+        const ident = readIdent(source, pos)
+        if (ident) {
+          name = ident.name
+          pos = skipWhitespaceAndComments(source, ident.end)
+        }
+
+        if (source.charCodeAt(pos) !== 40) {
+          i++
+          continue
+        }
+
+        const paramsEnd = skipBalanced(source, pos, 40, 41)
+        const paramsRaw = source.slice(pos + 1, paramsEnd - 1)
+        pos = skipWhitespaceAndComments(source, paramsEnd)
+        if (source.charCodeAt(pos) !== 123) {
+          i++
+          continue
+        }
+
+        const bodyClose = skipBalanced(source, pos, 123, 125) - 1
+        if (hasUseServerPrologue(source, pos, bodyClose)) {
+          actions.push({
+            start,
+            end: bodyClose + 1,
+            bodyOpen: pos,
+            bodyClose,
+            paramsRaw,
+            isAsync,
+            name,
+            kind: name != null ? 'declaration' : 'expression',
+          })
+          i = bodyClose + 1
+        } else {
+          i = pos + 1
+        }
+        continue
+      }
+
+      if (isAsync && source.charCodeAt(pos) === 40) {
+        const paramsEnd = skipBalanced(source, pos, 40, 41)
+        const paramsRaw = source.slice(pos + 1, paramsEnd - 1)
+        let after = skipWhitespaceAndComments(source, paramsEnd)
+        if (source.charCodeAt(after) === 61 && source.charCodeAt(after + 1) === 62) {
+          after = skipWhitespaceAndComments(source, after + 2)
+          if (source.charCodeAt(after) === 123) {
+            const bodyClose = skipBalanced(source, after, 123, 125) - 1
+            if (hasUseServerPrologue(source, after, bodyClose)) {
+              actions.push({
+                start,
+                end: bodyClose + 1,
+                bodyOpen: after,
+                bodyClose,
+                paramsRaw,
+                isAsync: true,
+                name: null,
+                kind: 'arrow',
+              })
+              i = bodyClose + 1
+            } else {
+              i = after + 1
+            }
+            continue
+          }
+        }
+      }
+    }
+
+    if (source.charCodeAt(i) === 40) {
+      const paramsEnd = skipBalanced(source, i, 40, 41)
+      let after = skipWhitespaceAndComments(source, paramsEnd)
+      if (source.charCodeAt(after) === 61 && source.charCodeAt(after + 1) === 62) {
+        after = skipWhitespaceAndComments(source, after + 2)
+        if (source.charCodeAt(after) === 123) {
+          const bodyClose = skipBalanced(source, after, 123, 125) - 1
+          if (hasUseServerPrologue(source, after, bodyClose)) {
+            actions.push({
+              start: i,
+              end: bodyClose + 1,
+              bodyOpen: after,
+              bodyClose,
+              paramsRaw: source.slice(i + 1, paramsEnd - 1),
+              isAsync: false,
+              name: null,
+              kind: 'arrow',
+            })
+            i = bodyClose + 1
+          } else {
+            i = after + 1
+          }
+          continue
+        }
+      }
+    }
+
+    i++
+  }
+
+  return actions
+}
+
+export function transformInlineServerActions(
+  code: string,
+  moduleId: string,
+): InlineServerActionTransformResult | null {
+  const actions = locateInlineUseServerActions(code)
+  if (actions.length === 0) return null
+
+  const moduleBindings = collectModuleBindings(code)
+  const actionNames: string[] = []
+  let result = code
+  const hoisted: string[] = []
+  let needsRegisterImport = false
+
+  const ordered = [...actions].sort((a, b) => b.start - a.start)
+  let actionIndex = actions.length - 1
+
+  for (const action of ordered) {
+    const originalName = action.name ?? 'anonymous_server_function'
+    const hoistedName = `$$ACTION_${actionIndex}_${originalName.replace(/\W/g, '_')}`
+    actionIndex--
+    actionNames.unshift(hoistedName)
+
+    const body = stripUseServerPrologue(result, action.bodyOpen, action.bodyClose)
+    const freeVars = collectFreeVars(body, action.paramsRaw, moduleBindings)
+    const params = [...freeVars, action.paramsRaw.trim()].filter(p => p !== '').join(', ')
+    const asyncKw = action.isAsync ? 'async ' : ''
+
+    hoisted.unshift(
+      `${asyncKw}function ${hoistedName}(${params}) {\n${body}\n}`,
+      `registerServerReference(${hoistedName}, ${JSON.stringify(moduleId)}, ${JSON.stringify(hoistedName)});`,
+    )
+    needsRegisterImport = true
+
+    const bindExpr =
+      freeVars.length > 0 ? `${hoistedName}.bind(null, ${freeVars.join(', ')})` : hoistedName
+
+    let replacement = bindExpr
+    if (action.kind === 'declaration' && action.name != null) {
+      replacement = `const ${action.name} = ${bindExpr}`
+    }
+
+    result = result.slice(0, action.start) + replacement + result.slice(action.end)
+  }
+
+  const registerImport = needsRegisterImport
+    ? `import { registerServerReference } from ${JSON.stringify(REGISTER_IMPORT)};\n`
+    : ''
+
+  const prefix =
+    needsRegisterImport && !result.includes('registerServerReference')
+      ? registerImport
+      : needsRegisterImport && !/import\s*\{[^}]*registerServerReference/.test(result)
+        ? registerImport
+        : ''
+
+  return {
+    code: `${prefix}${result}\n\n${hoisted.join('\n')}\n`,
+    actionNames,
+  }
+}

--- a/test/unit/vite/client-import-transform.test.ts
+++ b/test/unit/vite/client-import-transform.test.ts
@@ -80,6 +80,13 @@ describe('ensureNamedImportFromModule', () => {
       `import helpers, { registerServerReference, registerClientReference } from ${JSON.stringify(mod)};\n`,
     )
   })
+
+  it('preserves type-only specifiers by emitting helpers separately', () => {
+    const code = `import { type Props, registerServerReference } from ${JSON.stringify(mod)};\n`
+    const result = ensureNamedImportFromModule(code, mod, ['registerClientReference'])
+
+    expect(result).toBe(`import { registerClientReference } from ${JSON.stringify(mod)};\n${code}`)
+  })
 })
 
 describe('rewriteExportDefaultAsBinding', () => {

--- a/test/unit/vite/client-import-transform.test.ts
+++ b/test/unit/vite/client-import-transform.test.ts
@@ -71,6 +71,15 @@ describe('ensureNamedImportFromModule', () => {
     )
     expect(result.match(/from "react-server-dom-rari\/server"/g)).toHaveLength(1)
   })
+
+  it('preserves a default binding when merging named imports', () => {
+    const code = `import helpers, { registerServerReference } from ${JSON.stringify(mod)};\n`
+    const result = ensureNamedImportFromModule(code, mod, ['registerClientReference'])
+
+    expect(result).toBe(
+      `import helpers, { registerServerReference, registerClientReference } from ${JSON.stringify(mod)};\n`,
+    )
+  })
 })
 
 describe('rewriteExportDefaultAsBinding', () => {

--- a/test/unit/vite/client-import-transform.test.ts
+++ b/test/unit/vite/client-import-transform.test.ts
@@ -3,7 +3,10 @@ import {
   rewriteExportDefaultAsBinding,
   scanImportStatements,
 } from '@rari/vite/analysis/directives'
-import { buildClientReferenceReplacementFromImport } from '@rari/vite/transform/client-import'
+import {
+  buildClientReferenceReplacementFromImport,
+  ensureNamedImportFromModule,
+} from '@rari/vite/transform/client-import'
 import { describe, expect, it } from 'vite-plus/test'
 
 describe('buildClientReferenceReplacementFromImport', () => {
@@ -46,6 +49,27 @@ describe('buildClientReferenceReplacementFromImport', () => {
     const replacement = buildClientReferenceReplacementFromImport(imp, 'src/types.ts')
 
     expect(replacement).toEqual({ code: '', helpers: [] })
+  })
+})
+
+describe('ensureNamedImportFromModule', () => {
+  const mod = 'react-server-dom-rari/server'
+
+  it('prepends a new import when none exists', () => {
+    const code = `export default function Page() {}\n`
+    expect(ensureNamedImportFromModule(code, mod, ['registerClientReference'])).toBe(
+      `import { registerClientReference } from ${JSON.stringify(mod)};\n\n${code}`,
+    )
+  })
+
+  it('merges into an existing import from the same module', () => {
+    const code = `import { registerServerReference } from ${JSON.stringify(mod)};\nexport default function Page() {}\n`
+    const result = ensureNamedImportFromModule(code, mod, ['registerClientReference'])
+
+    expect(result).toBe(
+      `import { registerServerReference, registerClientReference } from ${JSON.stringify(mod)};\nexport default function Page() {}\n`,
+    )
+    expect(result.match(/from "react-server-dom-rari\/server"/g)).toHaveLength(1)
   })
 })
 
@@ -92,5 +116,24 @@ describe('rewriteExportDefaultAsBinding', () => {
 
     expect(code.slice(located!.valueStart, located!.valueEnd).trim()).toBe('a\n  + b')
     expect(rewritten).toContain('const __default_export__ = a\n  + b')
+  })
+
+  it('does not treat comparison a<b as JSX when locating export default', () => {
+    const code = `export default a<b;\n`
+    const located = locateExportDefaultValue(code)
+
+    expect(located).not.toBeNull()
+    expect(code.slice(located!.valueStart, located!.valueEnd).trim()).toBe('a<b')
+  })
+
+  it('does not treat generic arrow <T,> as JSX when locating export default', () => {
+    const code = `export default <T,>(value: T) => value\n`
+    const located = locateExportDefaultValue(code)
+    const rewritten = rewriteExportDefaultAsBinding(code, '__default_export__')
+
+    expect(code.slice(located!.valueStart, located!.valueEnd).trim()).toBe(
+      '<T,>(value: T) => value',
+    )
+    expect(rewritten).toContain('const __default_export__ = <T,>(value: T) => value')
   })
 })

--- a/test/unit/vite/client-import-transform.test.ts
+++ b/test/unit/vite/client-import-transform.test.ts
@@ -11,12 +11,11 @@ describe('buildClientReferenceReplacementFromImport', () => {
     const [imp] = scanImportStatements(`import Button, { Card as TheCard } from './ui'\n`)
     const replacement = buildClientReferenceReplacementFromImport(imp, 'src/ui.tsx')
 
-    expect(replacement).toContain(
-      'import { registerClientReference } from "react-server-dom-rari/server";',
-    )
-    expect(replacement).toContain('"default"')
-    expect(replacement).toContain('"Card"')
-    expect(replacement).toContain('const TheCard = registerClientReference')
+    expect(replacement.helpers).toEqual(['registerClientReference'])
+    expect(replacement.code).toContain('"default"')
+    expect(replacement.code).toContain('"Card"')
+    expect(replacement.code).toContain('const TheCard = registerClientReference')
+    expect(replacement.code).not.toContain('import {')
   })
 
   it('builds createClientModuleProxy for namespace imports', () => {
@@ -26,19 +25,27 @@ describe('buildClientReferenceReplacementFromImport', () => {
       'src/components/ClientButton.tsx',
     )
 
-    expect(replacement).toBe(
-      `import { createClientModuleProxy } from "react-server-dom-rari/server";\nconst ClientUI = createClientModuleProxy("src/components/ClientButton.tsx");`,
-    )
+    expect(replacement).toEqual({
+      helpers: ['createClientModuleProxy'],
+      code: `const ClientUI = createClientModuleProxy("src/components/ClientButton.tsx");`,
+    })
   })
 
   it('emits both helpers when default and namespace are combined', () => {
     const [imp] = scanImportStatements(`import React, * as ReactNS from 'react'\n`)
     const replacement = buildClientReferenceReplacementFromImport(imp, 'react')
 
-    expect(replacement).toContain('registerClientReference')
-    expect(replacement).toContain('createClientModuleProxy')
-    expect(replacement).toContain('const React = registerClientReference')
-    expect(replacement).toContain('const ReactNS = createClientModuleProxy')
+    expect(replacement.helpers).toContain('registerClientReference')
+    expect(replacement.helpers).toContain('createClientModuleProxy')
+    expect(replacement.code).toContain('const React = registerClientReference')
+    expect(replacement.code).toContain('const ReactNS = createClientModuleProxy')
+  })
+
+  it('returns empty code for imports with only inline type-only specifiers', () => {
+    const [imp] = scanImportStatements(`import { type Props } from './types'\n`)
+    const replacement = buildClientReferenceReplacementFromImport(imp, 'src/types.ts')
+
+    expect(replacement).toEqual({ code: '', helpers: [] })
   })
 })
 
@@ -66,5 +73,24 @@ describe('rewriteExportDefaultAsBinding', () => {
     expect(rewritten).toBe(
       `'use server'\nasync function save() {}\nconst __default_export__ = save;\nexport default __default_export__\n`,
     )
+  })
+
+  it('keeps scanning for next-line arrow bodies', () => {
+    const code = `'use server'\nexport default () =>\n  value\n`
+    const located = locateExportDefaultValue(code)
+    const rewritten = rewriteExportDefaultAsBinding(code, '__default_export__')
+
+    expect(code.slice(located!.valueStart, located!.valueEnd).trim()).toBe('() =>\n  value')
+    expect(rewritten).toContain('const __default_export__ = () =>\n  value')
+    expect(rewritten).toContain('export default __default_export__')
+  })
+
+  it('keeps scanning for operator-continued default exports', () => {
+    const code = `'use server'\nexport default a\n  + b\n`
+    const located = locateExportDefaultValue(code)
+    const rewritten = rewriteExportDefaultAsBinding(code, '__default_export__')
+
+    expect(code.slice(located!.valueStart, located!.valueEnd).trim()).toBe('a\n  + b')
+    expect(rewritten).toContain('const __default_export__ = a\n  + b')
   })
 })

--- a/test/unit/vite/client-import-transform.test.ts
+++ b/test/unit/vite/client-import-transform.test.ts
@@ -1,29 +1,70 @@
 import {
-  buildNamespaceClientReferenceReplacement,
-  NAMESPACE_IMPORT_LINE_REGEX,
-} from '@rari/vite/transform/client-import'
+  locateExportDefaultValue,
+  rewriteExportDefaultAsBinding,
+  scanImportStatements,
+} from '@rari/vite/analysis/directives'
+import { buildClientReferenceReplacementFromImport } from '@rari/vite/transform/client-import'
 import { describe, expect, it } from 'vite-plus/test'
 
-describe('namespace client import transform', () => {
-  it('matches namespace import lines', () => {
-    const match = 'import * as ClientUI from "./ClientButton.tsx"'.match(
-      NAMESPACE_IMPORT_LINE_REGEX,
+describe('buildClientReferenceReplacementFromImport', () => {
+  it('builds registerClientReference bindings for default and aliased named imports', () => {
+    const [imp] = scanImportStatements(`import Button, { Card as TheCard } from './ui'\n`)
+    const replacement = buildClientReferenceReplacementFromImport(imp, 'src/ui.tsx')
+
+    expect(replacement).toContain(
+      'import { registerClientReference } from "react-server-dom-rari/server";',
+    )
+    expect(replacement).toContain('"default"')
+    expect(replacement).toContain('"Card"')
+    expect(replacement).toContain('const TheCard = registerClientReference')
+  })
+
+  it('builds createClientModuleProxy for namespace imports', () => {
+    const [imp] = scanImportStatements(`import * as ClientUI from "./ClientButton.tsx"\n`)
+    const replacement = buildClientReferenceReplacementFromImport(
+      imp,
+      'src/components/ClientButton.tsx',
     )
 
-    expect(match?.[1]).toBe('ClientUI')
-    expect(match?.[2]).toBe('./ClientButton.tsx')
+    expect(replacement).toBe(
+      `import { createClientModuleProxy } from "react-server-dom-rari/server";\nconst ClientUI = createClientModuleProxy("src/components/ClientButton.tsx");`,
+    )
   })
 
-  it('does not match default or named imports', () => {
-    expect('import Client from "./ClientButton.tsx"'.match(NAMESPACE_IMPORT_LINE_REGEX)).toBeNull()
-    expect(
-      'import { Client } from "./ClientButton.tsx"'.match(NAMESPACE_IMPORT_LINE_REGEX),
-    ).toBeNull()
+  it('emits both helpers when default and namespace are combined', () => {
+    const [imp] = scanImportStatements(`import React, * as ReactNS from 'react'\n`)
+    const replacement = buildClientReferenceReplacementFromImport(imp, 'react')
+
+    expect(replacement).toContain('registerClientReference')
+    expect(replacement).toContain('createClientModuleProxy')
+    expect(replacement).toContain('const React = registerClientReference')
+    expect(replacement).toContain('const ReactNS = createClientModuleProxy')
+  })
+})
+
+describe('rewriteExportDefaultAsBinding', () => {
+  it('rewrites arrow defaults without truncating at inner semicolons', () => {
+    const code = `'use server'\nexport default async () => {\n  doA();\n  doB()\n}\n`
+    const rewritten = rewriteExportDefaultAsBinding(code, '__default_export__')
+
+    expect(rewritten).toContain('const __default_export__ = async () => {\n  doA();\n  doB()\n}')
+    expect(rewritten).toContain('export default __default_export__')
+    expect(rewritten).not.toContain('export default async () => {\n  doA()')
   })
 
-  it('builds createClientModuleProxy replacement', () => {
-    expect(buildNamespaceClientReferenceReplacement('ClientUI', 'src/components/ClientButton.tsx'))
-      .toBe(`import { createClientModuleProxy } from "react-server-dom-rari/server";
-const ClientUI = createClientModuleProxy("src/components/ClientButton.tsx");`)
+  it('leaves named function declarations alone', () => {
+    const code = `'use server'\nexport default async function save() {\n  return 1\n}\n`
+
+    expect(rewriteExportDefaultAsBinding(code, '__default_export__')).toBeNull()
+    expect(locateExportDefaultValue(code)?.bindingName).toBe('save')
+  })
+
+  it('rewrites simple identifier defaults', () => {
+    const code = `'use server'\nasync function save() {}\nexport default save\n`
+    const rewritten = rewriteExportDefaultAsBinding(code, '__default_export__')
+
+    expect(rewritten).toBe(
+      `'use server'\nasync function save() {}\nconst __default_export__ = save;\nexport default __default_export__\n`,
+    )
   })
 })

--- a/test/unit/vite/deferred-transforms.test.ts
+++ b/test/unit/vite/deferred-transforms.test.ts
@@ -1,0 +1,117 @@
+import {
+  buildClientReferenceStubModule,
+  collectExportNames,
+} from '@rari/vite/transform/client-reference-stub'
+import {
+  buildGlobalClientComponentWrapper,
+  buildGlobalClientNamespaceWrapper,
+} from '@rari/vite/transform/component-global'
+import { transformInlineServerActions } from '@rari/vite/transform/inline-server-action'
+import { describe, expect, it } from 'vite-plus/test'
+
+describe('collectExportNames', () => {
+  it('collects default and named declarations', () => {
+    expect(
+      collectExportNames(`export default function Button() {}\nexport function Card() {}\n`),
+    ).toEqual(['default', 'Card'])
+  })
+
+  it('collects export { a as b } lists', () => {
+    expect(collectExportNames(`const a = 1\nconst b = 2\nexport { a as Button, b }\n`)).toEqual([
+      'Button',
+      'b',
+    ])
+  })
+})
+
+describe('buildClientReferenceStubModule', () => {
+  it('emits named and default registerClientReference exports', () => {
+    const stub = buildClientReferenceStubModule('src/components/ui.tsx', ['default', 'Card'])
+
+    expect(stub).toContain(
+      'export default registerClientReference(null, "src/components/ui.tsx", "default")',
+    )
+    expect(stub).toContain(
+      'export const Card = registerClientReference(null, "src/components/ui.tsx", "Card")',
+    )
+  })
+})
+
+describe('component global wrappers', () => {
+  it('builds a named-export wrapper that reads the export off the registry module', () => {
+    const code = buildGlobalClientComponentWrapper('TheCard', 'components/ui', 'Card')
+
+    expect(code).toContain('Component["Card"]')
+    expect(code).toContain('globalThis[\'~clientComponents\']?.["components/ui"]')
+  })
+
+  it('builds a namespace wrapper', () => {
+    expect(buildGlobalClientNamespaceWrapper('UI', 'components/ui')).toContain(
+      'globalThis[\'~clientComponents\']?.["components/ui"]',
+    )
+  })
+})
+
+describe('transformInlineServerActions', () => {
+  it('returns null when there are no inline actions', () => {
+    expect(
+      transformInlineServerActions(`export async function Page() { return null }\n`, 'page'),
+    ).toBeNull()
+  })
+
+  it('hoists a nested async function declaration with no closure', () => {
+    const input = `import { persist } from './db'
+export default async function Page() {
+  async function save(formData) {
+    'use server'
+    await persist(formData)
+  }
+  return save
+}
+`
+
+    const result = transformInlineServerActions(input, 'src/app/page')
+    expect(result).not.toBeNull()
+    expect(result!.actionNames[0]).toMatch(/^\$\$ACTION_0_save$/)
+    expect(result!.code).toContain('const save = $$ACTION_0_save')
+    expect(result!.code).toContain('async function $$ACTION_0_save(formData)')
+    expect(result!.code).toContain('await persist(formData)')
+    expect(result!.code).not.toContain("'use server'")
+    expect(result!.code).toContain(
+      'registerServerReference($$ACTION_0_save, "src/app/page", "$$ACTION_0_save")',
+    )
+  })
+
+  it('binds closed-over identifiers as leading parameters', () => {
+    const input = `import { db } from './db'
+export default async function Page({ id }) {
+  async function like() {
+    "use server"
+    await db.like(id)
+  }
+  return like
+}
+`
+
+    const result = transformInlineServerActions(input, 'page')
+    expect(result!.code).toContain('$$ACTION_0_like.bind(null, id)')
+    expect(result!.code).toContain('async function $$ACTION_0_like(id)')
+    expect(result!.code).toContain('await db.like(id)')
+  })
+
+  it('hoists async arrow actions', () => {
+    const input = `import { save } from './db'
+export default function Page() {
+  const action = async (formData) => {
+    'use server'
+    await save(formData)
+  }
+  return action
+}
+`
+
+    const result = transformInlineServerActions(input, 'page')
+    expect(result!.code).toContain('const action = $$ACTION_0_anonymous_server_function')
+    expect(result!.code).toContain('async function $$ACTION_0_anonymous_server_function(formData)')
+  })
+})

--- a/test/unit/vite/deferred-transforms.test.ts
+++ b/test/unit/vite/deferred-transforms.test.ts
@@ -33,6 +33,17 @@ export function Real() {}
 `),
     ).toEqual(['Real'])
   })
+
+  it('collects export * as namespace names', () => {
+    expect(collectExportNames(`export * as ns from './mod'\nexport function Real() {}\n`)).toEqual([
+      'ns',
+      'Real',
+    ])
+  })
+
+  it('ignores bare export * re-exports', () => {
+    expect(collectExportNames(`export * from './mod'\n`)).toEqual([])
+  })
 })
 
 describe('buildClientReferenceStubModule', () => {
@@ -154,10 +165,13 @@ export default async function save(formData) {
     const result = transformInlineServerActions(input, 'page')
     expect(result).not.toBeNull()
     expect(result!.actionNames[0]).toMatch(/^\$\$ACTION_0_save$/)
-    expect(result!.code).toContain('export default $$ACTION_0_save')
+    expect(result!.rewrittenExportNames).toEqual(['default'])
+    expect(result!.code).toContain(
+      'export default registerServerReference($$ACTION_0_save, "page", "default")',
+    )
     expect(result!.code).toContain('async function $$ACTION_0_save(formData)')
     expect(result!.code).not.toContain('const save =')
-    expect(result!.code).toContain(
+    expect(result!.code).not.toContain(
       'registerServerReference($$ACTION_0_save, "page", "$$ACTION_0_save")',
     )
   })

--- a/test/unit/vite/deferred-transforms.test.ts
+++ b/test/unit/vite/deferred-transforms.test.ts
@@ -175,4 +175,23 @@ export default async function save(formData) {
       'registerServerReference($$ACTION_0_save, "page", "$$ACTION_0_save")',
     )
   })
+
+  it('preserves surrounding binding for exported arrow actions and registers once', () => {
+    const input = `import { db } from './db'
+export const save = async (formData) => {
+  'use server'
+  await db.write(formData)
+}
+`
+
+    const result = transformInlineServerActions(input, 'page')
+    expect(result!.rewrittenExportNames).toEqual(['save'])
+    expect(result!.code).toContain(
+      'export const save = registerServerReference($$ACTION_0_anonymous_server_function, "page", "save")',
+    )
+    expect(result!.code).toContain('async function $$ACTION_0_anonymous_server_function(formData)')
+    expect(result!.code).not.toContain(
+      'registerServerReference($$ACTION_0_anonymous_server_function, "page", "$$ACTION_0_anonymous_server_function")',
+    )
+  })
 })

--- a/test/unit/vite/deferred-transforms.test.ts
+++ b/test/unit/vite/deferred-transforms.test.ts
@@ -22,6 +22,17 @@ describe('collectExportNames', () => {
       'b',
     ])
   })
+
+  it('ignores export-like text in comments and strings', () => {
+    expect(
+      collectExportNames(`
+// export function Fake() {}
+/* export default function AlsoFake() {} */
+const msg = "export function Nope() {}"
+export function Real() {}
+`),
+    ).toEqual(['Real'])
+  })
 })
 
 describe('buildClientReferenceStubModule', () => {
@@ -130,5 +141,24 @@ export default async function Page() {
     const result = transformInlineServerActions(input, 'page')
     expect(result!.code).toContain('async function $$ACTION_0_save(formData)')
     expect(result!.code).not.toContain('.bind(null,')
+  })
+
+  it('emits export default for a directly default-exported inline action', () => {
+    const input = `import { db } from './db'
+export default async function save(formData) {
+  'use server'
+  await db.write(formData)
+}
+`
+
+    const result = transformInlineServerActions(input, 'page')
+    expect(result).not.toBeNull()
+    expect(result!.actionNames[0]).toMatch(/^\$\$ACTION_0_save$/)
+    expect(result!.code).toContain('export default $$ACTION_0_save')
+    expect(result!.code).toContain('async function $$ACTION_0_save(formData)')
+    expect(result!.code).not.toContain('const save =')
+    expect(result!.code).toContain(
+      'registerServerReference($$ACTION_0_save, "page", "$$ACTION_0_save")',
+    )
   })
 })

--- a/test/unit/vite/deferred-transforms.test.ts
+++ b/test/unit/vite/deferred-transforms.test.ts
@@ -114,4 +114,21 @@ export default function Page() {
     expect(result!.code).toContain('const action = $$ACTION_0_anonymous_server_function')
     expect(result!.code).toContain('async function $$ACTION_0_anonymous_server_function(formData)')
   })
+
+  it('ignores string literals and comments when collecting free vars', () => {
+    const input = `import { db } from './db'
+export default async function Page() {
+  async function save(formData) {
+    'use server'
+    // mentions leakedVar in a comment
+    await db.write(formData, "alsoLeaked")
+  }
+  return save
+}
+`
+
+    const result = transformInlineServerActions(input, 'page')
+    expect(result!.code).toContain('async function $$ACTION_0_save(formData)')
+    expect(result!.code).not.toContain('.bind(null,')
+  })
 })

--- a/test/unit/vite/import-scanner.test.ts
+++ b/test/unit/vite/import-scanner.test.ts
@@ -1,0 +1,147 @@
+import { scanImportStatements } from '@rari/vite/analysis/directives'
+import { describe, expect, it } from 'vite-plus/test'
+
+describe('scanImportStatements', () => {
+  it('parses a default import', () => {
+    const code = `import Button from './Button'\nexport const x = 1\n`
+    const [imp] = scanImportStatements(code)
+
+    expect(imp.source).toBe('./Button')
+    expect(imp.defaultBinding).toBe('Button')
+    expect(imp.namespaceBinding).toBeNull()
+    expect(imp.named).toEqual([])
+    expect(code.slice(imp.start, imp.end)).toBe(`import Button from './Button'`)
+  })
+
+  it('parses named imports with aliases', () => {
+    const code = `import { Button as B, Card } from "./ui";`
+    const [imp] = scanImportStatements(code)
+
+    expect(imp.named).toEqual([
+      { imported: 'Button', local: 'B', typeOnly: false },
+      { imported: 'Card', local: 'Card', typeOnly: false },
+    ])
+    expect(code.slice(imp.start, imp.end)).toBe(code)
+  })
+
+  it('parses combined default and named imports', () => {
+    const code = `import Button, { Card, Chip as C } from './ui'\n`
+    const [imp] = scanImportStatements(code)
+
+    expect(imp.defaultBinding).toBe('Button')
+    expect(imp.named).toEqual([
+      { imported: 'Card', local: 'Card', typeOnly: false },
+      { imported: 'Chip', local: 'C', typeOnly: false },
+    ])
+  })
+
+  it('parses namespace imports, including combined with default', () => {
+    const [ns, combined] = scanImportStatements(
+      `import * as UI from './ui'\nimport React, * as ReactNS from 'react'\n`,
+    )
+
+    expect(ns.namespaceBinding).toBe('UI')
+    expect(ns.defaultBinding).toBeNull()
+    expect(combined.defaultBinding).toBe('React')
+    expect(combined.namespaceBinding).toBe('ReactNS')
+  })
+
+  it('parses multi-line imports with a correct span', () => {
+    const code = `import {\n  Button,\n  Card as TheCard,\n} from './ui'\nconst after = 1\n`
+    const [imp] = scanImportStatements(code)
+
+    expect(imp.named).toEqual([
+      { imported: 'Button', local: 'Button', typeOnly: false },
+      { imported: 'Card', local: 'TheCard', typeOnly: false },
+    ])
+    expect(code.slice(imp.end)).toBe(`\nconst after = 1\n`)
+  })
+
+  it('parses side-effect imports', () => {
+    const [imp] = scanImportStatements(`import './styles.css';\n`)
+
+    expect(imp.sideEffectOnly).toBe(true)
+    expect(imp.source).toBe('./styles.css')
+  })
+
+  it('marks type-only imports and inline type specifiers', () => {
+    const code = `import type { Props } from './types'\nimport { type Meta, Button } from './ui'\n`
+    const [typeImport, mixed] = scanImportStatements(code)
+
+    expect(typeImport.typeOnly).toBe(true)
+    expect(mixed.typeOnly).toBe(false)
+    expect(mixed.named).toEqual([
+      { imported: 'Meta', local: 'Meta', typeOnly: true },
+      { imported: 'Button', local: 'Button', typeOnly: false },
+    ])
+  })
+
+  it('treats `type` as a default binding when followed by from', () => {
+    const [imp] = scanImportStatements(`import type from './type-module'\n`)
+
+    expect(imp.typeOnly).toBe(false)
+    expect(imp.defaultBinding).toBe('type')
+  })
+
+  it('parses string import names with aliases', () => {
+    const [imp] = scanImportStatements(`import { "dash-name" as dashName } from './x'\n`)
+
+    expect(imp.named).toEqual([{ imported: 'dash-name', local: 'dashName', typeOnly: false }])
+  })
+
+  it('ignores dynamic imports and import.meta', () => {
+    const code = `const mod = await import('./lazy')\nconsole.log(import.meta.url)\n`
+
+    expect(scanImportStatements(code)).toEqual([])
+  })
+
+  it('ignores imports inside strings, template literals, and comments', () => {
+    const code = [
+      `const a = "import Fake from './fake'"`,
+      'const b = `import Fake2 from "./fake2"`',
+      `// import Fake3 from './fake3'`,
+      `/* import Fake4 from './fake4' */`,
+      `import Real from './real'`,
+    ].join('\n')
+
+    const imports = scanImportStatements(code)
+    expect(imports).toHaveLength(1)
+    expect(imports[0].defaultBinding).toBe('Real')
+  })
+
+  it('ignores imports inside JSX text', () => {
+    const code = `import Real from './real'\nexport default function P() {\n  return <div>import Fake from './fake'</div>\n}\n`
+
+    const imports = scanImportStatements(code)
+    expect(imports).toHaveLength(1)
+    expect(imports[0].source).toBe('./real')
+  })
+
+  it('does not treat identifiers containing "import" as imports', () => {
+    const code = `const reimport = 1\nconst importantThing = reimport\n`
+
+    expect(scanImportStatements(code)).toEqual([])
+  })
+
+  it('includes the trailing semicolon in the span', () => {
+    const code = `import A from './a';  \nconst x = 1\n`
+    const [imp] = scanImportStatements(code)
+
+    expect(code.slice(imp.start, imp.end)).toBe(`import A from './a';`)
+  })
+
+  it('scans multiple statements with correct ordering', () => {
+    const code = `import A from './a'\nimport { B } from './b'\nimport * as C from './c'\n`
+    const imports = scanImportStatements(code)
+
+    expect(imports.map(imp => imp.source)).toEqual(['./a', './b', './c'])
+  })
+
+  it('recovers after malformed import-like code', () => {
+    const code = `import !!!\nimport Real from './real'\n`
+    const imports = scanImportStatements(code)
+
+    expect(imports).toHaveLength(1)
+    expect(imports[0].defaultBinding).toBe('Real')
+  })
+})


### PR DESCRIPTION
Drive both Vite and ServerComponentBuilder client-reference rewrites from scanImportStatements so multi-line, aliased, combined, and namespace imports are rewritten instead of silently bundling client code. Also span export default expressions correctly so 'use server' arrow bodies are not truncated at the first semicolon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for default, named, aliased, namespace, type-only, and multiline imports.
  * Added automatic handling for inline server actions and complex default exports.
  * Improved client component references with generated wrappers and named export support.

* **Bug Fixes**
  * Prevented type-only and side-effect imports from generating runtime code.
  * Improved handling of comments, strings, JSX, nested expressions, and malformed import syntax.
  * Preserved imported names and aliases during client-reference generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->