### PR TITLE
feat(cache, csp): expire HTML fast cache on max-age and make COEP configurable

### DIFF
--- a/crates/rari/src/server/cache/response.rs
+++ b/crates/rari/src/server/cache/response.rs
@@ -117,14 +117,19 @@ impl StaticFastCache {
 
     pub fn get(&self, key: &str) -> Option<Arc<PrebuiltResponse>> {
         let entry = self.map.get(key)?;
-        if !entry.value().is_fresh() {
-            drop(entry);
-            if self.map.remove(key).is_some() {
-                self.entry_count.fetch_sub(1, Ordering::Relaxed);
-            }
-            return None;
+        if entry.value().is_fresh() {
+            return Some(Arc::clone(entry.value()));
         }
-        Some(Arc::clone(entry.value()))
+        let observed = Arc::clone(entry.value());
+        drop(entry);
+        self.remove_observed(key, &observed);
+        None
+    }
+
+    fn remove_observed(&self, key: &str, observed: &Arc<PrebuiltResponse>) {
+        if self.map.remove_if(key, |_, current| Arc::ptr_eq(current, observed)).is_some() {
+            self.entry_count.fetch_sub(1, Ordering::Relaxed);
+        }
     }
 
     pub fn contains_key(&self, key: &str) -> bool {
@@ -1459,5 +1464,44 @@ mod tests {
             10,
         );
         assert!(cache.get("/").is_some());
+    }
+
+    #[test]
+    fn test_static_fast_cache_stale_cleanup_skips_replaced_entry() {
+        let cache = StaticFastCache::new();
+        let stale_at =
+            Instant::now().checked_sub(Duration::from_secs(10)).expect("monotonic clock");
+        let stale = Arc::new(PrebuiltResponse {
+            identity: Bytes::from("stale"),
+            gzip: None,
+            br: None,
+            zstd: None,
+            etag: "W/\"stale\"".to_string(),
+            content_type: "text/html; charset=utf-8".to_string(),
+            cache_control: "public, max-age=1".to_string(),
+            is_not_found: false,
+            cached_at: stale_at,
+        });
+        insert_static_fast_cache(&cache, "/", Arc::clone(&stale), 10);
+
+        let fresh = Arc::new(PrebuiltResponse {
+            identity: Bytes::from("fresh"),
+            gzip: None,
+            br: None,
+            zstd: None,
+            etag: "W/\"fresh\"".to_string(),
+            content_type: "text/html; charset=utf-8".to_string(),
+            cache_control: "public, max-age=60".to_string(),
+            is_not_found: false,
+            cached_at: Instant::now(),
+        });
+        insert_static_fast_cache(&cache, "/", Arc::clone(&fresh), 10);
+
+        cache.remove_observed("/", &stale);
+
+        let got = cache.get("/").expect("replacement must survive stale cleanup");
+        assert_eq!(got.identity.as_ref(), b"fresh");
+        assert!(Arc::ptr_eq(&got, &fresh));
+        assert_eq!(cache.entry_count(), 1);
     }
 }

--- a/crates/rari/src/server/cache/response.rs
+++ b/crates/rari/src/server/cache/response.rs
@@ -4,7 +4,7 @@ use std::{
         Arc,
         atomic::{AtomicUsize, Ordering},
     },
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use axum::http::HeaderMap;
@@ -32,9 +32,17 @@ pub struct PrebuiltResponse {
     pub content_type: String,
     pub cache_control: String,
     pub is_not_found: bool,
+    pub cached_at: Instant,
 }
 
 impl PrebuiltResponse {
+    fn is_fresh(&self) -> bool {
+        match RouteCachePolicy::max_age_from_cache_control(&self.cache_control) {
+            Some(secs) => self.cached_at.elapsed() < Duration::from_secs(secs),
+            None => true,
+        }
+    }
+
     pub fn body_for(&self, encoding: CompressionEncoding) -> (Bytes, Option<&'static str>) {
         match encoding {
             CompressionEncoding::Zstd => match &self.zstd {
@@ -108,7 +116,15 @@ impl StaticFastCache {
     }
 
     pub fn get(&self, key: &str) -> Option<Arc<PrebuiltResponse>> {
-        self.map.get(key).map(|entry| Arc::clone(entry.value()))
+        let entry = self.map.get(key)?;
+        if !entry.value().is_fresh() {
+            drop(entry);
+            if self.map.remove(key).is_some() {
+                self.entry_count.fetch_sub(1, Ordering::Relaxed);
+            }
+            return None;
+        }
+        Some(Arc::clone(entry.value()))
     }
 
     pub fn contains_key(&self, key: &str) -> bool {
@@ -1274,6 +1290,7 @@ mod tests {
                 content_type: "text/html; charset=utf-8".to_string(),
                 cache_control: "public".to_string(),
                 is_not_found: false,
+                cached_at: Instant::now(),
             })
         };
 
@@ -1305,6 +1322,7 @@ mod tests {
                 content_type: "text/html; charset=utf-8".to_string(),
                 cache_control: "public".to_string(),
                 is_not_found: false,
+                cached_at: Instant::now(),
             })
         };
 
@@ -1341,6 +1359,7 @@ mod tests {
                 content_type: "text/html; charset=utf-8".to_string(),
                 cache_control: "public".to_string(),
                 is_not_found: false,
+                cached_at: Instant::now(),
             })
         };
 
