### PR TITLE
feat(vite): add optional oxc React Compiler via rari({ compiler })

### DIFF
--- a/packages/rari/package.json
+++ b/packages/rari/package.json
@@ -138,11 +138,15 @@
   },
   "peerDependencies": {
     "@mdx-js/mdx": "catalog:mdx",
+    "oxc-transform-react": "catalog:build",
     "react": "catalog:react",
     "react-dom": "catalog:react"
   },
   "peerDependenciesMeta": {
     "@mdx-js/mdx": {
+      "optional": true
+    },
+    "oxc-transform-react": {
       "optional": true
     }
   },
@@ -167,6 +171,7 @@
     "@types/node": "catalog:typescript",
     "@types/react": "catalog:react",
     "@types/react-dom": "catalog:react",
+    "oxc-transform-react": "catalog:build",
     "typescript": "catalog:typescript",
     "typescript-7": "catalog:typescript",
     "vite-plus": "catalog:build"

--- a/packages/rari/src/vite/index.ts
+++ b/packages/rari/src/vite/index.ts
@@ -5,6 +5,7 @@ import type { MdxPluginOptions } from './mdx/registry'
 import type { RariPlugin } from './plugin/types'
 import type { ServerBuildOptions } from './server/build'
 import type { ServerCacheConfig, ServerCacheLayerConfig } from './server/config'
+import type { ReactCompilerOptions } from './transform/react-compiler'
 import type { ProxyPluginOptions } from '@/proxy/build/vite-plugin'
 import { Buffer } from 'node:buffer'
 import { spawn, spawnSync } from 'node:child_process'
@@ -79,6 +80,7 @@ import {
   transformInlineServerActions,
 } from './transform/inline-server-action'
 import { transformDefineMdxComponents } from './transform/mdx-components'
+import { createReactCompilerPlugin } from './transform/react-compiler'
 import { getUseCacheTransform } from './transform/use-cache'
 
 const DIST_NOT_BUILT_ERROR =
@@ -174,6 +176,7 @@ export interface RariOptions {
     readonly useCacheRemote?: ServerCacheLayerConfig
   }
   readonly mdx?: MdxPluginOptions
