### PR TITLE
test(rust): standardize unit tests under mod tests

### DIFF
--- a/crates/rari/src/rendering/layout/utils.rs
+++ b/crates/rari/src/rendering/layout/utils.rs
@@ -236,7 +236,7 @@ pub fn sort_flight_protocol(flight_protocol: &str) -> String {
 }
 
 #[cfg(test)]
-mod flight_tests {
+mod tests {
     use super::sort_flight_protocol;
 
     #[test]

--- a/crates/rari/src/runtime/mod.rs
+++ b/crates/rari/src/runtime/mod.rs
@@ -282,7 +282,7 @@ impl JsExecutionRuntime {
 
 #[cfg(test)]
 #[expect(clippy::expect_used)]
-mod overlapping_stream_tests {
+mod tests {
     use std::{
         sync::Arc,
         time::{Duration, Instant},

--- a/crates/rari/src/runtime/module_loader/transpiler.rs
+++ b/crates/rari/src/runtime/module_loader/transpiler.rs
@@ -11,11 +11,6 @@ pub fn needs_jsx_transpilation(specifier: &str) -> bool {
     specifier.ends_with(JSX_EXTENSION)
 }
 
-#[cfg(test)]
-pub fn needs_transpilation(specifier: &str) -> bool {
-    needs_typescript_transpilation(specifier) || needs_jsx_transpilation(specifier)
-}
-
 pub fn get_module_type(_specifier: &str) -> &'static str {
     "module"
 }
@@ -23,6 +18,10 @@ pub fn get_module_type(_specifier: &str) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn needs_transpilation(specifier: &str) -> bool {
+        needs_typescript_transpilation(specifier) || needs_jsx_transpilation(specifier)
+    }
 
     #[test]
     fn test_typescript_detection() {

--- a/crates/rari/src/runtime/ops.rs
+++ b/crates/rari/src/runtime/ops.rs
@@ -254,63 +254,6 @@ pub async fn op_send_chunk_to_rust(
     Ok(())
 }
 
-#[cfg(test)]
-pub fn create_module_operation(
-    row_id: &str,
-    module_id: &str,
-    chunks: &[&str],
-    name: &str,
-) -> String {
-    serde_json::json!({
-        "type": "module",
-        "row_id": row_id,
-        "module_id": module_id,
-        "chunks": chunks,
-        "name": name,
-        "async_module": false
-    })
-    .to_string()
-}
-
-#[cfg(test)]
-pub fn create_element_operation(row_id: &str, element: &serde_json::Value) -> String {
-    serde_json::json!({
-        "type": "element",
-        "row_id": row_id,
-        "element": element
-    })
-    .to_string()
-}
-
-#[cfg(test)]
-pub fn create_symbol_operation(row_id: &str, symbol_ref: &str) -> String {
-    serde_json::json!({
-        "type": "symbol",
-        "row_id": row_id,
-        "symbol_ref": symbol_ref
-    })
-    .to_string()
-}
-
-#[cfg(test)]
-pub fn create_error_operation(
-    row_id: &str,
-    message: &str,
-    stack: Option<&str>,
-    phase: Option<&str>,
-    digest: Option<&str>,
-) -> String {
-    serde_json::json!({
-        "type": "error",
-        "row_id": row_id,
-        "message": message,
-        "stack": stack,
-        "phase": phase,
-        "digest": digest
-    })
-    .to_string()
-}
-
 #[op2(fast)]
 pub fn op_rari_has_node_modules_dir(state: &OpState) -> bool {
     state.try_borrow::<BootstrapOptions>().is_some_and(|options| options.has_node_modules_dir)
@@ -888,6 +831,59 @@ mod tests {
     use tokio::sync::mpsc;
 
     use super::*;
+
+    fn create_module_operation(
+        row_id: &str,
+        module_id: &str,
+        chunks: &[&str],
+        name: &str,
+    ) -> String {
+        serde_json::json!({
+            "type": "module",
+            "row_id": row_id,
+            "module_id": module_id,
+            "chunks": chunks,
+            "name": name,
+            "async_module": false
+        })
+        .to_string()
+    }
+
+    fn create_element_operation(row_id: &str, element: &serde_json::Value) -> String {
+        serde_json::json!({
+            "type": "element",
+            "row_id": row_id,
+            "element": element
+        })
+        .to_string()
+    }
+
+    fn create_symbol_operation(row_id: &str, symbol_ref: &str) -> String {
+        serde_json::json!({
+            "type": "symbol",
+            "row_id": row_id,
+            "symbol_ref": symbol_ref
+        })
+        .to_string()
+    }
+
+    fn create_error_operation(
+        row_id: &str,
+        message: &str,
+        stack: Option<&str>,
+        phase: Option<&str>,
+        digest: Option<&str>,
+    ) -> String {
+        serde_json::json!({
+            "type": "error",
+            "row_id": row_id,
+            "message": message,
+            "stack": stack,
+            "phase": phase,
+            "digest": digest
+        })
+        .to_string()
+    }
 
     #[test]
     fn test_stream_op_state_operations() {

--- a/crates/rari/src/server/actions.rs
+++ b/crates/rari/src/server/actions.rs
@@ -1091,7 +1091,7 @@ pub fn build_set_cookie_header(cookie: &PendingCookie) -> Result<String, RariErr
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, clippy::expect_used)]
+#[expect(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::server::{config::RedirectConfig, middleware::request_context::PendingCookie};

--- a/crates/rari/src/server/core/utils/component.rs
+++ b/crates/rari/src/server/core/utils/component.rs
@@ -240,8 +240,8 @@ pub fn get_dist_path_for_component(file_path: &str) -> Result<PathBuf, RariError
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, clippy::expect_used)]
-mod analysis_golden_tests {
+#[expect(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
     use std::{fs, path::PathBuf};
 
     use serde::Deserialize;

--- a/crates/rari/src/server/og/generator.rs
+++ b/crates/rari/src/server/og/generator.rs
@@ -419,12 +419,6 @@ impl OgImageGenerator {
         Ok(webp.to_vec())
     }
 
-    #[cfg(test)]
-    #[expect(clippy::expect_used)]
-    pub async fn clear_cache(&self) {
-        self.cache.clear().await.expect("clear");
-    }
-
     #[expect(clippy::missing_errors_doc)]
     pub async fn invalidate(&self, route_path: &str) -> Result<(), CacheError> {
         self.cache.remove(route_path).await.map(|_| ())

--- a/crates/rari/src/server/routing/api_routes.rs
+++ b/crates/rari/src/server/routing/api_routes.rs
@@ -104,11 +104,6 @@ impl ApiRouteHandler {
         &self.runtime
     }
 
-    #[cfg(test)]
-    pub fn clear_cache(&self) {
-        self.handler_cache.clear();
-    }
-
     pub fn invalidate_handler(&self, file_path: &str) {
         self.handler_cache.remove(&create_component_id(file_path));
     }

--- a/crates/rari/src/server/routing/app_router.rs
+++ b/crates/rari/src/server/routing/app_router.rs
@@ -6,8 +6,6 @@ use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use tokio::fs;
 
-#[cfg(test)]
-use crate::server::routing::types::RouteSegmentType;
 use crate::server::routing::types::{ParamValue, RouteSegment};
 
 fn parse_decoded_path_segments(path: &str) -> Vec<String> {
@@ -661,6 +659,7 @@ impl AppRouter {
 #[expect(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use crate::server::routing::types::RouteSegmentType;
 
     fn build_minimal_manifest() -> AppRouteManifest {
         AppRouteManifest {

--- a/crates/rari_error/src/lib.rs
+++ b/crates/rari_error/src/lib.rs
@@ -651,8 +651,8 @@ impl From<DataError> for RariError {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used)]
 mod tests {
-    #![expect(clippy::unwrap_used)]
     use super::*;
 
     #[test]

--- a/crates/rari_use_cache/src/closure.rs
+++ b/crates/rari_use_cache/src/closure.rs
@@ -333,8 +333,8 @@ fn collect_pat_idents(pattern: &Pat, idents: &mut FxHashSet<Id>) {
 }
 
 #[cfg(test)]
+#[expect(clippy::expect_used, clippy::default_trait_access)]
 mod tests {
-    #![expect(clippy::default_trait_access, clippy::expect_used)]
     use deno_ast::swc::{
         ast::{
             AssignPatProp, BindingIdent, Class, ClassDecl, ClassExpr, Decl, DefaultDecl,

--- a/crates/rari_use_cache/src/directive.rs
+++ b/crates/rari_use_cache/src/directive.rs
@@ -142,8 +142,8 @@ pub fn detect_use_cache(source: &str) -> bool {
 }
 
 #[cfg(test)]
+#[expect(clippy::default_trait_access)]
 mod tests {
-    #![expect(clippy::default_trait_access)]
     use super::*;
 
     #[test]


### PR DESCRIPTION
Rename alternate test modules, move free test helpers into mod tests, and drop unused clear_cache helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restricted test-only helpers and cache controls to test code.
  * Removed unused public access to internal testing utilities without changing runtime behavior.
* **Tests**
  * Standardized test module naming and lint configuration.
  * Preserved existing test behavior and serialization checks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->