### PR TITLE
fix: support shorthand hex colors and enable React ESM minify

### DIFF
--- a/crates/rari/src/server/og/layout/style/gradient.rs
+++ b/crates/rari/src/server/og/layout/style/gradient.rs
@@ -180,6 +180,9 @@ impl LinearGradient {
             _ => {
                 if color_str.starts_with('#') {
                     let hex = color_str.trim_start_matches('#');
+                    if !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+                        return None;
+                    }
                     if hex.len() == 6 {
                         let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
                         let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
@@ -409,6 +412,16 @@ mod tests {
         let grad = LinearGradient::parse("linear-gradient(#fff0, #0008)").unwrap();
         assert_eq!(grad.stops[0].color, Rgba([255, 255, 255, 0]));
         assert_eq!(grad.stops[1].color, Rgba([0, 0, 0, 136]));
+    }
+
+    #[test]
+    fn test_parse_rejects_invalid_hex_colors() {
+        assert!(LinearGradient::parse("linear-gradient(#ggg, #xyz)").is_none());
+        assert!(LinearGradient::parse("linear-gradient(#ffß, #00ß)").is_none());
+
+        let grad = LinearGradient::parse("linear-gradient(#ggg, blue)").unwrap();
+        assert_eq!(grad.stops.len(), 1);
+        assert_eq!(grad.stops[0].color, Rgba([0, 0, 255, 255]));
     }
 
     #[test]

--- a/crates/rari/src/server/og/layout/style/gradient.rs
+++ b/crates/rari/src/server/og/layout/style/gradient.rs
@@ -190,6 +190,12 @@ impl LinearGradient {
                         let g = u8::from_str_radix(&hex[1..2], 16).ok()? * 17;
                         let b = u8::from_str_radix(&hex[2..3], 16).ok()? * 17;
                         [r, g, b, 255]
+                    } else if hex.len() == 4 {
+                        let r = u8::from_str_radix(&hex[0..1], 16).ok()? * 17;
+                        let g = u8::from_str_radix(&hex[1..2], 16).ok()? * 17;
+                        let b = u8::from_str_radix(&hex[2..3], 16).ok()? * 17;
+                        let a = u8::from_str_radix(&hex[3..4], 16).ok()? * 17;
+                        [r, g, b, a]
                     } else if hex.len() == 8 {
                         let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
                         let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
@@ -392,6 +398,17 @@ mod tests {
         let grad = LinearGradient::parse("linear-gradient(#ff0000, #0000ff)").unwrap();
         assert_eq!(grad.stops[0].color, Rgba([255, 0, 0, 255]));
         assert_eq!(grad.stops[1].color, Rgba([0, 0, 255, 255]));
+    }
+
+    #[test]
+    fn test_parse_shorthand_hex_colors() {
+        let grad = LinearGradient::parse("linear-gradient(#f00, #0ff)").unwrap();
+        assert_eq!(grad.stops[0].color, Rgba([255, 0, 0, 255]));
+        assert_eq!(grad.stops[1].color, Rgba([0, 255, 255, 255]));
+
+        let grad = LinearGradient::parse("linear-gradient(#fff0, #0008)").unwrap();
+        assert_eq!(grad.stops[0].color, Rgba([255, 255, 255, 0]));
+        assert_eq!(grad.stops[1].color, Rgba([0, 0, 0, 136]));
     }
 
     #[test]

--- a/crates/rari/src/server/og/layout/style/gradient.rs
+++ b/crates/rari/src/server/og/layout/style/gradient.rs
@@ -179,7 +179,7 @@ impl LinearGradient {
             "silver" => [192, 192, 192, 255],
             _ => {
                 if color_str.starts_with('#') {
-                    let hex = color_str.trim_start_matches('#');
+                    let hex = color_str.strip_prefix('#')?;
                     if !hex.chars().all(|c| c.is_ascii_hexdigit()) {
                         return None;
                     }
@@ -420,6 +420,15 @@ mod tests {
         assert!(LinearGradient::parse("linear-gradient(#ffß, #00ß)").is_none());
 
         let grad = LinearGradient::parse("linear-gradient(#ggg, blue)").unwrap();
+        assert_eq!(grad.stops.len(), 1);
+        assert_eq!(grad.stops[0].color, Rgba([0, 0, 255, 255]));
+    }
+
+    #[test]
+    fn test_parse_rejects_repeated_hash_prefix() {
+        assert!(LinearGradient::parse("linear-gradient(##fff, ##000)").is_none());
+
+        let grad = LinearGradient::parse("linear-gradient(##ff0000, blue)").unwrap();
         assert_eq!(grad.stops.len(), 1);
         assert_eq!(grad.stops[0].color, Rgba([0, 0, 255, 255]));
     }

--- a/crates/rari/src/server/og/rendering/renderer.rs
+++ b/crates/rari/src/server/og/rendering/renderer.rs
@@ -116,6 +116,9 @@ impl ImageRenderer {
             "blue" => Rgba([0, 0, 255, 255]),
             _ if color_str.starts_with('#') => {
                 let hex = color_str.trim_start_matches('#');
+                if !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+                    return Rgba([0, 0, 0, 255]);
+                }
                 match hex.len() {
                     3 => {
                         let r = u8::from_str_radix(&hex[0..1], 16).unwrap_or(0) * 17;
@@ -187,5 +190,14 @@ mod tests {
     fn parse_color_accepts_six_and_eight_digit_hex() {
         assert_eq!(ImageRenderer::parse_color("#f0f6fc"), Rgba([240, 246, 252, 255]));
         assert_eq!(ImageRenderer::parse_color("#ff000080"), Rgba([255, 0, 0, 128]));
+    }
+
+    #[test]
+    fn parse_color_rejects_non_hex_tokens() {
+        assert_eq!(ImageRenderer::parse_color("#ggg"), Rgba([0, 0, 0, 255]));
+        assert_eq!(ImageRenderer::parse_color("#fffg"), Rgba([0, 0, 0, 255]));
+        assert_eq!(ImageRenderer::parse_color("#xyzxyz"), Rgba([0, 0, 0, 255]));
+        // Multi-byte input must not panic on byte slicing.
+        assert_eq!(ImageRenderer::parse_color("#ffß"), Rgba([0, 0, 0, 255]));
     }
 }

--- a/crates/rari/src/server/og/rendering/renderer.rs
+++ b/crates/rari/src/server/og/rendering/renderer.rs
@@ -115,7 +115,9 @@ impl ImageRenderer {
             "green" => Rgba([0, 255, 0, 255]),
             "blue" => Rgba([0, 0, 255, 255]),
             _ if color_str.starts_with('#') => {
-                let hex = color_str.trim_start_matches('#');
+                let Some(hex) = color_str.strip_prefix('#') else {
+                    return Rgba([0, 0, 0, 255]);
+                };
                 if !hex.chars().all(|c| c.is_ascii_hexdigit()) {
                     return Rgba([0, 0, 0, 255]);
                 }
@@ -199,5 +201,12 @@ mod tests {
         assert_eq!(ImageRenderer::parse_color("#xyzxyz"), Rgba([0, 0, 0, 255]));
         // Multi-byte input must not panic on byte slicing.
         assert_eq!(ImageRenderer::parse_color("#ffß"), Rgba([0, 0, 0, 255]));
+    }
+
+    #[test]
+    fn parse_color_rejects_repeated_hash_prefix() {
+        assert_eq!(ImageRenderer::parse_color("##fff"), Rgba([0, 0, 0, 255]));
+        assert_eq!(ImageRenderer::parse_color("###000"), Rgba([0, 0, 0, 255]));
+        assert_eq!(ImageRenderer::parse_color("##ff0000"), Rgba([0, 0, 0, 255]));
     }
 }

--- a/crates/rari/src/server/og/rendering/renderer.rs
+++ b/crates/rari/src/server/og/rendering/renderer.rs
@@ -116,13 +116,34 @@ impl ImageRenderer {
             "blue" => Rgba([0, 0, 255, 255]),
             _ if color_str.starts_with('#') => {
                 let hex = color_str.trim_start_matches('#');
-                if hex.len() == 6 {
-                    let r = u8::from_str_radix(&hex[0..2], 16).unwrap_or(0);
-                    let g = u8::from_str_radix(&hex[2..4], 16).unwrap_or(0);
-                    let b = u8::from_str_radix(&hex[4..6], 16).unwrap_or(0);
-                    Rgba([r, g, b, 255])
-                } else {
-                    Rgba([0, 0, 0, 255])
+                match hex.len() {
+                    3 => {
+                        let r = u8::from_str_radix(&hex[0..1], 16).unwrap_or(0) * 17;
+                        let g = u8::from_str_radix(&hex[1..2], 16).unwrap_or(0) * 17;
+                        let b = u8::from_str_radix(&hex[2..3], 16).unwrap_or(0) * 17;
+                        Rgba([r, g, b, 255])
+                    }
+                    4 => {
+                        let r = u8::from_str_radix(&hex[0..1], 16).unwrap_or(0) * 17;
+                        let g = u8::from_str_radix(&hex[1..2], 16).unwrap_or(0) * 17;
+                        let b = u8::from_str_radix(&hex[2..3], 16).unwrap_or(0) * 17;
+                        let a = u8::from_str_radix(&hex[3..4], 16).unwrap_or(0) * 17;
+                        Rgba([r, g, b, a])
+                    }
+                    6 => {
+                        let r = u8::from_str_radix(&hex[0..2], 16).unwrap_or(0);
+                        let g = u8::from_str_radix(&hex[2..4], 16).unwrap_or(0);
+                        let b = u8::from_str_radix(&hex[4..6], 16).unwrap_or(0);
+                        Rgba([r, g, b, 255])
+                    }
+                    8 => {
+                        let r = u8::from_str_radix(&hex[0..2], 16).unwrap_or(0);
+                        let g = u8::from_str_radix(&hex[2..4], 16).unwrap_or(0);
+                        let b = u8::from_str_radix(&hex[4..6], 16).unwrap_or(0);
+                        let a = u8::from_str_radix(&hex[6..8], 16).unwrap_or(0);
+                        Rgba([r, g, b, a])
+                    }
+                    _ => Rgba([0, 0, 0, 255]),
                 }
             }
             _ if color_str.starts_with("rgb(") => {
@@ -139,5 +160,32 @@ impl ImageRenderer {
             }
             _ => Rgba([0, 0, 0, 255]),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use image::Rgba;
+
+    use super::ImageRenderer;
+
+    #[test]
+    fn parse_color_accepts_shorthand_hex() {
+        assert_eq!(ImageRenderer::parse_color("#fff"), Rgba([255, 255, 255, 255]));
+        assert_eq!(ImageRenderer::parse_color("#000"), Rgba([0, 0, 0, 255]));
+        assert_eq!(ImageRenderer::parse_color("#f0f"), Rgba([255, 0, 255, 255]));
+        assert_eq!(ImageRenderer::parse_color("#abc"), Rgba([170, 187, 204, 255]));
+    }
+
+    #[test]
+    fn parse_color_accepts_shorthand_hex_with_alpha() {
+        assert_eq!(ImageRenderer::parse_color("#fff0"), Rgba([255, 255, 255, 0]));
+        assert_eq!(ImageRenderer::parse_color("#f008"), Rgba([255, 0, 0, 136]));
+    }
+
+    #[test]
+    fn parse_color_accepts_six_and_eight_digit_hex() {
+        assert_eq!(ImageRenderer::parse_color("#f0f6fc"), Rgba([240, 246, 252, 255]));
+        assert_eq!(ImageRenderer::parse_color("#ff000080"), Rgba([255, 0, 0, 128]));
     }
 }

--- a/packages/rari/src/shared/patch-flight-browser-client.ts
+++ b/packages/rari/src/shared/patch-flight-browser-client.ts
@@ -77,10 +77,3 @@ export function patchBrowserClientForFormActions(
     'browser registerBoundServerReference',
   )
 }
-
-/** Rolldown collapses $$FORM_ACTION to $FORM_ACTION in property keys. */
-export function fixRolldownDoubleDollarProperties(code: string): string {
-  return code
-    .replace(/(?<!\$)\$FORM_ACTION/g, () => '$$FORM_ACTION')
-    .replace(/(?<!\$)\$IS_SIGNATURE_EQUAL/g, () => '$$IS_SIGNATURE_EQUAL')
-}

--- a/packages/rari/src/vite/index.ts
+++ b/packages/rari/src/vite/index.ts
@@ -22,10 +22,7 @@ import {
 } from '@/image/constants'
 import { rariProxy } from '@/proxy/build/vite-plugin'
 import { rariRouter } from '@/router/build/vite-plugin'
-import {
-  fixRolldownDoubleDollarProperties,
-  patchBrowserClientForFormActions,
-} from '@/shared/patch-flight-browser-client'
+import { patchBrowserClientForFormActions } from '@/shared/patch-flight-browser-client'
 import {
   BACKSLASH_REGEX,
   EXPORT_NAMED_DECLARATION_REGEX,
@@ -2029,9 +2026,7 @@ import * as React from 'react';\n${content}`
 
         const browserSource = fs.readFileSync(browserClientPath, 'utf-8')
         const edgeSource = fs.readFileSync(edgeClientPath, 'utf-8')
-        const cjsSource = fixRolldownDoubleDollarProperties(
-          patchBrowserClientForFormActions(browserSource, edgeSource),
-        )
+        const cjsSource = patchBrowserClientForFormActions(browserSource, edgeSource)
 
         return {
           code: `

--- a/test/unit/shared/patch-flight-browser-client.test.ts
+++ b/test/unit/shared/patch-flight-browser-client.test.ts
@@ -1,10 +1,7 @@
 import fs from 'node:fs'
 import { createRequire } from 'node:module'
 import path from 'node:path'
-import {
-  fixRolldownDoubleDollarProperties,
-  patchBrowserClientForFormActions,
-} from '@rari/shared/patch-flight-browser-client'
+import { patchBrowserClientForFormActions } from '@rari/shared/patch-flight-browser-client'
 import { describe, expect, it } from 'vite-plus/test'
 
 const require = createRequire(import.meta.url)
@@ -26,13 +23,12 @@ describe('patchBrowserClientForFormActions', () => {
       'utf-8',
     )
 
-    const patched = fixRolldownDoubleDollarProperties(
-      patchBrowserClientForFormActions(browserSource, edgeSource),
-    )
+    const patched = patchBrowserClientForFormActions(browserSource, edgeSource)
 
     expect(patched).toContain('var boundCache = new WeakMap();')
     expect(patched).toContain('action: resolveRariFormActionUrl()')
     expect(patched).toContain('$$FORM_ACTION')
+    expect(patched).toContain('$$IS_SIGNATURE_EQUAL')
     expect(patched).not.toContain('function registerBoundServerReference(reference, id, bound) {')
   })
 
@@ -90,15 +86,6 @@ describe('patchBrowserClientForFormActions', () => {
 
     expect(() => patchBrowserClientForFormActions('irrelevant', fakeEdgeSource)).toThrow(
       /edge \$\$FORM_ACTION return block matched more than once/,
-    )
-  })
-})
-
-describe('fixRolldownDoubleDollarProperties', () => {
-  it('restores double-dollar React internal property names', () => {
-    const input = 'props.$FORM_ACTION = fn; props.$IS_SIGNATURE_EQUAL = eq;'
-    expect(fixRolldownDoubleDollarProperties(input)).toBe(
-      'props.$$FORM_ACTION = fn; props.$$IS_SIGNATURE_EQUAL = eq;',
     )
   })
 })

--- a/test/unit/tools/rewrite-external-requires.test.ts
+++ b/test/unit/tools/rewrite-external-requires.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vite-plus/test'
+import {
+  assertExternalsRewritten,
+  packageStillRequired,
+  rewriteExternalRequires,
+} from '../../../tools/bundle-react-esm/rewrite-external-requires'
+
+const EXTERNALIZED_ENTRIES = [
+  {
+    name: 'react-jsx-runtime',
+    externals: { react: 'ext:rari/react/vendor/react.js' },
+  },
+  {
+    name: 'react-dom-server',
+    externals: {
+      'react': 'ext:rari/react/vendor/react.js',
+      'react-dom': 'ext:rari/react/vendor/react-dom.js',
+    },
+  },
+  {
+    name: 'react-server-dom-webpack-client',
+    externals: {
+      'react': 'ext:rari/react/vendor/react.js',
+      'react-dom': 'ext:rari/react/vendor/react-dom.js',
+    },
+  },
+  {
+    name: 'react-server-dom-webpack-server',
+    externals: {
+      react: 'ext:rari/react/vendor/react-server.js',
+    },
+  },
+] as const
+
+function minifiedFixture(pkgs: readonly string[]): string {
+  const calls = pkgs.map(pkg => `l(\`${pkg}\`)`).join(';')
+  return `var l=(e=>typeof require<"u"?require:typeof Proxy<"u"?new Proxy(e,{get:(e,t)=>(typeof require<"u"?require:e)[t]}):e)(()=>{});${calls};export{}`
+}
+
+describe('rewriteExternalRequires', () => {
+  it.each(EXTERNALIZED_ENTRIES)(
+    'rewrites minified helper requires for $name',
+    ({ name, externals }) => {
+      const pkgs = Object.keys(externals)
+      const input = minifiedFixture(pkgs)
+
+      for (const pkg of pkgs) expect(packageStillRequired(input, pkg)).toBe(true)
+
+      const rewritten = rewriteExternalRequires(input, externals)
+      assertExternalsRewritten(name, rewritten, externals)
+
+      for (const [pkg, target] of Object.entries(externals)) {
+        expect(packageStillRequired(rewritten, pkg)).toBe(false)
+        expect(rewritten).toContain(`__ext_${pkg.replace(/\W/g, '_')}`)
+        expect(rewritten).toContain(`from '${target}'`)
+      }
+
+      expect(rewritten).not.toMatch(/\bl\(([`"'])react\1\)/)
+      expect(rewritten).not.toMatch(/\bl\(([`"'])react-dom\1\)/)
+    },
+  )
+
+  it('rewrites unminified __require calls', () => {
+    const externals = { react: 'ext:rari/react/vendor/react.js' }
+    const input = 'const React = __require("react"); export default React'
+    const rewritten = rewriteExternalRequires(input, externals)
+
+    expect(packageStillRequired(rewritten, 'react')).toBe(false)
+    expect(rewritten).toContain("import * as __ext_react from 'ext:rari/react/vendor/react.js'")
+    expect(rewritten).toContain('const React = __ext_react')
+  })
+})

--- a/tools/bundle-react-esm/bundle.ts
+++ b/tools/bundle-react-esm/bundle.ts
@@ -5,10 +5,7 @@ import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 import { build } from 'rolldown'
-import {
-  fixRolldownDoubleDollarProperties,
-  patchBrowserClientForFormActions,
-} from '../../packages/rari/src/shared/patch-flight-browser-client.ts'
+import { patchBrowserClientForFormActions } from '../../packages/rari/src/shared/patch-flight-browser-client.ts'
 import { isRecord } from '../../packages/rari/src/shared/utils/type-guards.ts'
 
 const require = createRequire(import.meta.url)
@@ -349,6 +346,63 @@ function bundleShimEntry(entry: BundleEntry): void {
   writeVendorBundle(entry, entry.source)
 }
 
+function packageStillRequired(code: string, pkg: string): boolean {
+  const escaped = pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`(?:__require|\\b[A-Za-z_$][\\w$]*)\\(([\`"'])${escaped}\\1\\)`).test(code)
+}
+
+function rewriteExternalRequires(
+  code: string,
+  externals: Readonly<Record<string, string>>,
+): string {
+  const importLines: string[] = []
+  let result = code
+
+  // Unminified Rolldown emits `__require("pkg")`. Minified output uses a short
+  // CJS interop helper shaped like `l=(e=>typeof require...` with calls `l(\`pkg\`)`.
+  const minifiedHelper = /([A-Za-z_$][\w$]*)=\(e=>typeof require/.exec(result)?.[1]
+
+  for (const [pkg, target] of Object.entries(externals)) {
+    const ident = `__ext_${pkg.replace(/\W/g, '_')}`
+    const escaped = pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const patterns = [new RegExp(`__require\\((["'])${escaped}\\1\\)`, 'g')]
+
+    if (minifiedHelper != null && minifiedHelper !== '') {
+      const helper = minifiedHelper.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      patterns.push(new RegExp(`\\b${helper}\\(([\`"'])${escaped}\\1\\)`, 'g'))
+    }
+
+    let matched = false
+    for (const pattern of patterns) {
+      const next = result.replace(pattern, ident)
+      if (next !== result) {
+        result = next
+        matched = true
+      }
+    }
+
+    if (matched) importLines.push(`import * as ${ident} from '${target}';`)
+  }
+
+  if (importLines.length > 0) result = `${importLines.join('\n')}\n${result}`
+  return result
+}
+
+function assertExternalsRewritten(
+  entryName: string,
+  code: string,
+  externals: Readonly<Record<string, string>>,
+): void {
+  for (const pkg of Object.keys(externals)) {
+    if (packageStillRequired(code, pkg)) {
+      throw new Error(
+        `Failed to rewrite external require for "${pkg}" in ${entryName}. ` +
+          `Minified Rolldown output may have changed shape; update rewriteExternalRequires.`,
+      )
+    }
+  }
+}
+
 async function bundleCjsEntry(entry: BundleEntry): Promise<void> {
   const virtualId = `\0virtual:${entry.name}`
   const { source: entrySource, tempPath } = createEntrySource(entry)
@@ -371,7 +425,7 @@ async function bundleCjsEntry(entry: BundleEntry): Promise<void> {
       external: externalPatterns,
       output: {
         format: 'esm',
-        minify: false,
+        minify: true,
         exports: 'named',
       },
       resolve: {
@@ -399,23 +453,14 @@ async function bundleCjsEntry(entry: BundleEntry): Promise<void> {
     })
 
     const output = result.output[0]
-    // Rolldown emits external CJS deps as `__require("pkg")` calls, which throw
-    // in deno_core's V8 (no `require`). Rewrite them into a static ESM import of
-    // the shared vendor module so the whole runtime resolves to ONE React
-    // instance (file:///react_vendor/react.js).
+    // Rolldown emits external CJS deps as `__require("pkg")` (unminified) or a
+    // short helper call (minified), which throw in deno_core's V8 (no `require`).
+    // Rewrite them into a static ESM import of the shared vendor module so the
+    // whole runtime resolves to ONE React instance (file:///react_vendor/react.js).
     let code = output.code
     if (entry.externals) {
-      const importLines: string[] = []
-      for (const [pkg, target] of Object.entries(entry.externals)) {
-        const ident = `__ext_${pkg.replace(/\W/g, '_')}`
-        const escaped = pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-        const requirePattern = `__require\\((["'])${escaped}\\1\\)`
-        if (new RegExp(requirePattern).test(code)) {
-          importLines.push(`import * as ${ident} from '${target}';`)
-          code = code.replace(new RegExp(requirePattern, 'g'), ident)
-        }
-      }
-      if (importLines.length > 0) code = `${importLines.join('\n')}\n${code}`
+      code = rewriteExternalRequires(code, entry.externals)
+      assertExternalsRewritten(entry.name, code, entry.externals)
     }
 
     if (code.includes('__webpack_chunk_load__'))
@@ -425,12 +470,6 @@ async function bundleCjsEntry(entry: BundleEntry): Promise<void> {
       if (code.includes('__webpack_require__.u'))
         code = code.replaceAll('__webpack_require__.u', '({}).u')
       code = code.replaceAll('__webpack_require__', '__rari_rsc_require__')
-    }
-
-    // Rolldown collapses React's $$FORM_ACTION / $$IS_SIGNATURE_EQUAL property
-    // names to a single $ prefix. react-dom-server checks the double-$ names.
-    if (entry.name === 'react-server-dom-webpack-client') {
-      code = fixRolldownDoubleDollarProperties(code)
     }
 
     writeVendorBundle(entry, code)

--- a/tools/bundle-react-esm/bundle.ts
+++ b/tools/bundle-react-esm/bundle.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url'
 import { build } from 'rolldown'
 import { patchBrowserClientForFormActions } from '../../packages/rari/src/shared/patch-flight-browser-client.ts'
 import { isRecord } from '../../packages/rari/src/shared/utils/type-guards.ts'
+import { assertExternalsRewritten, rewriteExternalRequires } from './rewrite-external-requires.ts'
 
 const require = createRequire(import.meta.url)
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url))
@@ -344,63 +345,6 @@ function bundleShimEntry(entry: BundleEntry): void {
     throw new Error(`Entry ${entry.name} is missing source`)
 
   writeVendorBundle(entry, entry.source)
-}
-
-function packageStillRequired(code: string, pkg: string): boolean {
-  const escaped = pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  return new RegExp(`(?:__require|\\b[A-Za-z_$][\\w$]*)\\(([\`"'])${escaped}\\1\\)`).test(code)
-}
-
-function rewriteExternalRequires(
-  code: string,
-  externals: Readonly<Record<string, string>>,
-): string {
-  const importLines: string[] = []
-  let result = code
-
-  // Unminified Rolldown emits `__require("pkg")`. Minified output uses a short
-  // CJS interop helper shaped like `l=(e=>typeof require...` with calls `l(\`pkg\`)`.
-  const minifiedHelper = /([A-Za-z_$][\w$]*)=\(e=>typeof require/.exec(result)?.[1]
-
-  for (const [pkg, target] of Object.entries(externals)) {
-    const ident = `__ext_${pkg.replace(/\W/g, '_')}`
-    const escaped = pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    const patterns = [new RegExp(`__require\\((["'])${escaped}\\1\\)`, 'g')]
-
-    if (minifiedHelper != null && minifiedHelper !== '') {
-      const helper = minifiedHelper.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-      patterns.push(new RegExp(`\\b${helper}\\(([\`"'])${escaped}\\1\\)`, 'g'))
-    }
-
-    let matched = false
-    for (const pattern of patterns) {
-      const next = result.replace(pattern, ident)
-      if (next !== result) {
-        result = next
-        matched = true
-      }
-    }
-
-    if (matched) importLines.push(`import * as ${ident} from '${target}';`)
-  }
-
-  if (importLines.length > 0) result = `${importLines.join('\n')}\n${result}`
-  return result
-}
-
-function assertExternalsRewritten(
-  entryName: string,
-  code: string,
-  externals: Readonly<Record<string, string>>,
-): void {
-  for (const pkg of Object.keys(externals)) {
-    if (packageStillRequired(code, pkg)) {
-      throw new Error(
-        `Failed to rewrite external require for "${pkg}" in ${entryName}. ` +
-          `Minified Rolldown output may have changed shape; update rewriteExternalRequires.`,
-      )
-    }
-  }
 }
 
 async function bundleCjsEntry(entry: BundleEntry): Promise<void> {

--- a/tools/bundle-react-esm/rewrite-external-requires.ts
+++ b/tools/bundle-react-esm/rewrite-external-requires.ts
@@ -1,0 +1,56 @@
+export function packageStillRequired(code: string, pkg: string): boolean {
+  const escaped = pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`(?:__require|\\b[A-Za-z_$][\\w$]*)\\(([\`"'])${escaped}\\1\\)`).test(code)
+}
+
+export function rewriteExternalRequires(
+  code: string,
+  externals: Readonly<Record<string, string>>,
+): string {
+  const importLines: string[] = []
+  let result = code
+
+  // Unminified Rolldown emits `__require("pkg")`. Minified output uses a short
+  // CJS interop helper shaped like `l=(e=>typeof require...` with calls `l(\`pkg\`)`.
+  const minifiedHelper = /([A-Za-z_$][\w$]*)=\(e=>typeof require/.exec(result)?.[1]
+
+  for (const [pkg, target] of Object.entries(externals)) {
+    const ident = `__ext_${pkg.replace(/\W/g, '_')}`
+    const escaped = pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const patterns = [new RegExp(`__require\\((["'])${escaped}\\1\\)`, 'g')]
+
+    if (minifiedHelper != null && minifiedHelper !== '') {
+      const helper = minifiedHelper.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      patterns.push(new RegExp(`\\b${helper}\\(([\`"'])${escaped}\\1\\)`, 'g'))
+    }
+
+    let matched = false
+    for (const pattern of patterns) {
+      const next = result.replace(pattern, ident)
+      if (next !== result) {
+        result = next
+        matched = true
+      }
+    }
+
+    if (matched) importLines.push(`import * as ${ident} from '${target}';`)
+  }
+
+  if (importLines.length > 0) result = `${importLines.join('\n')}\n${result}`
+  return result
+}
+
+export function assertExternalsRewritten(
+  entryName: string,
+  code: string,
+  externals: Readonly<Record<string, string>>,
+): void {
+  for (const pkg of Object.keys(externals)) {
+    if (packageStillRequired(code, pkg)) {
+      throw new Error(
+        `Failed to rewrite external require for "${pkg}" in ${entryName}. ` +
+          `Minified Rolldown output may have changed shape; update rewriteExternalRequires.`,
+      )
+    }
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for 3-, 4-, 6-, and 8-digit hexadecimal colors, including transparency.
  * Improved shorthand RGB/RGBA parsing and safely handle invalid or unsupported color values.
  * Prevented malformed multibyte hexadecimal input from causing rendering issues.

* **Improvements**
  * Improved browser client bundling and preservation of React form-action properties.
  * Enhanced external module handling and validation during React bundle generation.
  * Removed obsolete processing that could alter generated client code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->