### PR TITLE
fix: add support for react-compiler-runtime in SSR

### DIFF
--- a/crates/rari/src/runtime/ext/rari/mod.rs
+++ b/crates/rari/src/runtime/ext/rari/mod.rs
@@ -27,6 +27,7 @@ extension!(
         "react/vendor/react.js",
         "react/vendor/react-server.js",
         "react/vendor/react-jsx-runtime.js",
+        "react/vendor/react-compiler-runtime.js",
         "react/vendor/react-dom-server.js",
         "react/vendor/react-dom.js",
         "react/vendor/react-server-dom-webpack-client.js",

--- a/crates/rari/src/runtime/module_loader/core.rs
+++ b/crates/rari/src/runtime/module_loader/core.rs
@@ -1039,6 +1039,11 @@ impl ModuleLoader for RariModuleLoader {
                         | "react/jsx-dev-runtime.js"
                 ) {
                     react_vendor::node_vendor_specifier("react-jsx-runtime.js")
+                } else if matches!(
+                    specifier,
+                    "react/compiler-runtime" | "react/compiler-runtime.js"
+                ) {
+                    react_vendor::node_vendor_specifier("react-compiler-runtime.js")
                 } else {
                     react_vendor::node_vendor_specifier("react.js")
                 };

--- a/crates/rari/src/runtime/module_loader/react_vendor.rs
+++ b/crates/rari/src/runtime/module_loader/react_vendor.rs
@@ -10,6 +10,7 @@ const VENDOR_MODULES: &[&str] = &[
     "react.js",
     "react-server.js",
     "react-jsx-runtime.js",
+    "react-compiler-runtime.js",
     "react-dom.js",
     "react-dom-server.js",
     "react-server-dom-webpack-client.js",

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -6,7 +6,12 @@
       "project": ["test/**/*.ts"]
     },
     "packages/rari": {
-      "entry": ["src/**/*.ts", "src/runtime/**/*.tsx"],
+      "entry": [
+        "src/**/*.ts",
+        "src/runtime/**/*.tsx",
+        // Pack entry; consumed via virtual:client-router at runtime, not a direct import.
+        "src/router/navigation/client-router.tsx"
+      ],
       "project": ["src/**/*.{ts,tsx,js,jsx,mdx}"],
       "ignoreBinaries": [
         "npx.cmd" // Windows-specific npx command used in cross-platform spawn logic

--- a/packages/rari/src/vite/server/build.ts
+++ b/packages/rari/src/vite/server/build.ts
@@ -1799,7 +1799,9 @@ export class ServerComponentBuilder {
         NODE_PROTOCOL_REGEX,
         'react',
         'react-dom',
-        /^react\//,
+        'react/jsx-runtime',
+        'react/jsx-dev-runtime',
+        'react/compiler-runtime',
         /^rari/,
         'react-server-dom-webpack/client',
         /^react-server-dom-webpack\//,
@@ -1814,7 +1816,7 @@ export class ServerComponentBuilder {
       resolve: {
         mainFields: ['module', 'main'],
         conditionNames: ['import', 'module', 'default'],
-        extensions: ['.ts', '.tsx', '.js', '.jsx'],
+        extensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs'],
       },
       transform: {
         jsx: 'react-jsx',

--- a/test/unit/tools/rewrite-external-requires.test.ts
+++ b/test/unit/tools/rewrite-external-requires.test.ts
@@ -11,6 +11,10 @@ const EXTERNALIZED_ENTRIES = [
     externals: { react: 'ext:rari/react/vendor/react.js' },
   },
   {
+    name: 'react-compiler-runtime',
+    externals: { react: 'ext:rari/react/vendor/react.js' },
+  },
+  {
     name: 'react-dom-server',
     externals: {
       'react': 'ext:rari/react/vendor/react.js',

--- a/tools/bundle-react-esm/bundle.ts
+++ b/tools/bundle-react-esm/bundle.ts
@@ -188,6 +188,12 @@ const entries: BundleEntry[] = [
     externals: { react: 'ext:rari/react/vendor/react.js' },
   },
   {
+    name: 'react-compiler-runtime',
+    cjsFile: resolveReactCjs('react', 'react-compiler-runtime'),
+    namedExports: ['c'],
+    externals: { react: 'ext:rari/react/vendor/react.js' },
+  },
+  {
     name: 'react-dom-server',
     cjsFile: resolveReactCjs('react-dom', 'react-dom-server.browser'),
     namedExports: [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for the React Compiler runtime in server-side builds.
  * Improved resolution and loading of React runtime modules, including `.mjs` files.
  * Ensured React Compiler runtime modules are correctly bundled and available at runtime.
  * Improved compatibility for applications using React Compiler features during rendering and deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->