### PR TITLE
feat(config): add support for server origin configuration and enhance base URL handling

### DIFF
--- a/crates/rari/src/server/cache/handler.rs
+++ b/crates/rari/src/server/cache/handler.rs
@@ -770,7 +770,7 @@ mod tests {
     async fn test_noop_get_all_keys() {
         let handler = NoOpCacheHandler;
         handler.set("k", b"v".to_vec(), 60).await.unwrap();
-        assert!(handler.get_all_keys().is_empty());
+        assert_eq!(handler.get_all_keys(), Vec::<String>::new());
     }
 
     #[tokio::test]

--- a/crates/rari/src/server/cache/handler.rs
+++ b/crates/rari/src/server/cache/handler.rs
@@ -42,6 +42,10 @@ pub enum CacheError {
     Backend(String),
 }
 
+#[expect(
+    clippy::double_must_use,
+    reason = "async_trait adds #[must_use] on methods that already return a must-use Future"
+)]
 #[async_trait::async_trait]
 pub trait CacheHandler: Send + Sync + fmt::Debug {
     async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, CacheError>;

--- a/crates/rari/src/server/cache/response.rs
+++ b/crates/rari/src/server/cache/response.rs
@@ -993,7 +993,7 @@ mod tests {
         let policy = RouteCachePolicy::default();
         assert_eq!(policy.ttl, 60);
         assert!(policy.enabled);
-        assert!(policy.tags.is_empty());
+        assert_eq!(policy.tags, Vec::<String>::new());
     }
 
     #[test]

--- a/crates/rari/src/server/cache/warmup.rs
+++ b/crates/rari/src/server/cache/warmup.rs
@@ -158,7 +158,9 @@ async fn warm_route(
     let html_cache_key = response::ResponseCache::generate_cache_key(path, None);
     let cache_control = state.config.get_cache_control_for_route(path);
     let cache_policy = response::RouteCachePolicy::from_cache_control(cache_control, path);
-    let for_response_cache = cache_policy.enabled && state.response_cache.config.enabled;
+    let for_response_cache = cache_policy.enabled
+        && state.response_cache.config.enabled
+        && state.config.server.origin.is_some();
 
     let html = wrap_html_with_metadata(html, context.metadata.as_ref(), state);
     let etag = response::ResponseCache::generate_etag(html.as_bytes());

--- a/crates/rari/src/server/compression/stream.rs
+++ b/crates/rari/src/server/compression/stream.rs
@@ -272,7 +272,7 @@ mod tests {
             chunks.push(chunk.unwrap());
         }
 
-        assert!(!chunks.is_empty());
+        assert_ne!(chunks, Vec::<Bytes>::new());
         assert!(chunks.iter().all(|c| !c.is_empty()));
     }
 
@@ -288,7 +288,7 @@ mod tests {
             chunks.push(chunk.unwrap());
         }
 
-        assert!(!chunks.is_empty());
+        assert_ne!(chunks, Vec::<Bytes>::new());
     }
 
     #[tokio::test]
@@ -303,7 +303,7 @@ mod tests {
             chunks.push(chunk.unwrap());
         }
 
-        assert!(!chunks.is_empty());
+        assert_ne!(chunks, Vec::<Bytes>::new());
         assert!(chunks.iter().all(|c| !c.is_empty()));
     }
 

--- a/crates/rari/src/server/config.rs
+++ b/crates/rari/src/server/config.rs
@@ -684,6 +684,15 @@ impl Config {
                         .collect();
                 }
 
