### PR TITLE
fix(vite): resolve react/compiler-runtime when aliasing react

### DIFF
--- a/packages/rari/src/vite/index.ts
+++ b/packages/rari/src/vite/index.ts
@@ -107,6 +107,19 @@ function matchesAliasImport(source: string, aliases: Readonly<Record<string, str
   return false
 }
 
+function isMissingPackageExportError(error: unknown): boolean {
+  const code = getErrnoCode(error)
+  return (
+    code === 'ENOENT' || code === 'ERR_PACKAGE_PATH_NOT_EXPORTED' || code === 'ERR_MODULE_NOT_FOUND'
+  )
+}
+
+function isExactReactAliasFind(find: string | RegExp): boolean {
+  return (
+    find === 'react' || (find instanceof RegExp && find.source === '^react$' && find.flags === '')
+  )
+}
+
 const REACT_IMPORT_REGEX = /import\s+\{[^}]*\}\s+from\s+['"]react['"]/
 const REACT_IMPORT_WITH_DEFAULT_REGEX = /import\s+[^,\s]+\s*,\s*\{[^}]*\}\s+from\s+['"]react['"]/
 const REACT_IMPORT_MATCH_REGEX = /import React(,\s*\{([^}]*)\})?\s+from\s+['"]react['"];?/
@@ -801,7 +814,12 @@ if (import.meta.hot) {
         existingAlias = aliasEntriesFromRecord(resolveOptions.alias)
       }
 
+      existingAlias = existingAlias.map(entry =>
+        entry.find === 'react' ? { find: /^react$/, replacement: entry.replacement } : entry,
+      )
+
       const aliasFinds = new Set(existingAlias.map(a => String(a.find)))
+      const hasExactReactAlias = existingAlias.some(entry => isExactReactAliasFind(entry.find))
       try {
         const reactPath = fileURLToPath(import.meta.resolve('react'))
         const reactDomClientPath = fileURLToPath(import.meta.resolve('react-dom/client'))
@@ -822,7 +840,7 @@ if (import.meta.hot) {
             })
           }
         } catch (err) {
-          if (getErrnoCode(err) !== 'ENOENT') {
+          if (!isMissingPackageExportError(err)) {
             console.warn('[rari] Unexpected error resolving react/jsx-dev-runtime:', err)
           }
         }
@@ -837,23 +855,20 @@ if (import.meta.hot) {
             })
           }
         } catch (err) {
-          if (getErrnoCode(err) !== 'ENOENT') {
+          if (!isMissingPackageExportError(err)) {
             console.warn('[rari] Unexpected error resolving react/compiler-runtime:', err)
           }
         }
-        if (!aliasFinds.has('react'))
-          aliasesToAppend.push({ find: /^react$/, replacement: reactPath })
+        if (!hasExactReactAlias) aliasesToAppend.push({ find: /^react$/, replacement: reactPath })
         if (!aliasFinds.has('react-dom/client')) {
           aliasesToAppend.push({
             find: 'react-dom/client',
             replacement: reactDomClientPath,
           })
         }
-        if (aliasesToAppend.length > 0) {
-          resolveOptions.alias = [...existingAlias, ...aliasesToAppend]
-        }
+        resolveOptions.alias = [...existingAlias, ...aliasesToAppend]
       } catch (err) {
-        if (getErrnoCode(err) !== 'ENOENT') {
+        if (!isMissingPackageExportError(err)) {
           console.warn('[rari] Unexpected error configuring React aliases:', err)
         }
       }

--- a/packages/rari/src/vite/index.ts
+++ b/packages/rari/src/vite/index.ts
@@ -806,7 +806,7 @@ if (import.meta.hot) {
         const reactPath = fileURLToPath(import.meta.resolve('react'))
         const reactDomClientPath = fileURLToPath(import.meta.resolve('react-dom/client'))
         const reactJsxRuntimePath = fileURLToPath(import.meta.resolve('react/jsx-runtime'))
-        const aliasesToAppend: Array<{ find: string; replacement: string }> = []
+        const aliasesToAppend: Array<{ find: string | RegExp; replacement: string }> = []
         if (!aliasFinds.has('react/jsx-runtime')) {
           aliasesToAppend.push({
             find: 'react/jsx-runtime',
@@ -826,8 +826,23 @@ if (import.meta.hot) {
             console.warn('[rari] Unexpected error resolving react/jsx-dev-runtime:', err)
           }
         }
+        try {
+          const reactCompilerRuntimePath = fileURLToPath(
+            import.meta.resolve('react/compiler-runtime'),
+          )
+          if (!aliasFinds.has('react/compiler-runtime')) {
+            aliasesToAppend.push({
+              find: 'react/compiler-runtime',
+              replacement: reactCompilerRuntimePath,
+            })
+          }
+        } catch (err) {
+          if (getErrnoCode(err) !== 'ENOENT') {
+            console.warn('[rari] Unexpected error resolving react/compiler-runtime:', err)
+          }
+        }
         if (!aliasFinds.has('react'))
-          aliasesToAppend.push({ find: 'react', replacement: reactPath })
+          aliasesToAppend.push({ find: /^react$/, replacement: reactPath })
         if (!aliasFinds.has('react-dom/client')) {
           aliasesToAppend.push({
             find: 'react-dom/client',
@@ -1009,6 +1024,7 @@ if (import.meta.hot) {
         'react-dom',
         'react/jsx-runtime',
         'react/jsx-dev-runtime',
+        'react/compiler-runtime',
         'react-dom/client',
       ])
 

--- a/packages/rari/src/vite/server/build.ts
+++ b/packages/rari/src/vite/server/build.ts
@@ -2394,6 +2394,7 @@ export function createServerBuildPlugin(options: ServerBuildOptions = {}): Plugi
         'react-dom',
         'react/jsx-runtime',
         'react/jsx-dev-runtime',
+        'react/compiler-runtime',
         'react-dom/client',
       ])
 

--- a/test/unit/vite/react-compiler.test.ts
+++ b/test/unit/vite/react-compiler.test.ts
@@ -248,3 +248,37 @@ describe('rari({ compiler })', () => {
     expect(plugins.some(plugin => plugin.name === 'rari:react-compiler')).toBe(false)
   })
 })
+
+describe('rari react resolve aliases', () => {
+  it('uses an exact react match and pins react/compiler-runtime', async () => {
+    const main = rari().find(plugin => plugin.name === 'rari')
+    expect(main).toBeDefined()
+
+    const config: {
+      resolve?: {
+        alias?: Array<{ find: string | RegExp; replacement: string }>
+      }
+    } = { resolve: {} }
+
+    await getConfig(castMock<Plugin>(main)).call(
+      {
+        error(message: string): never {
+          throw new Error(message)
+        },
+      },
+      castMock(config),
+      { command: 'build' },
+    )
+
+    const aliases = config.resolve?.alias ?? []
+    const reactAlias = aliases.find(
+      (entry): entry is { find: RegExp; replacement: string } =>
+        entry.find instanceof RegExp && entry.find.source === '^react$' && entry.find.flags === '',
+    )
+    expect(reactAlias).toBeDefined()
+    expect(reactAlias!.find.test('react')).toBe(true)
+    expect(reactAlias!.find.test('react/compiler-runtime')).toBe(false)
+    expect(aliases.some(entry => entry.find === 'react')).toBe(false)
+    expect(aliases.some(entry => entry.find === 'react/compiler-runtime')).toBe(true)
+  })
+})

--- a/test/unit/vite/react-compiler.test.ts
+++ b/test/unit/vite/react-compiler.test.ts
@@ -281,4 +281,41 @@ describe('rari react resolve aliases', () => {
     expect(aliases.some(entry => entry.find === 'react')).toBe(false)
     expect(aliases.some(entry => entry.find === 'react/compiler-runtime')).toBe(true)
   })
+
+  it('normalizes a user string react alias so compiler-runtime is not prefix-matched', async () => {
+    const main = rari().find(plugin => plugin.name === 'rari')
+    expect(main).toBeDefined()
+
+    const userReact = '/virtual/user-react.js'
+    const config: {
+      resolve?: {
+        alias?: Array<{ find: string | RegExp; replacement: string }>
+      }
+    } = {
+      resolve: {
+        alias: [{ find: 'react', replacement: userReact }],
+      },
+    }
+
+    await getConfig(castMock<Plugin>(main)).call(
+      {
+        error(message: string): never {
+          throw new Error(message)
+        },
+      },
+      castMock(config),
+      { command: 'build' },
+    )
+
+    const aliases = config.resolve?.alias ?? []
+    expect(aliases.some(entry => entry.find === 'react')).toBe(false)
+    const reactAlias = aliases.find(
+      (entry): entry is { find: RegExp; replacement: string } =>
+        entry.find instanceof RegExp && entry.find.source === '^react$' && entry.find.flags === '',
+    )
+    expect(reactAlias).toBeDefined()
+    expect(reactAlias!.replacement).toBe(userReact)
+    expect(reactAlias!.find.test('react/compiler-runtime')).toBe(false)
+    expect(aliases.some(entry => entry.find === 'react/compiler-runtime')).toBe(true)
+  })
 })


### PR DESCRIPTION
String `find: 'react'` prefix-matched subpaths, so compiler-runtime resolved to index.js/compiler-runtime (ENOTDIR). Use /^react$/ and pin an explicit react/compiler-runtime alias.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved React module resolution in Vite configurations.
  * Prevented `react/compiler-runtime` from being incorrectly rewritten by custom aliases.
  * Ensured the exact `react` module is matched without affecting related module paths.
  * Reduced unnecessary warnings when optional React modules or package exports are unavailable.

* **Tests**
  * Added coverage verifying React and compiler runtime aliases resolve correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->