@@ -1381,6 +1400,7 @@ mod tests {
                         content_type: "text/html; charset=utf-8".to_string(),
                         cache_control: "public".to_string(),
                         is_not_found: false,
+                        cached_at: Instant::now(),
                     });
                     insert_static_fast_cache(&cache, &key, entry, max_entries);
                 }
@@ -1393,5 +1413,51 @@ mod tests {
 
         assert!(cache.entry_count() <= max_entries);
         assert_eq!(cache.entry_count(), max_entries);
+    }
+
+    #[test]
+    fn test_static_fast_cache_get_expires_after_max_age() {
+        let cache = StaticFastCache::new();
+        let cached_at =
+            Instant::now().checked_sub(Duration::from_secs(10)).expect("monotonic clock");
+        insert_static_fast_cache(
+            &cache,
+            "/",
+            Arc::new(PrebuiltResponse {
+                identity: Bytes::from("html"),
+                gzip: None,
+                br: None,
+                zstd: None,
+                etag: "W/\"1\"".to_string(),
+                content_type: "text/html; charset=utf-8".to_string(),
+                cache_control: "public, max-age=1".to_string(),
+                is_not_found: false,
+                cached_at,
+            }),
+            10,
+        );
+
+        assert!(cache.contains_key("/"));
+        assert!(cache.get("/").is_none());
+        assert!(!cache.contains_key("/"));
+        assert_eq!(cache.entry_count(), 0);
+
+        insert_static_fast_cache(
+            &cache,
+            "/",
+            Arc::new(PrebuiltResponse {
+                identity: Bytes::from("html"),
+                gzip: None,
+                br: None,
+                zstd: None,
+                etag: "W/\"1\"".to_string(),
+                content_type: "text/html; charset=utf-8".to_string(),
+                cache_control: "public".to_string(),
+                is_not_found: false,
+                cached_at,
+            }),
+            10,
+        );
+        assert!(cache.get("/").is_some());
     }
 }

--- a/crates/rari/src/server/cache/warmup.rs
+++ b/crates/rari/src/server/cache/warmup.rs
@@ -202,6 +202,7 @@ async fn warm_route(
                 content_type: "text/html; charset=utf-8".to_string(),
                 cache_control: cache_control.to_string(),
                 is_not_found: false,
+                cached_at: Instant::now(),
             }),
             state.response_cache.config.max_entries,
         );