+                if config.server.origin.is_none()
+                    && let Some(origin) = config_data.get("origin").and_then(Value::as_str)
+                {
+                    let origin = origin.trim();
+                    if !origin.is_empty() {
+                        config.server.origin = Some(origin.to_string());
+                    }
+                }
+
                 if let Some(pool_size) =
                     config_data.get("jsPoolSize").and_then(serde_json::Value::as_u64)
                 {
@@ -1243,6 +1252,33 @@ mod tests {
             !config.caching.routes.contains_key("/invalid-type"),
             "Non-string cache-control value should be rejected"
         );
+    }
+
+    #[test]
+    fn test_origin_config_json_and_env_precedence() {
+        let temp_dir = env::temp_dir().join(format!("rari_test_origin_{}", process::id()));
+        let dist_server_dir = temp_dir.join("dist").join("server");
+        fs::create_dir_all(&dist_server_dir).unwrap();
+
+        let prev = env::var("RARI_ORIGIN").ok();
+        // SAFETY: test-only env mutation; restored below. Keep both cases in one
+        // test so parallel suite workers cannot race on this process-global var.
+        unsafe { env::remove_var("RARI_ORIGIN") };
+
+        fs::write(dist_server_dir.join("config.json"), r#"{"origin":"https://rari.build"}"#)
+            .unwrap();
+        let from_json = Config::from_env_with_base(Some(&temp_dir)).unwrap();
+        assert_eq!(from_json.server.origin.as_deref(), Some("https://rari.build"));
+
+        unsafe { env::set_var("RARI_ORIGIN", "https://preview.example") };
+        let from_env = Config::from_env_with_base(Some(&temp_dir)).unwrap();
+        assert_eq!(from_env.server.origin.as_deref(), Some("https://preview.example"));
+
+        let _ = fs::remove_dir_all(&temp_dir);
+        match prev {
+            Some(v) => unsafe { env::set_var("RARI_ORIGIN", v) },
+            None => unsafe { env::remove_var("RARI_ORIGIN") },
+        }
     }
 
     #[test]

--- a/crates/rari/src/server/config.rs
+++ b/crates/rari/src/server/config.rs
@@ -523,7 +523,10 @@ impl Config {
         }
 
         if let Ok(origin) = env::var("RARI_ORIGIN") {
-            config.server.origin = Some(origin);
+            let origin = origin.trim().trim_end_matches('/');
+            if !origin.is_empty() {
+                config.server.origin = Some(origin.to_string());
+            }
         }
 
         if let Ok(vite_host) = env::var("RARI_VITE_HOST") {
@@ -687,7 +690,7 @@ impl Config {
                 if config.server.origin.is_none()
                     && let Some(origin) = config_data.get("origin").and_then(Value::as_str)
                 {
-                    let origin = origin.trim();
+                    let origin = origin.trim().trim_end_matches('/');
                     if !origin.is_empty() {
                         config.server.origin = Some(origin.to_string());
                     }
@@ -1265,12 +1268,16 @@ mod tests {
         // test so parallel suite workers cannot race on this process-global var.
         unsafe { env::remove_var("RARI_ORIGIN") };
 
-        fs::write(dist_server_dir.join("config.json"), r#"{"origin":"https://rari.build"}"#)
+        fs::write(dist_server_dir.join("config.json"), r#"{"origin":"https://rari.build/"}"#)
             .unwrap();
         let from_json = Config::from_env_with_base(Some(&temp_dir)).unwrap();
         assert_eq!(from_json.server.origin.as_deref(), Some("https://rari.build"));
 
-        unsafe { env::set_var("RARI_ORIGIN", "https://preview.example") };
+        unsafe { env::set_var("RARI_ORIGIN", "   ") };
+        let blank_env = Config::from_env_with_base(Some(&temp_dir)).unwrap();
+        assert_eq!(blank_env.server.origin.as_deref(), Some("https://rari.build"));
+
+        unsafe { env::set_var("RARI_ORIGIN", "https://preview.example/") };
         let from_env = Config::from_env_with_base(Some(&temp_dir)).unwrap();
         assert_eq!(from_env.server.origin.as_deref(), Some("https://preview.example"));
 

--- a/crates/rari/src/server/middleware/request_context.rs
+++ b/crates/rari/src/server/middleware/request_context.rs
@@ -382,7 +382,7 @@ mod tests {
         let ctx = RequestContext::new("/test".to_string());
 
         assert_eq!(ctx.route_path(), "/test");
-        assert!(!ctx.request_id().is_empty());
+        assert_ne!(ctx.request_id(), "");
         assert!(ctx.elapsed().as_millis() < 100);
     }
 

--- a/crates/rari/src/server/routing/app.rs
+++ b/crates/rari/src/server/routing/app.rs
@@ -303,7 +303,9 @@ async fn inject_og_image_into_metadata(
     metadata: &mut PageMetadata,
     context: &LayoutRenderContext,
 ) {
-    let base_url = get_base_url_from_context(context, &state.config);
+    let Some(base_url) = get_base_url_from_context(context, &state.config) else {
+        return;
+    };
     let current_url = format!("{base_url}{route_path}");
 
     if let Some(ref mut og) = metadata.open_graph {
@@ -367,21 +369,20 @@ async fn inject_og_image_into_metadata(
     }
 }
 
-fn get_base_url_from_context(context: &LayoutRenderContext, config: &Config) -> String {
-    if let Some(host) = context.headers.get("host") {
-        let protocol = context
-            .headers
-            .get("x-forwarded-proto")
-            .or_else(|| context.headers.get("x-forwarded-protocol"))
-            .map(String::as_str)
-            .unwrap_or_else(|| if config.is_production() { "https" } else { "http" });
-
-        format!("{protocol}://{host}")
-    } else if config.is_production() {
-        "https://localhost".to_string()
-    } else {
-        format!("http://localhost:{}", config.server.port)
+fn get_base_url_from_context(context: &LayoutRenderContext, config: &Config) -> Option<String> {
+    if let Some(origin) = config.server.origin.as_deref().map(str::trim).filter(|o| !o.is_empty()) {
+        return Some(origin.trim_end_matches('/').to_string());
     }
+
+    let host = context.headers.get("host")?;
+    let protocol = context
+        .headers
+        .get("x-forwarded-proto")
+        .or_else(|| context.headers.get("x-forwarded-protocol"))
+        .map(String::as_str)
+        .unwrap_or_else(|| if config.is_production() { "https" } else { "http" });
+
+    Some(format!("{protocol}://{host}"))
 }
 
 pub async fn render_with_fallback(
@@ -2005,5 +2006,49 @@ mod tests {
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
         let _ = fs::remove_dir_all(public_dir);
+    }
+
+    fn empty_layout_context() -> LayoutRenderContext {
+        LayoutRenderContext {
+            params: FxHashMap::default(),
+            search_params: FxHashMap::default(),
+            headers: FxHashMap::default(),
+            pathname: "/".to_string(),
+            template_navigation_id: None,
+            metadata: None,
+            streaming_head_extra: None,
+        }
+    }
+
+    #[test]
+    fn test_og_base_url_prefers_configured_origin() {
+        let mut config = Config::new(Mode::Production);
+        config.server.origin = Some("https://rari.build/".to_string());
+
+        let mut context = empty_layout_context();
+        context.headers.insert("host".to_string(), "localhost".to_string());
+
+        assert_eq!(
+            get_base_url_from_context(&context, &config).as_deref(),
+            Some("https://rari.build")
+        );
+    }
+
+    #[test]
+    fn test_og_base_url_uses_host_when_origin_unset() {
+        let config = Config::new(Mode::Production);
+        let mut context = empty_layout_context();
+        context.headers.insert("host".to_string(), "rari.build".to_string());
+
+        assert_eq!(
+            get_base_url_from_context(&context, &config).as_deref(),
+            Some("https://rari.build")
+        );
+    }
+
+    #[test]
+    fn test_og_base_url_none_without_host_or_origin() {
+        let config = Config::new(Mode::Production);
+        assert_eq!(get_base_url_from_context(&empty_layout_context(), &config), None);
     }
 }

--- a/crates/rari/src/server/routing/app.rs
+++ b/crates/rari/src/server/routing/app.rs
@@ -375,12 +375,21 @@ fn get_base_url_from_context(context: &LayoutRenderContext, config: &Config) -> 
     }
 
     let host = context.headers.get("host")?;
-    let protocol = context
+    let forwarded = context
         .headers
         .get("x-forwarded-proto")
         .or_else(|| context.headers.get("x-forwarded-protocol"))
         .map(String::as_str)
-        .unwrap_or_else(|| if config.is_production() { "https" } else { "http" });
+        .unwrap_or("");
+    let protocol = if forwarded.eq_ignore_ascii_case("https") {
+        "https"
+    } else if forwarded.eq_ignore_ascii_case("http") {
+        "http"
+    } else if config.is_production() {
+        "https"
+    } else {
+        "http"
+    };
 
     Some(format!("{protocol}://{host}"))
 }
@@ -2050,5 +2059,18 @@ mod tests {
     fn test_og_base_url_none_without_host_or_origin() {
         let config = Config::new(Mode::Production);
         assert_eq!(get_base_url_from_context(&empty_layout_context(), &config), None);
+    }
+
+    #[test]
+    fn test_og_base_url_ignores_non_http_forwarded_proto() {
+        let config = Config::new(Mode::Production);
+        let mut context = empty_layout_context();
+        context.headers.insert("host".to_string(), "rari.build".to_string());
+        context.headers.insert("x-forwarded-proto".to_string(), "javascript".to_string());
+
+        assert_eq!(
+            get_base_url_from_context(&context, &config).as_deref(),
+            Some("https://rari.build")
+        );
     }
 }

--- a/packages/rari/src/vite/index.ts
+++ b/packages/rari/src/vite/index.ts
@@ -1379,6 +1379,7 @@ ${clientTransformedCode}`
 
         const vitePort = server.config.server.port
         const origin = options.origin?.trim().replace(/\/+$/, '')
+        const envOrigin = process.env.RARI_ORIGIN?.trim().replace(/\/+$/, '')
 
         const args = ['--mode', mode, '--port', serverPort.toString(), '--host', '127.0.0.1']
 
@@ -1397,9 +1398,7 @@ ${clientTransformedCode}`
             (process.env.RARI_JS_POOL_SIZE == null || process.env.RARI_JS_POOL_SIZE === '')
               ? { RARI_JS_POOL_SIZE: String(options.jsPoolSize) }
               : {}),
-            ...(origin != null &&
-            origin !== '' &&
-            (process.env.RARI_ORIGIN == null || process.env.RARI_ORIGIN === '')
+            ...(origin != null && origin !== '' && (envOrigin == null || envOrigin === '')
               ? { RARI_ORIGIN: origin }
               : {}),
             ...(options.htmlLimitedBots != null &&

--- a/packages/rari/src/vite/index.ts
+++ b/packages/rari/src/vite/index.ts
@@ -169,6 +169,7 @@ export interface RariOptions {
     readonly allowedOrigins?: readonly string[]
   }
   readonly jsPoolSize?: number
+  readonly origin?: string
   readonly htmlLimitedBots?: string
   readonly cache?: ServerCacheConfig
   readonly experimental?: {
@@ -1257,6 +1258,7 @@ ${clientTransformedCode}`
             cache: options.cache,
             action: options.action,
             jsPoolSize: options.jsPoolSize,
+            origin: options.origin,
             htmlLimitedBots: options.htmlLimitedBots,
             experimental: options.experimental,
             moduleAnalysisCache,
@@ -1389,10 +1391,15 @@ ${clientTransformedCode}`
                 ? process.env.RUST_LOG
                 : 'error',
             RARI_VITE_PORT: vitePort.toString(),
-            // Dev starts the binary before config.json is written; pass pool size / bots via env.
+            // Dev starts the binary before config.json is written; pass pool size / origin / bots via env.
             ...(options.jsPoolSize != null &&
             (process.env.RARI_JS_POOL_SIZE == null || process.env.RARI_JS_POOL_SIZE === '')
               ? { RARI_JS_POOL_SIZE: String(options.jsPoolSize) }
+              : {}),
+            ...(options.origin != null &&
+            options.origin !== '' &&
+            (process.env.RARI_ORIGIN == null || process.env.RARI_ORIGIN === '')
+              ? { RARI_ORIGIN: options.origin }
               : {}),
             ...(options.htmlLimitedBots != null &&
             (process.env.RARI_HTML_LIMITED_BOTS == null ||
@@ -2208,6 +2215,7 @@ export const createTemporaryReferenceSet = module.exports.createTemporaryReferen
     cache: options.cache,
     action: options.action,
     jsPoolSize: options.jsPoolSize,
+    origin: options.origin,
     htmlLimitedBots: options.htmlLimitedBots,
     experimental: options.experimental,
     moduleAnalysisCache,

--- a/packages/rari/src/vite/index.ts
+++ b/packages/rari/src/vite/index.ts
@@ -1378,6 +1378,7 @@ ${clientTransformedCode}`
         const mode = process.env.NODE_ENV === 'production' ? 'production' : 'development'
 
         const vitePort = server.config.server.port
+        const origin = options.origin?.trim().replace(/\/+$/, '')
 
         const args = ['--mode', mode, '--port', serverPort.toString(), '--host', '127.0.0.1']
 
@@ -1396,10 +1397,10 @@ ${clientTransformedCode}`
             (process.env.RARI_JS_POOL_SIZE == null || process.env.RARI_JS_POOL_SIZE === '')
               ? { RARI_JS_POOL_SIZE: String(options.jsPoolSize) }
               : {}),
-            ...(options.origin != null &&
-            options.origin !== '' &&
+            ...(origin != null &&
+            origin !== '' &&
             (process.env.RARI_ORIGIN == null || process.env.RARI_ORIGIN === '')
-              ? { RARI_ORIGIN: options.origin }
+              ? { RARI_ORIGIN: origin }
               : {}),
             ...(options.htmlLimitedBots != null &&
             (process.env.RARI_HTML_LIMITED_BOTS == null ||

--- a/packages/rari/src/vite/server/build.ts
+++ b/packages/rari/src/vite/server/build.ts
@@ -1456,8 +1456,8 @@ export class ServerComponentBuilder {
     if (this.options.cache) serverConfig.cache = this.options.cache
     if (this.options.action) serverConfig.action = this.options.action
     if (this.options.jsPoolSize != null) serverConfig.jsPoolSize = this.options.jsPoolSize
-    if (this.options.origin != null && this.options.origin !== '')
-      serverConfig.origin = this.options.origin
+    const origin = this.options.origin?.trim().replace(/\/+$/, '')
+    if (origin != null && origin !== '') serverConfig.origin = origin
     if (this.options.htmlLimitedBots != null)
       serverConfig.htmlLimitedBots = this.options.htmlLimitedBots
     if (

--- a/packages/rari/src/vite/server/build.ts
+++ b/packages/rari/src/vite/server/build.ts
@@ -230,6 +230,7 @@ export interface ServerBuildOptions {
   readonly cache?: ServerCacheConfig
   readonly action?: ServerActionConfig
   readonly jsPoolSize?: number
+  readonly origin?: string
   readonly htmlLimitedBots?: string
   readonly moduleAnalysisCache?: ModuleAnalysisCache
   readonly experimental?: {
@@ -254,6 +255,7 @@ type ResolvedServerBuildOptions = Required<
     | 'cache'
     | 'action'
     | 'jsPoolSize'
+    | 'origin'
     | 'htmlLimitedBots'
     | 'define'
     | 'serverConfigPath'
@@ -268,6 +270,7 @@ type ResolvedServerBuildOptions = Required<
   cache?: ServerBuildOptions['cache']
   action?: ServerBuildOptions['action']
   jsPoolSize?: ServerBuildOptions['jsPoolSize']
+  origin?: ServerBuildOptions['origin']
   htmlLimitedBots?: ServerBuildOptions['htmlLimitedBots']
   define?: ServerBuildOptions['define']
   experimental?: ServerBuildOptions['experimental']
@@ -484,6 +487,7 @@ export class ServerComponentBuilder {
       cache: options.cache,
       action: options.action,
       jsPoolSize: options.jsPoolSize,
+      origin: options.origin,
       htmlLimitedBots: options.htmlLimitedBots,
       experimental: options.experimental,
       mdx: options.mdx,
@@ -1452,6 +1456,8 @@ export class ServerComponentBuilder {
     if (this.options.cache) serverConfig.cache = this.options.cache
     if (this.options.action) serverConfig.action = this.options.action
     if (this.options.jsPoolSize != null) serverConfig.jsPoolSize = this.options.jsPoolSize
+    if (this.options.origin != null && this.options.origin !== '')
+      serverConfig.origin = this.options.origin
     if (this.options.htmlLimitedBots != null)
       serverConfig.htmlLimitedBots = this.options.htmlLimitedBots
     if (

--- a/packages/rari/src/vite/server/config.ts
+++ b/packages/rari/src/vite/server/config.ts
@@ -44,5 +44,6 @@ export interface ServerConfig {
   useCache?: ServerUseCacheConfig
   action?: ServerActionConfig
   jsPoolSize?: number
+  origin?: string
   htmlLimitedBots?: string
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional server origin configuration for builds and development environments.
  - Server origins can be loaded from configuration files or environment settings, with whitespace and trailing slashes normalized.
  - Open Graph URLs now use the configured origin or request host when available.

- **Bug Fixes**
  - Prevented response-cache warmup when no server origin is configured.
  - Stopped generating metadata URLs with an incorrect localhost fallback when no host is available.
  - Rejected unsupported forwarded protocols when generating metadata URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->