### PR TITLE
feat(svg): enhance JSX to SVG conversion by adding style serialization and layout-only style filtering

### DIFF
--- a/crates/rari/src/server/og/rendering/svg.rs
+++ b/crates/rari/src/server/og/rendering/svg.rs
@@ -142,68 +142,47 @@ fn json_attr_value(value: &serde_json::Value) -> Option<String> {
     }
 }
 
-fn is_layout_only_style(key: &str) -> bool {
+fn is_svg_presentation_style(key: &str) -> bool {
+    if key.starts_with("--") || key.starts_with('-') {
+        return false;
+    }
+
     matches!(
         key,
-        "display"
-            | "flex"
-            | "flexDirection"
-            | "flexGrow"
-            | "flexShrink"
-            | "flexBasis"
-            | "flexWrap"
-            | "alignItems"
-            | "alignContent"
-            | "alignSelf"
-            | "justifyContent"
-            | "justifyItems"
-            | "justifySelf"
-            | "gap"
-            | "rowGap"
-            | "columnGap"
-            | "margin"
-            | "marginTop"
-            | "marginRight"
-            | "marginBottom"
-            | "marginLeft"
-            | "padding"
-            | "paddingTop"
-            | "paddingRight"
-            | "paddingBottom"
-            | "paddingLeft"
-            | "width"
-            | "height"
-            | "minWidth"
-            | "minHeight"
-            | "maxWidth"
-            | "maxHeight"
-            | "position"
-            | "top"
-            | "right"
-            | "bottom"
-            | "left"
-            | "inset"
-            | "overflow"
-            | "overflowX"
-            | "overflowY"
-            | "border"
-            | "borderWidth"
-            | "borderStyle"
-            | "borderColor"
-            | "borderRadius"
-            | "borderTop"
-            | "borderRight"
-            | "borderBottom"
-            | "borderLeft"
-            | "background"
-            | "backgroundColor"
-            | "backgroundImage"
-            | "lineHeight"
-            | "textAlign"
-            | "objectFit"
-            | "objectPosition"
-            | "boxSizing"
-            | "zIndex"
+        "color"
+            | "fill"
+            | "stroke"
+            | "opacity"
+            | "fillOpacity"
+            | "strokeOpacity"
+            | "strokeWidth"
+            | "strokeLinecap"
+            | "strokeLinejoin"
+            | "strokeDasharray"
+            | "strokeDashoffset"
+            | "strokeMiterlimit"
+            | "fillRule"
+            | "clipPath"
+            | "clipRule"
+            | "fontFamily"
+            | "fontSize"
+            | "fontWeight"
+            | "fontStyle"
+            | "fontVariant"
+            | "letterSpacing"
+            | "wordSpacing"
+            | "textAnchor"
+            | "textDecoration"
+            | "stopColor"
+            | "stopOpacity"
+            | "floodColor"
+            | "floodOpacity"
+            | "transform"
+            | "filter"
+            | "mask"
+            | "vectorEffect"
+            | "paintOrder"
+            | "dominantBaseline"
     )
 }
 
@@ -226,7 +205,7 @@ fn write_element(element: &JsxElement, buf: &mut String) {
 
         if let Some(style) = obj.get("style").and_then(serde_json::Value::as_object) {
             for (key, value) in style {
-                if is_layout_only_style(key) {
+                if !is_svg_presentation_style(key) {
                     continue;
                 }
                 let attr_name = camel_to_kebab(key);
@@ -459,6 +438,28 @@ mod tests {
         let options = Options::default();
         let result = Tree::from_str(&svg, &options);
         assert!(result.is_ok(), "usvg failed to parse currentColor SVG: {:?}", result.err());
+    }
+
+    #[test]
+    fn test_jsx_to_svg_rejects_custom_properties_and_vendor_prefixes() {
+        let element = JsxElement {
+            element_type: "svg".to_string(),
+            props: serde_json::json!({
+                "xmlns": "http://www.w3.org/2000/svg",
+                "viewBox": "0 0 10 10",
+                "style": {
+                    "--accent": "#fff",
+                    "-webkit-text-stroke": "1px red",
+                    "color": "#f0f6fc"
+                }
+            }),
+            children: vec![],
+        };
+
+        let svg = jsx_to_svg_string(&element);
+        assert!(svg.contains("color=\"#f0f6fc\""));
+        assert!(!svg.contains("--accent"), "custom properties must not become SVG attrs: {svg}");
+        assert!(!svg.contains("webkit"), "vendor-prefixed styles must not become SVG attrs: {svg}");
     }
 
     #[test]

--- a/crates/rari/src/server/og/rendering/svg.rs
+++ b/crates/rari/src/server/og/rendering/svg.rs
@@ -133,29 +133,119 @@ fn jsx_to_svg_string(element: &JsxElement) -> String {
     buf
 }
 
+fn json_attr_value(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        serde_json::Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    }
+}
+
+fn is_layout_only_style(key: &str) -> bool {
+    matches!(
+        key,
+        "display"
+            | "flex"
+            | "flexDirection"
+            | "flexGrow"
+            | "flexShrink"
+            | "flexBasis"
+            | "flexWrap"
+            | "alignItems"
+            | "alignContent"
+            | "alignSelf"
+            | "justifyContent"
+            | "justifyItems"
+            | "justifySelf"
+            | "gap"
+            | "rowGap"
+            | "columnGap"
+            | "margin"
+            | "marginTop"
+            | "marginRight"
+            | "marginBottom"
+            | "marginLeft"
+            | "padding"
+            | "paddingTop"
+            | "paddingRight"
+            | "paddingBottom"
+            | "paddingLeft"
+            | "width"
+            | "height"
+            | "minWidth"
+            | "minHeight"
+            | "maxWidth"
+            | "maxHeight"
+            | "position"
+            | "top"
+            | "right"
+            | "bottom"
+            | "left"
+            | "inset"
+            | "overflow"
+            | "overflowX"
+            | "overflowY"
+            | "border"
+            | "borderWidth"
+            | "borderStyle"
+            | "borderColor"
+            | "borderRadius"
+            | "borderTop"
+            | "borderRight"
+            | "borderBottom"
+            | "borderLeft"
+            | "background"
+            | "backgroundColor"
+            | "backgroundImage"
+            | "lineHeight"
+            | "textAlign"
+            | "objectFit"
+            | "objectPosition"
+            | "boxSizing"
+            | "zIndex"
+    )
+}
+
 fn write_element(element: &JsxElement, buf: &mut String) {
     let tag = &element.element_type;
     buf.push('<');
     buf.push_str(tag);
 
+    let mut attrs: Vec<(String, String)> = Vec::new();
+
     if let Some(obj) = element.props.as_object() {
         for (key, value) in obj {
-            if matches!(key.as_str(), "children" | "key" | "ref") {
+            if matches!(key.as_str(), "children" | "key" | "ref" | "style") {
                 continue;
             }
-            let attr_name = camel_to_kebab(key);
-            let attr_val = match value {
-                serde_json::Value::String(s) => s.clone(),
-                serde_json::Value::Number(n) => n.to_string(),
-                serde_json::Value::Bool(b) => b.to_string(),
-                _ => continue,
-            };
-            buf.push(' ');
-            buf.push_str(&attr_name);
-            buf.push_str("=\"");
-            buf.push_str(&escape_xml(&attr_val));
-            buf.push('"');
+            if let Some(attr_val) = json_attr_value(value) {
+                attrs.push((camel_to_kebab(key), attr_val));
+            }
         }
+
+        if let Some(style) = obj.get("style").and_then(serde_json::Value::as_object) {
+            for (key, value) in style {
+                if is_layout_only_style(key) {
+                    continue;
+                }
+                let attr_name = camel_to_kebab(key);
+                if attrs.iter().any(|(name, _)| name == &attr_name) {
+                    continue;
+                }
+                if let Some(attr_val) = json_attr_value(value) {
+                    attrs.push((attr_name, attr_val));
+                }
+            }
+        }
+    }
+
+    for (name, val) in attrs {
+        buf.push(' ');
+        buf.push_str(&name);
+        buf.push_str("=\"");
+        buf.push_str(&escape_xml(&val));
+        buf.push('"');
     }
 
     if element.children.is_empty() {
@@ -331,6 +421,61 @@ mod tests {
         assert_eq!(escape_xml("<tag>"), "&lt;tag&gt;");
         assert_eq!(escape_xml("say \"hi\""), "say &quot;hi&quot;");
         assert_eq!(escape_xml("normal"), "normal");
+    }
+
+    #[test]
+    fn test_jsx_to_svg_style_color_for_current_color() {
+        let element = JsxElement {
+            element_type: "svg".to_string(),
+            props: serde_json::json!({
+                "xmlns": "http://www.w3.org/2000/svg",
+                "viewBox": "0 0 10 10",
+                "style": {
+                    "color": "#f0f6fc",
+                    "marginRight": "20px",
+                    "display": "flex"
+                }
+            }),
+            children: vec![JsxChild::Element(Box::new(JsxElement {
+                element_type: "g".to_string(),
+                props: serde_json::json!({ "fill": "currentColor" }),
+                children: vec![JsxChild::Element(Box::new(JsxElement {
+                    element_type: "path".to_string(),
+                    props: serde_json::json!({ "d": "M0 0h10v10H0z" }),
+                    children: vec![],
+                }))],
+            }))],
+        };
+
+        let svg = jsx_to_svg_string(&element);
+        assert!(
+            svg.contains("color=\"#f0f6fc\""),
+            "style.color should become an SVG attribute: {svg}"
+        );
+        assert!(!svg.contains("margin"), "layout-only styles must not become SVG attrs: {svg}");
+        assert!(!svg.contains("display"), "layout-only styles must not become SVG attrs: {svg}");
+        assert!(svg.contains("fill=\"currentColor\""));
+
+        let options = Options::default();
+        let result = Tree::from_str(&svg, &options);
+        assert!(result.is_ok(), "usvg failed to parse currentColor SVG: {:?}", result.err());
+    }
+
+    #[test]
+    fn test_jsx_to_svg_prop_fill_wins_over_style() {
+        let element = JsxElement {
+            element_type: "path".to_string(),
+            props: serde_json::json!({
+                "d": "M0 0h10v10H0z",
+                "fill": "#fff",
+                "style": { "fill": "#000", "strokeWidth": 2 }
+            }),
+            children: vec![],
+        };
+        let svg = jsx_to_svg_string(&element);
+        assert!(svg.contains("fill=\"#fff\""));
+        assert!(!svg.contains("fill=\"#000\""));
+        assert!(svg.contains("stroke-width=\"2\""));
     }
 
     #[test]

--- a/packages/rari/src/og/image-response.tsx
+++ b/packages/rari/src/og/image-response.tsx
@@ -149,15 +149,35 @@ export class ImageResponse {
     for (const [key, value] of Object.entries(props)) {
       if (key === 'children') continue
 
-      if (
-        value == null ||
-        typeof value === 'string' ||
-        typeof value === 'number' ||
-        typeof value === 'boolean'
-      )
-        result[key] = value
+      const serialized = this.serializePropValue(value)
+      if (serialized !== undefined) result[key] = serialized
     }
 
     return result
+  }
+
+  private serializePropValue(value: unknown): unknown {
+    if (
+      value == null ||
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean'
+    )
+      return value
+
+    if (Array.isArray(value)) {
+      return value.map(item => this.serializePropValue(item)).filter(item => item !== undefined)
+    }
+
+    if (isRecord(value)) {
+      const result: Record<string, unknown> = {}
+      for (const [key, nested] of Object.entries(value)) {
+        const serialized = this.serializePropValue(nested)
+        if (serialized !== undefined) result[key] = serialized
+      }
+      return result
+    }
+
+    return undefined
   }
 }

--- a/packages/rari/src/og/image-response.tsx
+++ b/packages/rari/src/og/image-response.tsx
@@ -156,7 +156,7 @@ export class ImageResponse {
     return result
   }
 
-  private serializePropValue(value: unknown): unknown {
+  private serializePropValue(value: unknown, seen: Set<object> = new Set()): unknown {
     if (
       value == null ||
       typeof value === 'string' ||
@@ -166,16 +166,30 @@ export class ImageResponse {
       return value
 
     if (Array.isArray(value)) {
-      return value.map(item => this.serializePropValue(item)).filter(item => item !== undefined)
+      if (seen.has(value)) return undefined
+      seen.add(value)
+      try {
+        return value
+          .map(item => this.serializePropValue(item, seen))
+          .filter(item => item !== undefined)
+      } finally {
+        seen.delete(value)
+      }
     }
 
     if (isRecord(value)) {
-      const result: Record<string, unknown> = {}
-      for (const [key, nested] of Object.entries(value)) {
-        const serialized = this.serializePropValue(nested)
-        if (serialized !== undefined) result[key] = serialized
+      if (seen.has(value)) return undefined
+      seen.add(value)
+      try {
+        const result: Record<string, unknown> = {}
+        for (const [key, nested] of Object.entries(value)) {
+          const serialized = this.serializePropValue(nested, seen)
+          if (serialized !== undefined) result[key] = serialized
+        }
+        return result
+      } finally {
+        seen.delete(value)
       }
-      return result
     }
 
     return undefined

--- a/test/unit/og/image-response.test.ts
+++ b/test/unit/og/image-response.test.ts
@@ -8,12 +8,13 @@ describe('image response', () => {
       createElement(
         'div',
         {
-          style: {
+          'style': {
             display: 'flex',
             flexDirection: 'column',
             background: '#0d1117',
             width: '100%',
           },
+          'data-values': ['ok', 1, true, () => 'skip', Symbol('skip')],
         },
         createElement('div', { style: { fontSize: 48, color: '#f0f6fc' } }, 'Hello'),
       ),
@@ -22,12 +23,13 @@ describe('image response', () => {
     expect(response.toJSON()).toMatchObject({
       element: {
         props: {
-          style: {
+          'style': {
             display: 'flex',
             flexDirection: 'column',
             background: '#0d1117',
             width: '100%',
           },
+          'data-values': ['ok', 1, true],
         },
         children: [
           {
@@ -39,6 +41,35 @@ describe('image response', () => {
             },
           },
         ],
+      },
+    })
+  })
+
+  it('omits cyclic object and array references', () => {
+    const cyclicObject: Record<string, unknown> = { color: '#fff' }
+    cyclicObject.self = cyclicObject
+
+    const cyclicArray: unknown[] = ['ok']
+    cyclicArray.push(cyclicArray)
+
+    const shared = { tone: 'muted' }
+    const response = new ImageResponse(
+      createElement('div', {
+        'style': cyclicObject,
+        'data-items': cyclicArray,
+        'data-a': shared,
+        'data-b': shared,
+      }),
+    )
+
+    expect(response.toJSON()).toMatchObject({
+      element: {
+        props: {
+          'style': { color: '#fff' },
+          'data-items': ['ok'],
+          'data-a': { tone: 'muted' },
+          'data-b': { tone: 'muted' },
+        },
       },
     })
   })

--- a/test/unit/og/image-response.test.ts
+++ b/test/unit/og/image-response.test.ts
@@ -1,0 +1,45 @@
+import { createElement } from 'react'
+import { describe, expect, it } from 'vite-plus/test'
+import { ImageResponse } from '../../../packages/rari/src/og/image-response'
+
+describe('image response', () => {
+  it('serializes style objects into toJSON props', () => {
+    const response = new ImageResponse(
+      createElement(
+        'div',
+        {
+          style: {
+            display: 'flex',
+            flexDirection: 'column',
+            background: '#0d1117',
+            width: '100%',
+          },
+        },
+        createElement('div', { style: { fontSize: 48, color: '#f0f6fc' } }, 'Hello'),
+      ),
+    )
+
+    expect(response.toJSON()).toMatchObject({
+      element: {
+        props: {
+          style: {
+            display: 'flex',
+            flexDirection: 'column',
+            background: '#0d1117',
+            width: '100%',
+          },
+        },
+        children: [
+          {
+            props: {
+              style: {
+                fontSize: 48,
+                color: '#f0f6fc',
+              },
+            },
+          },
+        ],
+      },
+    })
+  })
+})

--- a/web/src/lib/og-image.tsx
+++ b/web/src/lib/og-image.tsx
@@ -38,7 +38,7 @@ export function generateOGImage({
             padding: '80px',
           }}
         >
-          <Rari width={360} height={120} style={{ marginBottom: '60px' }} />
+          <Rari width={360} height={120} style={{ marginBottom: '60px', color: '#f0f6fc' }} />
 
           <div
             style={{
@@ -94,7 +94,7 @@ export function generateOGImage({
             marginBottom: '40px',
           }}
         >
-          <Rari width={120} height={40} style={{ marginRight: '20px' }} />
+          <Rari width={120} height={40} style={{ marginRight: '20px', color: '#f0f6fc' }} />
           {section != null && section !== '' && (
             <div
               style={{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved SVG and image serialization for nested properties, styles, arrays, and objects.
  - Preserved supported style values in generated image responses.
  - Applied the updated Rari logo color to Open Graph image layouts.

- **Bug Fixes**
  - Filtered unsupported, custom, vendor-prefixed, and layout-only styles from SVG attributes.
  - Ensured explicit properties override equivalent style values.
  - Improved handling of unsupported and cyclic values while preserving XML escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->