--- a/crates/rari/src/server/config.rs
+++ b/crates/rari/src/server/config.rs
@@ -195,12 +195,16 @@ pub struct CspConfig {
     pub worker_src: Vec<String>,
     #[serde(default = "csp_default_frame_ancestors")]
     pub frame_ancestors: Vec<String>,
+    #[serde(default)]
+    pub frame_src: Vec<String>,
     #[serde(default = "csp_default_base_uri")]
     pub base_uri: Vec<String>,
     #[serde(default = "csp_default_form_action")]
     pub form_action: Vec<String>,
     #[serde(default)]
     pub use_nonces: bool,
+    #[serde(default = "csp_default_embedder_policy")]
+    pub embedder_policy: String,
 }
 
 fn csp_default_frame_ancestors() -> Vec<String> {
@@ -215,6 +219,10 @@ fn csp_default_form_action() -> Vec<String> {
     vec!["'self'".to_string()]
 }
 
+fn csp_default_embedder_policy() -> String {
+    "credentialless".to_string()
+}
+
 impl Default for CspConfig {
     fn default() -> Self {
         Self {
@@ -226,9 +234,11 @@ impl Default for CspConfig {
             connect_src: vec!["'self'".to_string(), "ws:".to_string(), "wss:".to_string()],
             worker_src: vec!["'self'".to_string()],
             frame_ancestors: csp_default_frame_ancestors(),
+            frame_src: Vec::new(),
             base_uri: csp_default_base_uri(),
             form_action: csp_default_form_action(),
             use_nonces: false,
+            embedder_policy: csp_default_embedder_policy(),
         }
     }
 }
@@ -659,6 +669,12 @@ impl Config {
                             .filter_map(|v| v.as_str().map(ToString::to_string))
                             .collect();
                     }
+                    if let Some(frame_src) = csp_data.get("frameSrc").and_then(|v| v.as_array()) {
+                        config.csp.frame_src = frame_src
+                            .iter()
+                            .filter_map(|v| v.as_str().map(ToString::to_string))
+                            .collect();
+                    }
                     if let Some(base_uri) = csp_data.get("baseUri").and_then(|v| v.as_array()) {
                         config.csp.base_uri = base_uri
                             .iter()
@@ -674,6 +690,20 @@ impl Config {
                     }
                     if let Some(use_nonces) = csp_data.get("useNonces").and_then(Value::as_bool) {
                         config.csp.use_nonces = use_nonces;
+                    }
+                    if let Some(embedder_policy) =
+                        csp_data.get("embedderPolicy").and_then(Value::as_str)
+                    {
+                        match embedder_policy {
+                            "credentialless" | "unsafe-none" => {
+                                config.csp.embedder_policy = embedder_policy.to_string();
+                            }
+                            other => {
+                                tracing::warn!(
+                                    "Invalid csp.embedderPolicy {other:?}; expected \"credentialless\" or \"unsafe-none\". Using credentialless."
+                                );
+                            }
+                        }
                     }
                 }
 
@@ -1058,6 +1088,10 @@ impl Config {
             directives.push(format!("frame-ancestors {}", config.frame_ancestors.join(" ")));
         }
 
+        if !config.frame_src.is_empty() {
+            directives.push(format!("frame-src {}", config.frame_src.join(" ")));
+        }
+
         if !config.base_uri.is_empty() {
             directives.push(format!("base-uri {}", config.base_uri.join(" ")));
         }
@@ -1337,6 +1371,52 @@ mod tests {
         assert!(invalid.html_limited_bots_regex.is_none());
 
         let _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn test_csp_embedder_policy_and_frame_src_from_config_json() {
+        let temp_dir = env::temp_dir().join(format!("rari_test_coep_{}", process::id()));
+        let dist_server_dir = temp_dir.join("dist").join("server");
+        fs::create_dir_all(&dist_server_dir).unwrap();
+
+        fs::write(
+            dist_server_dir.join("config.json"),
+            r#"{
+                "csp": {
+                    "embedderPolicy": "unsafe-none",
+                    "frameSrc": ["'self'", "https://www.google.com", "https://maps.google.com"]
+                }
+            }"#,
+        )
+        .unwrap();
+        let config = Config::from_env_with_base(Some(&temp_dir)).unwrap();
+        assert_eq!(config.csp.embedder_policy, "unsafe-none");
+        assert_eq!(
+            config.csp.frame_src,
+            vec!["'self'", "https://www.google.com", "https://maps.google.com"]
+        );
+        let policy = config.build_csp_policy();
+        assert!(
+            policy.contains("frame-src 'self' https://www.google.com https://maps.google.com"),
+            "frame-src missing from {policy}"
+        );
+
+        fs::write(
+            dist_server_dir.join("config.json"),
+            r#"{"csp":{"embedderPolicy":"require-corp"}}"#,
+        )
+        .unwrap();
+        let invalid = Config::from_env_with_base(Some(&temp_dir)).unwrap();
+        assert_eq!(invalid.csp.embedder_policy, "credentialless");
+
+        let _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn test_csp_embedder_policy_defaults_to_credentialless() {
+        assert_eq!(CspConfig::default().embedder_policy, "credentialless");
+        assert!(CspConfig::default().frame_src.is_empty());
+        assert!(!Config::default().build_csp_policy().contains("frame-src"));
     }
 
     #[test]

--- a/crates/rari/src/server/config.rs
+++ b/crates/rari/src/server/config.rs
@@ -1415,7 +1415,7 @@ mod tests {
     #[test]
     fn test_csp_embedder_policy_defaults_to_credentialless() {
         assert_eq!(CspConfig::default().embedder_policy, "credentialless");
-        assert!(CspConfig::default().frame_src.is_empty());
+        assert_eq!(CspConfig::default().frame_src, Vec::<String>::new());
         assert!(!Config::default().build_csp_policy().contains("frame-src"));
     }
 

--- a/crates/rari/src/server/middleware/request.rs
+++ b/crates/rari/src/server/middleware/request.rs
@@ -107,10 +107,15 @@ pub async fn security_headers_middleware(mut request: Request<Body>, next: Next)
 }
 
 fn add_security_headers(headers: &mut HeaderMap, nonce: Option<&str>) {
-    let csp_policy = if let Some(config) = Config::get() {
+    let config = Config::get();
+    let csp_policy = if let Some(config) = config.as_ref() {
         config.build_csp_policy()
     } else {
         "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' ws: wss:; frame-ancestors 'self'; base-uri 'self'; form-action 'self'".to_string()
+    };
+    let coep = match config.as_ref().map(|c| c.csp.embedder_policy.as_str()) {
+        Some("unsafe-none") => "unsafe-none",
+        _ => COEP_CREDENTIALLESS,
     };
 
     let csp_policy = match nonce {
@@ -124,7 +129,7 @@ fn add_security_headers(headers: &mut HeaderMap, nonce: Option<&str>) {
         (X_XSS_PROTECTION, XSS_PROTECTION),
         (STRICT_TRANSPORT_SECURITY, HSTS_HEADER),
         (X_PERMITTED_CROSS_DOMAIN_POLICIES, CROSS_DOMAIN_POLICIES_NONE),
-        (CROSS_ORIGIN_EMBEDDER_POLICY, COEP_CREDENTIALLESS),
+        (CROSS_ORIGIN_EMBEDDER_POLICY, coep),
         (CROSS_ORIGIN_OPENER_POLICY, COOP_SAME_ORIGIN),
         (CROSS_ORIGIN_RESOURCE_POLICY, CORP_SAME_ORIGIN),
         (REFERRER_POLICY, REFERRER_STRICT_ORIGIN),

--- a/crates/rari/src/server/routing/app.rs
+++ b/crates/rari/src/server/routing/app.rs
@@ -1884,6 +1884,7 @@ pub async fn handle_app_route(
                             content_type: "text/html; charset=utf-8".to_string(),
                             cache_control: cache_control_value.to_string(),
                             is_not_found: route_match.not_found.is_some(),
+                            cached_at: Instant::now(),
                         }),
                         state.response_cache.config.max_entries,
                     );

--- a/packages/rari/src/vite/index.ts
+++ b/packages/rari/src/vite/index.ts
@@ -155,9 +155,11 @@ export interface RariOptions {
     readonly defaultSrc?: readonly string[]
     readonly workerSrc?: readonly string[]
     readonly frameAncestors?: readonly string[]
+    readonly frameSrc?: readonly string[]
     readonly baseUri?: readonly string[]
     readonly formAction?: readonly string[]
     readonly useNonces?: boolean
+    readonly embedderPolicy?: 'credentialless' | 'unsafe-none'
   }
   readonly cacheControl?: {
     readonly routes: Readonly<Record<string, string>>

--- a/packages/rari/src/vite/server/config.ts
+++ b/packages/rari/src/vite/server/config.ts
@@ -7,9 +7,11 @@ export interface ServerCSPConfig {
   readonly defaultSrc?: readonly string[]
   readonly workerSrc?: readonly string[]
   readonly frameAncestors?: readonly string[]
+  readonly frameSrc?: readonly string[]
   readonly baseUri?: readonly string[]
   readonly formAction?: readonly string[]
   readonly useNonces?: boolean
+  readonly embedderPolicy?: 'credentialless' | 'unsafe-none'
 }
 
 export interface ServerCacheControlConfig {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Content Security Policy support for frame sources and embedder policies.
  * Added `credentialless` and `unsafe-none` embedder policy options, with safe defaults and validation.
* **Bug Fixes**
  * Cached responses now respect `Cache-Control` max-age values.
  * Expired cache entries are removed instead of being served.
  * Cache cleanup now preserves newer replacements.
* **Configuration**
  * Added support for the new CSP settings in application configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->