+  readonly compiler?: boolean | ReactCompilerOptions
 }
 
 const DEFAULT_IMAGE_CONFIG = {
@@ -290,7 +293,11 @@ async function loadRscReferences(): Promise<string> {
   return loadRuntimeFile('rsc-references.mjs')
 }
 
-async function writeImageConfig(projectRoot: string, options: RariOptions): Promise<void> {
+async function writeImageConfig(
+  projectRoot: string,
+  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- RariOptions embeds optional peer option bags (oxc/mdx) that are not deeply readonly
+  options: RariOptions,
+): Promise<void> {
   const srcDir = path.join(projectRoot, 'src')
   const { getBinaryPath } = await import('@/cli/platform')
   const binaryPath = getBinaryPath()
@@ -348,11 +355,17 @@ async function writeImageConfig(projectRoot: string, options: RariOptions): Prom
   fs.writeFileSync(configPath, JSON.stringify(imageConfig))
 }
 
-export function defineRariOptions(config: RariOptions): RariOptions {
+export function defineRariOptions(
+  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- RariOptions embeds optional peer option bags (oxc/mdx) that are not deeply readonly
+  config: RariOptions,
+): RariOptions {
   return config
 }
 
-export function rari(options: RariOptions = {}): RariPlugin[] {
+export function rari(
+  // oxlint-disable-next-line typescript/prefer-readonly-parameter-types -- RariOptions embeds optional peer option bags (oxc/mdx) that are not deeply readonly
+  options: RariOptions = {},
+): RariPlugin[] {
   if (options.jsPoolSize != null) {
     const size = options.jsPoolSize
     if (!Number.isInteger(size) || size < 1 || !Number.isFinite(size)) {
@@ -2244,7 +2257,12 @@ export const createTemporaryReferenceSet = module.exports.createTemporaryReferen
     },
   }
 
-  const plugins: Plugin[] = [mainPlugin, webpackRequirePatchPlugin, serverBuildPlugin]
+  const plugins: Plugin[] = []
+
+  if (options.compiler != null && options.compiler !== false)
+    plugins.push(createReactCompilerPlugin(options.compiler))
+
+  plugins.push(mainPlugin, webpackRequirePatchPlugin, serverBuildPlugin)
 
   if (options.proxy !== false) plugins.push(rariProxy(options.proxy ?? {}))
 
@@ -2276,6 +2294,8 @@ export type {
   ServerCSPConfig,
   ServerUseCacheConfig,
 } from './server/config'
+
+export type { RariCompilerOption, ReactCompilerOptions } from './transform/react-compiler'
 // oxlint-disable-next-line typescript/no-useless-empty-export -- side-effect import of ambient declarations
 export type {} from '@/ambient'
 

--- a/packages/rari/src/vite/transform/react-compiler.ts
+++ b/packages/rari/src/vite/transform/react-compiler.ts
@@ -16,7 +16,8 @@ type OxcTransformReact = typeof import('oxc-transform-react')
 function resolveCompilerOptions(
   compiler: Exclude<RariCompilerOption, false>,
 ): ReactCompilerOptions {
-  return compiler === true ? {} : compiler
+  const options = compiler === true ? {} : compiler
+  return { ...options, target: '19' }
 }
 
 export function shouldApplyReactCompiler(code: string, options: ReactCompilerOptions): boolean {
@@ -24,12 +25,10 @@ export function shouldApplyReactCompiler(code: string, options: ReactCompilerOpt
   return REACT_COMPILER_CODE_FILTER.test(code)
 }
 
-export function compilerRuntimeModule(options: ReactCompilerOptions): string {
-  const target = options.target
-  return target === '17' || target === '18' ? 'react-compiler-runtime' : 'react/compiler-runtime'
-}
+const COMPILER_RUNTIME = 'react/compiler-runtime'
 
 export function matchesCompilerId(id: string): boolean {
+  if (id.startsWith('\0') || id.includes('virtual:')) return false
   const cleanId = id.replace(QUERY_STRIP_RE, '')
   return DEFAULT_INCLUDE_RE.test(cleanId) && !cleanId.includes('/node_modules/')
 }
@@ -70,7 +69,7 @@ export function createReactCompilerPlugin(compiler: Exclude<RariCompilerOption, 
           },
         },
         optimizeDeps: {
-          include: [compilerRuntimeModule(options)],
+          include: [COMPILER_RUNTIME],
         },
       }
     },

--- a/packages/rari/src/vite/transform/react-compiler.ts
+++ b/packages/rari/src/vite/transform/react-compiler.ts
@@ -1,0 +1,122 @@
+/* oxlint-disable typescript/prefer-readonly-parameter-types -- oxc ReactCompilerOptions is a mutable options bag */
+import type { ReactCompilerOptions as OxcReactCompilerOptions } from 'oxc-transform-react'
+import type { Plugin } from 'vite-plus'
+
+export type ReactCompilerOptions = OxcReactCompilerOptions
+export type RariCompilerOption = boolean | ReactCompilerOptions
+
+export const REACT_COMPILER_CODE_FILTER = /forwardRef|memo|\b(?:[A-Z]|use[A-Z0-9])/
+
+const DEFAULT_INCLUDE_RE = /\.[cm]?[jt]sx?$/
+const QUERY_STRIP_RE = /\?.*$/
+const USE_MEMO_DIRECTIVE_RE = /['"]use memo['"]/
+
+type OxcTransformReact = typeof import('oxc-transform-react')
+
+function resolveCompilerOptions(
+  compiler: Exclude<RariCompilerOption, false>,
+): ReactCompilerOptions {
+  return compiler === true ? {} : compiler
+}
+
+export function shouldApplyReactCompiler(code: string, options: ReactCompilerOptions): boolean {
+  if (options.compilationMode === 'annotation') return USE_MEMO_DIRECTIVE_RE.test(code)
+  return REACT_COMPILER_CODE_FILTER.test(code)
+}
+
+export function compilerRuntimeModule(options: ReactCompilerOptions): string {
+  const target = options.target
+  return target === '17' || target === '18' ? 'react-compiler-runtime' : 'react/compiler-runtime'
+}
+
+export function matchesCompilerId(id: string): boolean {
+  const cleanId = id.replace(QUERY_STRIP_RE, '')
+  return DEFAULT_INCLUDE_RE.test(cleanId) && !cleanId.includes('/node_modules/')
+}
+
+export function createReactCompilerPlugin(compiler: Exclude<RariCompilerOption, false>): Plugin {
+  const options = resolveCompilerOptions(compiler)
+  let oxc: OxcTransformReact | undefined
+  let sourcemap = true
+  let jsxDevelopment = false
+  let fastRefresh = false
+
+  const loadOxc = async (onError: (message: string) => never): Promise<OxcTransformReact> => {
+    if (oxc) return oxc
+    try {
+      oxc = await import('oxc-transform-react')
+      return oxc
+    } catch (error) {
+      return onError(
+        `React Compiler requires the optional \`oxc-transform-react\` package. Install it before enabling \`rari({ compiler: true })\`.${
+          error instanceof Error ? `\n${error.message}` : ''
+        }`,
+      )
+    }
+  }
+
+  return {
+    name: 'rari:react-compiler',
+    enforce: 'pre',
+    async config(_, { command }) {
+      await loadOxc(message => this.error(message))
+      fastRefresh = command === 'serve'
+      return {
+        // Own Fast Refresh when the compiler plugin runs so Vite's oxc
+        // refresh pass does not double-register.
+        oxc: {
+          jsx: {
+            refresh: false,
+          },
+        },
+        optimizeDeps: {
+          include: [compilerRuntimeModule(options)],
+        },
+      }
+    },
+    configResolved(config) {
+      sourcemap = config.command !== 'build' || config.build.sourcemap !== false
+      jsxDevelopment = !config.isProduction
+      fastRefresh =
+        !config.isProduction && config.command === 'serve' && config.server.hmr !== false
+    },
+    async transform(code, id) {
+      if (!matchesCompilerId(id)) return null
+
+      const isClient = this.environment.config.consumer !== 'server'
+      // Compiler + Fast Refresh are client-only; leave RSC/SSR to Vite oxc.
+      if (!isClient) return null
+
+      const { transform } = oxc ?? (await loadOxc(message => this.error(message)))
+      const filename = id.replace(QUERY_STRIP_RE, '')
+      const shouldCompile = shouldApplyReactCompiler(code, options)
+
+      const result = await transform(filename, code, {
+        jsx: {
+          runtime: 'automatic',
+          development: jsxDevelopment,
+          importSource: 'react',
+          refresh: fastRefresh,
+        },
+        reactCompiler: shouldCompile ? options : false,
+        sourcemap,
+      })
+
+      const diagnostics = result.errors.map(error => {
+        const codeframe = error.codeframe
+        if (codeframe != null && codeframe !== '') return `${error.message}\n${codeframe}`
+        return error.message
+      })
+
+      if (result.fatal) {
+        const message = diagnostics.join('\n\n')
+        this.error(message !== '' ? message : 'React Compiler transform failed.')
+      }
+      for (const diagnostic of diagnostics) {
+        this.warn(diagnostic)
+      }
+
+      return { code: result.code, map: result.map }
+    },
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ catalogs:
     lightningcss:
       specifier: ^1.33.0
       version: 1.33.0
+    oxc-transform-react:
+      specifier: ^0.147.0
+      version: 0.147.0
     rolldown:
       specifier: ^1.2.5
       version: 1.2.5
@@ -394,6 +397,9 @@ importers:
       '@types/react-dom':
         specifier: catalog:react
         version: 19.2.4(@types/react@19.2.18)
+      oxc-transform-react:
+        specifier: catalog:build
+        version: 0.147.0
       typescript:
         specifier: catalog:typescript
         version: '@typescript/typescript6@6.0.2'
@@ -1607,6 +1613,128 @@ packages:
 
   '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
     resolution: {integrity: sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-transform-react/binding-android-arm-eabi@0.147.0':
+    resolution: {integrity: sha512-VRKQm1E8GA0yqii9t9f7EAOn3Y7wikAPjSdUDVQlfZx+p29MRG72oaVnS8vRjug2/a6wy8wrjlDiYi0fgvks3g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-transform-react/binding-android-arm64@0.147.0':
+    resolution: {integrity: sha512-Ishxo2U0RYWAC3AEuNP7h11/rZa03phq3QcmdPXoOCD5s1gM8JflC1yWsZmQEVmHQe8VLocEaHAlYkWwUGiYIQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-transform-react/binding-darwin-arm64@0.147.0':
+    resolution: {integrity: sha512-2f3KkcleD6AzbtTgVJMRUEgGSfST24n+xc8Uy/smiBSHBXSGWfKFWMP7iR6JDVil3rHsqlDsnv9l7sy++mrbMw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-transform-react/binding-darwin-x64@0.147.0':
+    resolution: {integrity: sha512-jVHMynO2NdP5uEeTLMet8Lh3Y60q67rxyGID43XEXoh4qYS9nA0+tA78eQIX3fb+UeM0eTZi2l6NcAjhDs8ZcQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-transform-react/binding-freebsd-x64@0.147.0':
+    resolution: {integrity: sha512-qJbfDnU0R1Y90mZvOaoF/lAWBoYxzAwik7cXxfh07mBuuUxbwfIifaHKv4CDhA42KhsM3ASpsyIzQcy6qU58dA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-transform-react/binding-linux-arm-gnueabihf@0.147.0':
+    resolution: {integrity: sha512-dzxP8VrfvODG/Gh7TWZzzX3w08C7QDohKqppwKwbox+W3xFgevRAH+aJj5PMvbUO+AwZRx7AHcEKgqJV00YLww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform-react/binding-linux-arm-musleabihf@0.147.0':
+    resolution: {integrity: sha512-+V3y6Ad+tQJJ3RqfEs01vUp/aFcaRRDNzvLvTFgDjEtEy2KTVmzCbOgqiI5QOqO/5of2Eu+iHaIT9FVFsT8pIw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform-react/binding-linux-arm64-gnu@0.147.0':
+    resolution: {integrity: sha512-qwu3NoFx4OrwEUCML0emQguUL0sF4zWtVasMLyy5c1yeXL50bgER+FmavE9TOdINhY7L6eYt3bg/BRyRaihFHQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-arm64-musl@0.147.0':
+    resolution: {integrity: sha512-Edtn1bdSUZUsVumt/uSnKuPYR2iqHgULff1W77dqZyhxrQKUVk4pPBt6yiEmwBeWLc4AtBui4JuO6Akj2n5BZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform-react/binding-linux-ppc64-gnu@0.147.0':
+    resolution: {integrity: sha512-P1MHO3HbPTpeDO6qiQeFpM3qyJWdLhcV/kys65HelsIag6kU+ixrl/fAvOMdt+MfpJAusY42B+6x/IQsfaHoow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-riscv64-gnu@0.147.0':
+    resolution: {integrity: sha512-/IR46J5U0kYVLDUsHJr0Y7vT1lQt4haOi2uOMcsSCp+NEBhSaOomQyZ8GaQJVtTn49lYw/yfIm/D3D69L/VwmA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-riscv64-musl@0.147.0':
+    resolution: {integrity: sha512-2Z+T/VYg+6onfi2b+umNr/37r3qCyutBtSE6dP6KzzNPDlwy3qGg9qIvj1AzKXJpIIheDNJ7hfYn7SBtnSlu0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform-react/binding-linux-s390x-gnu@0.147.0':
+    resolution: {integrity: sha512-EmkqOECTHdQj4tbuWn34eYzy3yYfsRWLOoPDAQ2SK6dddMTSGKLyvc/RsP+l65Q4AIM2tTpQshmcerlZDYScNA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-x64-gnu@0.147.0':
+    resolution: {integrity: sha512-gaktP45FnQ63VvXbK0vC81IbFtU7rBpj1Rcxc/mXYMQk24vRnMV3nGdAQb1jKFeg14GokrloQ4gNW+XLMID1vA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-x64-musl@0.147.0':
+    resolution: {integrity: sha512-FjZwrDx4xWZzy06/5hjdcJlXr3Zmv11buW/b4HKFVQ90u6dPUmiPiPRNd7QWJGGksVCm/zBQlA2P0HtAHS38YA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform-react/binding-openharmony-arm64@0.147.0':
+    resolution: {integrity: sha512-Sp7bVak/0y5Lwpfk2fIIYOQmFNvmBG1qPR3010FTx361kANJmH+N1o7MkQ5PnDTCM7FkVOIBROjiRyW6WGimyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-transform-react/binding-win32-arm64-msvc@0.147.0':
+    resolution: {integrity: sha512-i+4W8zSlYUfIRIUR5+Omttx49M44FoL7YXJzzdT+ZmjgeS5hMOQNZDI6Cvkb1vm+4fh1b/lOjJeZjK5E4VYXbA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-transform-react/binding-win32-ia32-msvc@0.147.0':
+    resolution: {integrity: sha512-mSc4BxQPdCN5DdzyxfYWK2OvzrUGqj4Hi+Q61XA96HIU5UtuSx8pVY34tjvMPZ/QrN8MReGSikAk9NI9njWgSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-transform-react/binding-win32-x64-msvc@0.147.0':
+    resolution: {integrity: sha512-4vtoIsur+v2mGj5UewMxm5BiuK9Se3skVyPRczNLXSYCjPVzHMV9XBkySWBGLBzcNICiejiiF+gVidNNGc3HDQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
@@ -4491,6 +4619,10 @@ packages:
   oxc-resolver@11.24.2:
     resolution: {integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==}
 
+  oxc-transform-react@0.147.0:
+    resolution: {integrity: sha512-u3u8qZFlcQPawQx/kvMnK6csGPAQW5JJ4WWsmqYb3djL4SHfvsu5ftHCTkWgzdYkGfIjq5aSoBetVXfPb1ZiXw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   oxfmt@0.62.0:
     resolution: {integrity: sha512-vxgGHTmnDU9j4CX7dDBLzxgmHxfda/yPcgJkGCMUSCwRmz+euo/V08xXLNgXTeqAB9Fhf3Pe2nO1RNKLCVgphQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6134,6 +6266,63 @@ snapshots:
     optional: true
 
   '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
+    optional: true
+
+  '@oxc-transform-react/binding-android-arm-eabi@0.147.0':
+    optional: true
+
+  '@oxc-transform-react/binding-android-arm64@0.147.0':
+    optional: true
+
+  '@oxc-transform-react/binding-darwin-arm64@0.147.0':
+    optional: true
+
+  '@oxc-transform-react/binding-darwin-x64@0.147.0':
+    optional: true
+
+  '@oxc-transform-react/binding-freebsd-x64@0.147.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-arm-gnueabihf@0.147.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-arm-musleabihf@0.147.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-arm64-gnu@0.147.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-arm64-musl@0.147.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-ppc64-gnu@0.147.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-riscv64-gnu@0.147.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-riscv64-musl@0.147.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-s390x-gnu@0.147.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-x64-gnu@0.147.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-x64-musl@0.147.0':
+    optional: true
+
+  '@oxc-transform-react/binding-openharmony-arm64@0.147.0':
+    optional: true
+
+  '@oxc-transform-react/binding-win32-arm64-msvc@0.147.0':
+    optional: true
+
+  '@oxc-transform-react/binding-win32-ia32-msvc@0.147.0':
+    optional: true
+
+  '@oxc-transform-react/binding-win32-x64-msvc@0.147.0':
     optional: true
 
   '@oxfmt/binding-android-arm-eabi@0.62.0':
@@ -9058,6 +9247,28 @@ snapshots:
       '@oxc-resolver/binding-wasm32-wasi': 11.24.2
       '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
       '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
+
+  oxc-transform-react@0.147.0:
+    optionalDependencies:
+      '@oxc-transform-react/binding-android-arm-eabi': 0.147.0
+      '@oxc-transform-react/binding-android-arm64': 0.147.0
+      '@oxc-transform-react/binding-darwin-arm64': 0.147.0
+      '@oxc-transform-react/binding-darwin-x64': 0.147.0
+      '@oxc-transform-react/binding-freebsd-x64': 0.147.0
+      '@oxc-transform-react/binding-linux-arm-gnueabihf': 0.147.0
+      '@oxc-transform-react/binding-linux-arm-musleabihf': 0.147.0
+      '@oxc-transform-react/binding-linux-arm64-gnu': 0.147.0
+      '@oxc-transform-react/binding-linux-arm64-musl': 0.147.0
+      '@oxc-transform-react/binding-linux-ppc64-gnu': 0.147.0
+      '@oxc-transform-react/binding-linux-riscv64-gnu': 0.147.0
+      '@oxc-transform-react/binding-linux-riscv64-musl': 0.147.0
+      '@oxc-transform-react/binding-linux-s390x-gnu': 0.147.0
+      '@oxc-transform-react/binding-linux-x64-gnu': 0.147.0
+      '@oxc-transform-react/binding-linux-x64-musl': 0.147.0
+      '@oxc-transform-react/binding-openharmony-arm64': 0.147.0
+      '@oxc-transform-react/binding-win32-arm64-msvc': 0.147.0
+      '@oxc-transform-react/binding-win32-ia32-msvc': 0.147.0
+      '@oxc-transform-react/binding-win32-x64-msvc': 0.147.0
 
   oxfmt@0.62.0(vite-plus@0.2.9(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(@typescript/typescript6@6.0.2)(@vitest/coverage-v8@4.1.11(vitest@4.1.11))(jiti@2.7.0)(terser@5.48.0)(vite@8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,25 @@
 catalogMode: prefer
+minimumReleaseAgeExclude:
+  - '@oxc-transform-react/binding-android-arm-eabi@0.147.0'
+  - '@oxc-transform-react/binding-android-arm64@0.147.0'
+  - '@oxc-transform-react/binding-darwin-arm64@0.147.0'
+  - '@oxc-transform-react/binding-darwin-x64@0.147.0'
+  - '@oxc-transform-react/binding-freebsd-x64@0.147.0'
+  - '@oxc-transform-react/binding-linux-arm-gnueabihf@0.147.0'
+  - '@oxc-transform-react/binding-linux-arm-musleabihf@0.147.0'
+  - '@oxc-transform-react/binding-linux-arm64-gnu@0.147.0'
+  - '@oxc-transform-react/binding-linux-arm64-musl@0.147.0'
+  - '@oxc-transform-react/binding-linux-ppc64-gnu@0.147.0'
+  - '@oxc-transform-react/binding-linux-riscv64-gnu@0.147.0'
+  - '@oxc-transform-react/binding-linux-riscv64-musl@0.147.0'
+  - '@oxc-transform-react/binding-linux-s390x-gnu@0.147.0'
+  - '@oxc-transform-react/binding-linux-x64-gnu@0.147.0'
+  - '@oxc-transform-react/binding-linux-x64-musl@0.147.0'
+  - '@oxc-transform-react/binding-openharmony-arm64@0.147.0'
+  - '@oxc-transform-react/binding-win32-arm64-msvc@0.147.0'
+  - '@oxc-transform-react/binding-win32-ia32-msvc@0.147.0'
+  - '@oxc-transform-react/binding-win32-x64-msvc@0.147.0'
+  - oxc-transform-react@0.147.0
 shellEmulator: true
 trustPolicy: no-downgrade
 packages:
@@ -13,6 +34,7 @@ catalogs:
   build:
     '@napi-rs/cli': ^3.8.6
     lightningcss: ^1.33.0
+    oxc-transform-react: ^0.147.0
     rolldown: ^1.2.5
     vite: ^8.2.2
     vite-plus: ^0.2.9

--- a/test/unit/vite/react-compiler.test.ts
+++ b/test/unit/vite/react-compiler.test.ts
@@ -1,0 +1,255 @@
+import type { Plugin } from 'vite-plus'
+import { rari } from '@rari/vite'
+import {
+  compilerRuntimeModule,
+  createReactCompilerPlugin,
+  matchesCompilerId,
+  REACT_COMPILER_CODE_FILTER,
+  shouldApplyReactCompiler,
+} from '@rari/vite/transform/react-compiler'
+import { describe, expect, it, vi } from 'vite-plus/test'
+import { castMock } from '../../helpers/mock-cast'
+
+const COMPONENT_SOURCE = `
+export function Hello({ name }: { name: string }) {
+  return <div>Hello {name}</div>
+}
+`
+
+const PLAIN_SOURCE = `
+export const answer = 42
+export function getAnswer() {
+  return answer
+}
+`
+
+const ANNOTATED_SOURCE = `
+export function Hello({ name }: { name: string }) {
+  "use memo"
+  return <div>Hello {name}</div>
+}
+`
+
+type TransformHook = (
+  this: Readonly<{
+    readonly environment: { readonly config: { readonly consumer: string } }
+    readonly error: (message: string) => never
+    readonly warn: (message: string) => void
+  }>,
+  code: string,
+  id: string,
+) => Promise<{ code?: string; map?: unknown } | null>
+
+type ConfigHook = (
+  this: Readonly<{ readonly error: (message: string) => never }>,
+  config: Readonly<Record<string, unknown>>,
+  env: Readonly<{ command: 'serve' | 'build' }>,
+) => Promise<Record<string, unknown> | undefined>
+
+function getTransform(plugin: Plugin): TransformHook {
+  const hook = plugin.transform
+  if (typeof hook === 'function') {
+    return async function (this, code, id) {
+      return castMock(await hook.call(castMock(this), code, id))
+    }
+  }
+  if (hook != null && typeof hook === 'object' && typeof hook.handler === 'function') {
+    return async function (this, code, id) {
+      return castMock(await hook.handler.call(castMock(this), code, id))
+    }
+  }
+  throw new Error('expected transform hook on react-compiler plugin')
+}
+
+function getConfig(plugin: Plugin): ConfigHook {
+  const hook = plugin.config
+  if (typeof hook === 'function') {
+    return async function (this, config, env) {
+      return castMock(await hook.call(castMock(this), castMock(config), castMock(env)))
+    }
+  }
+  throw new Error('expected config hook on react-compiler plugin')
+}
+
+function createClientContext(warn = vi.fn()) {
+  return {
+    environment: { config: { consumer: 'client' } },
+    error(message: string): never {
+      throw new Error(message)
+    },
+    warn,
+  }
+}
+
+function createServerContext() {
+  return {
+    environment: { config: { consumer: 'server' } },
+    error(message: string): never {
+      throw new Error(message)
+    },
+    warn: vi.fn(),
+  }
+}
+
+describe('react compiler helpers', () => {
+  it('matches component and hook-shaped identifiers', () => {
+    expect(REACT_COMPILER_CODE_FILTER.test('export function Hello() {}')).toBe(true)
+    expect(REACT_COMPILER_CODE_FILTER.test('const x = useState(0)')).toBe(true)
+    expect(REACT_COMPILER_CODE_FILTER.test('memo(Foo)')).toBe(true)
+    expect(REACT_COMPILER_CODE_FILTER.test('forwardRef(Foo)')).toBe(true)
+    expect(REACT_COMPILER_CODE_FILTER.test('export const answer = 42')).toBe(false)
+  })
+
+  it('applies infer mode via the default code filter', () => {
+    expect(shouldApplyReactCompiler(COMPONENT_SOURCE, {})).toBe(true)
+    expect(shouldApplyReactCompiler(PLAIN_SOURCE, {})).toBe(false)
+  })
+
+  it('applies annotation mode only with use memo', () => {
+    expect(shouldApplyReactCompiler(COMPONENT_SOURCE, { compilationMode: 'annotation' })).toBe(
+      false,
+    )
+    expect(shouldApplyReactCompiler(ANNOTATED_SOURCE, { compilationMode: 'annotation' })).toBe(true)
+  })
+
+  it('picks the runtime module from the React target', () => {
+    expect(compilerRuntimeModule({})).toBe('react/compiler-runtime')
+    expect(compilerRuntimeModule({ target: '19' })).toBe('react/compiler-runtime')
+    expect(compilerRuntimeModule({ target: '18' })).toBe('react-compiler-runtime')
+    expect(compilerRuntimeModule({ target: '17' })).toBe('react-compiler-runtime')
+  })
+
+  it('filters module ids like plugin-react include/exclude', () => {
+    expect(matchesCompilerId('/app/src/Hello.tsx')).toBe(true)
+    expect(matchesCompilerId('/app/src/Hello.tsx?v=1')).toBe(true)
+    expect(matchesCompilerId('/app/src/util.ts')).toBe(true)
+    expect(matchesCompilerId('/app/node_modules/react/index.js')).toBe(false)
+    expect(matchesCompilerId('/app/src/styles.css')).toBe(false)
+  })
+})
+
+describe('createReactCompilerPlugin', () => {
+  it('disables vite oxc refresh and prebundles the compiler runtime', async () => {
+    const plugin = createReactCompilerPlugin(true)
+    const result = await getConfig(plugin).call(
+      {
+        error(message: string): never {
+          throw new Error(message)
+        },
+      },
+      {},
+      { command: 'serve' },
+    )
+
+    expect(result).toEqual({
+      oxc: { jsx: { refresh: false } },
+      optimizeDeps: { include: ['react/compiler-runtime'] },
+    })
+  })
+
+  it('prebundles react-compiler-runtime for React 18 targets', async () => {
+    const plugin = createReactCompilerPlugin({ target: '18' })
+    const result = await getConfig(plugin).call(
+      {
+        error(message: string): never {
+          throw new Error(message)
+        },
+      },
+      {},
+      { command: 'build' },
+    )
+
+    expect(result?.optimizeDeps).toEqual({ include: ['react-compiler-runtime'] })
+  })
+
+  it('compiles client components with oxc-transform-react', async () => {
+    const plugin = createReactCompilerPlugin(true)
+    const result = await getTransform(plugin).call(
+      createClientContext(),
+      COMPONENT_SOURCE,
+      '/app/src/Hello.tsx',
+    )
+
+    expect(result).not.toBeNull()
+    expect(result?.code).toContain('react/compiler-runtime')
+    expect(result?.code).toContain('react/jsx-runtime')
+    expect(result?.code).not.toContain('<div>')
+  })
+
+  it('transforms jsx without compiling non-matching client modules', async () => {
+    const plugin = createReactCompilerPlugin(true)
+    const result = await getTransform(plugin).call(
+      createClientContext(),
+      PLAIN_SOURCE,
+      '/app/src/util.ts',
+    )
+
+    expect(result).not.toBeNull()
+    expect(result?.code).not.toContain('react/compiler-runtime')
+    expect(result?.code).toContain('export const answer = 42')
+  })
+
+  it('respects annotation mode', async () => {
+    const plugin = createReactCompilerPlugin({ compilationMode: 'annotation' })
+    const transform = getTransform(plugin)
+
+    const withoutDirective = await transform.call(
+      createClientContext(),
+      COMPONENT_SOURCE,
+      '/app/src/Hello.tsx',
+    )
+    expect(withoutDirective?.code).not.toContain('react/compiler-runtime')
+
+    const withDirective = await transform.call(
+      createClientContext(),
+      ANNOTATED_SOURCE,
+      '/app/src/Hello.tsx',
+    )
+    expect(withDirective?.code).toContain('react/compiler-runtime')
+  })
+
+  it('skips server environments', async () => {
+    const plugin = createReactCompilerPlugin(true)
+    const result = await getTransform(plugin).call(
+      createServerContext(),
+      COMPONENT_SOURCE,
+      '/app/src/Hello.tsx',
+    )
+
+    expect(result).toBeNull()
+  })
+
+  it('skips node_modules ids', async () => {
+    const plugin = createReactCompilerPlugin(true)
+    const result = await getTransform(plugin).call(
+      createClientContext(),
+      COMPONENT_SOURCE,
+      '/app/node_modules/ui/Hello.tsx',
+    )
+
+    expect(result).toBeNull()
+  })
+
+  it('strips vite query strings before transforming', async () => {
+    const plugin = createReactCompilerPlugin(true)
+    const result = await getTransform(plugin).call(
+      createClientContext(),
+      COMPONENT_SOURCE,
+      '/app/src/Hello.tsx?v=123',
+    )
+
+    expect(result?.code).toContain('react/compiler-runtime')
+  })
+})
+
+describe('rari({ compiler })', () => {
+  it('registers the react-compiler plugin when enabled', () => {
+    const plugins = rari({ compiler: true })
+    expect(plugins.some(plugin => plugin.name === 'rari:react-compiler')).toBe(true)
+  })
+
+  it('omits the react-compiler plugin by default', () => {
+    const plugins = rari()
+    expect(plugins.some(plugin => plugin.name === 'rari:react-compiler')).toBe(false)
+  })
+})

--- a/test/unit/vite/react-compiler.test.ts
+++ b/test/unit/vite/react-compiler.test.ts
@@ -1,7 +1,6 @@
 import type { Plugin } from 'vite-plus'
 import { rari } from '@rari/vite'
 import {
-  compilerRuntimeModule,
   createReactCompilerPlugin,
   matchesCompilerId,
   REACT_COMPILER_CODE_FILTER,
@@ -112,11 +111,19 @@ describe('react compiler helpers', () => {
     expect(shouldApplyReactCompiler(ANNOTATED_SOURCE, { compilationMode: 'annotation' })).toBe(true)
   })
 
-  it('picks the runtime module from the React target', () => {
-    expect(compilerRuntimeModule({})).toBe('react/compiler-runtime')
-    expect(compilerRuntimeModule({ target: '19' })).toBe('react/compiler-runtime')
-    expect(compilerRuntimeModule({ target: '18' })).toBe('react-compiler-runtime')
-    expect(compilerRuntimeModule({ target: '17' })).toBe('react-compiler-runtime')
+  it('forces React 19 compiler runtime regardless of requested target', async () => {
+    const plugin = createReactCompilerPlugin({ target: '18' })
+    const result = await getConfig(plugin).call(
+      {
+        error(message: string): never {
+          throw new Error(message)
+        },
+      },
+      {},
+      { command: 'build' },
+    )
+
+    expect(result?.optimizeDeps).toEqual({ include: ['react/compiler-runtime'] })
   })
 
   it('filters module ids like plugin-react include/exclude', () => {
@@ -125,6 +132,9 @@ describe('react compiler helpers', () => {
     expect(matchesCompilerId('/app/src/util.ts')).toBe(true)
     expect(matchesCompilerId('/app/node_modules/react/index.js')).toBe(false)
     expect(matchesCompilerId('/app/src/styles.css')).toBe(false)
+    expect(matchesCompilerId('virtual:app-router-provider.tsx')).toBe(false)
+    expect(matchesCompilerId('\0virtual:/app/src/Hello.tsx')).toBe(false)
+    expect(matchesCompilerId('\0ssr-virtual:/app/src/Hello.tsx')).toBe(false)
   })
 })
 
@@ -145,21 +155,6 @@ describe('createReactCompilerPlugin', () => {
       oxc: { jsx: { refresh: false } },
       optimizeDeps: { include: ['react/compiler-runtime'] },
     })
-  })
-
-  it('prebundles react-compiler-runtime for React 18 targets', async () => {
-    const plugin = createReactCompilerPlugin({ target: '18' })
-    const result = await getConfig(plugin).call(
-      {
-        error(message: string): never {
-          throw new Error(message)
-        },
-      },
-      {},
-      { command: 'build' },
-    )
-
-    expect(result?.optimizeDeps).toEqual({ include: ['react-compiler-runtime'] })
   })
 
   it('compiles client components with oxc-transform-react', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional React Compiler support for Rari applications.
  * Compiler behavior can be enabled and configured through Rari options.
  * Supports development, refresh, runtime, annotation, and client-only compilation scenarios.
  * Provides clear diagnostics when compiler transformation is unavailable or encounters errors.

* **Tests**
  * Added comprehensive coverage for compiler configuration, transformations, filtering, runtime selection, and registration defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->